### PR TITLE
Fix multi-day events disappearing from dashboard

### DIFF
--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -562,6 +562,7 @@ class Dashboard {
 
 		for (const e of this.allEvents) {
 			const t = new Date(e.time);
+			const end = e.endTime ? new Date(e.endTime) : null;
 			const live = this.liveScores[e.id];
 
 			// Has live score data — use state directly
@@ -577,6 +578,9 @@ class Dashboard {
 				} else {
 					bands.today.push(e);
 				}
+			} else if (t < todayStart && end && end >= todayStart) {
+				// Multi-day event that started before today but hasn't ended
+				bands.today.push(e);
 			} else if (t >= tomorrowStart && t < dayAfterTomorrow) {
 				bands.tomorrow.push(e);
 			} else if (t >= dayAfterTomorrow && t < weekEnd) {


### PR DESCRIPTION
## Summary
- `categorizeEvents()` only used event start time (`e.time`) to assign events to bands (Today, Tomorrow, etc.)
- Multi-day events like golf tournaments (Pebble Beach: Feb 12-15) were silently dropped on day 2+ because their start time was before `todayStart`
- Now checks `endTime` — if a multi-day event hasn't ended yet, it appears in the "Today" band

## Test plan
- [x] All 768 tests pass
- [ ] Verify Pebble Beach appears in dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)