### PR TITLE
Centralize event time filtering into isEventInWindow()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,11 @@ tests/                      # 634 tests across 30 files (vitest)
 AUTOPILOT_ROADMAP.md        # Prioritized task queue for autopilot
 ```
 
+## Conventions
+
+### Event time filtering — use `isEventInWindow()`
+When filtering events by time, **always** use `isEventInWindow(event, windowStart, windowEnd)` from `scripts/lib/helpers.js` (server-side) or the global function in `dashboard.js` (client-side). This handles multi-day events (golf tournaments, Olympics sessions) that have an `endTime` spanning multiple days. Never write manual `new Date(e.time) >= start` filters — they silently drop multi-day events.
+
 ## Development Notes
 
 - **No build process** - pure static files with embedded CSS

--- a/scripts/lib/ai-quality-gates.js
+++ b/scripts/lib/ai-quality-gates.js
@@ -1,4 +1,4 @@
-import { MS_PER_DAY } from "./helpers.js";
+import { MS_PER_DAY, isEventInWindow } from "./helpers.js";
 
 const BLOCK_WORD_LIMITS = {
 	headline: 15,
@@ -477,13 +477,7 @@ function filterTodayEvents(events, now) {
 	const ref = now || new Date();
 	const todayStart = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate());
 	const todayEnd = new Date(todayStart.getTime() + MS_PER_DAY);
-	return events.filter((e) => {
-		const t = new Date(e.time);
-		const end = e.endTime ? new Date(e.endTime) : null;
-		if (t >= todayStart && t < todayEnd) return true;
-		if (t < todayStart && end && end >= todayStart) return true;
-		return false;
-	});
+	return events.filter((e) => isEventInWindow(e, todayStart, todayEnd));
 }
 
 export function evaluateWatchPlanQuality(watchPlan) {

--- a/scripts/lib/base-fetcher.js
+++ b/scripts/lib/base-fetcher.js
@@ -1,4 +1,4 @@
-import { iso, normalizeToUTC } from "./helpers.js";
+import { iso, normalizeToUTC, isEventInWindow } from "./helpers.js";
 import { APIClient } from "./api-client.js";
 
 export class BaseFetcher {
@@ -63,10 +63,7 @@ export class BaseFetcher {
 	filterByTimeRange(events, range) {
 		const now = new Date();
 		const future = new Date(now.getTime() + range * 86400000);
-		return events.filter(event => {
-			const eventDate = new Date(event.time);
-			return eventDate >= now && eventDate <= future;
-		});
+		return events.filter(event => isEventInWindow(event, now, future));
 	}
 
 	applyCustomFilters(events) {

--- a/scripts/lib/filters.js
+++ b/scripts/lib/filters.js
@@ -1,4 +1,4 @@
-import { MS_PER_DAY } from "./helpers.js";
+import { MS_PER_DAY, isEventInWindow } from "./helpers.js";
 
 export class EventFilters {
 	static filterByTimeRange(events, days = 7) {
@@ -6,36 +6,20 @@ export class EventFilters {
 
 		const now = new Date();
 		const future = new Date(now.getTime() + days * MS_PER_DAY);
-		
-		return events.filter(event => {
-			try {
-				const eventDate = new Date(event.time);
-				return eventDate >= now && eventDate <= future;
-			} catch {
-				return false;
-			}
-		});
+		return events.filter(event => isEventInWindow(event, now, future));
 	}
 
 	static filterCurrentWeek(events) {
 		if (!Array.isArray(events)) return [];
-		
+
 		const now = new Date();
 		const startOfWeek = new Date(now);
 		startOfWeek.setDate(now.getDate() - now.getDay());
 		startOfWeek.setHours(0, 0, 0, 0);
-		
+
 		const endOfWeek = new Date(startOfWeek);
 		endOfWeek.setDate(startOfWeek.getDate() + 7);
-		
-		return events.filter(event => {
-			try {
-				const eventDate = new Date(event.time);
-				return eventDate >= startOfWeek && eventDate < endOfWeek;
-			} catch {
-				return false;
-			}
-		});
+		return events.filter(event => isEventInWindow(event, startOfWeek, endOfWeek));
 	}
 
 	static filterByTeams(events, teams) {

--- a/scripts/lib/helpers.js
+++ b/scripts/lib/helpers.js
@@ -10,6 +10,21 @@ export function iso(d = Date.now()) {
 	return new Date(d).toISOString();
 }
 
+/**
+ * Check if an event overlaps with a time window.
+ * Handles multi-day events (endTime) and single-point events uniformly.
+ * An event overlaps [windowStart, windowEnd) if it starts before the window
+ * ends AND it ends at or after the window starts.
+ */
+export function isEventInWindow(event, windowStart, windowEnd) {
+	if (!event?.time) return false;
+	const start = new Date(event.time).getTime();
+	const end = event.endTime ? new Date(event.endTime).getTime() : start;
+	const ws = windowStart instanceof Date ? windowStart.getTime() : windowStart;
+	const we = windowEnd instanceof Date ? windowEnd.getTime() : windowEnd;
+	return start < we && end >= ws;
+}
+
 export function normalizeToUTC(dateString) {
 	// Handle various date formats from APIs and ensure proper UTC conversion
 	if (!dateString) return new Date().toISOString();

--- a/tests/categorize-events.test.js
+++ b/tests/categorize-events.test.js
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
+import { isEventInWindow } from "../scripts/lib/helpers.js";
 
 // Extract categorizeEvents from dashboard.js to test it directly.
-// The method only depends on this.allEvents and this.liveScores (no DOM).
+// The method only depends on this.allEvents, this.liveScores, and isEventInWindow (no DOM).
 const src = fs.readFileSync(path.resolve("docs/js/dashboard.js"), "utf-8");
 const match = src.match(/categorizeEvents\(\)\s*\{([\s\S]*?)\n\t\}/);
 if (!match) throw new Error("Could not extract categorizeEvents from dashboard.js");
-const categorizeEvents = new Function(match[1]);
+// Provide isEventInWindow in scope (it's a global function in dashboard.js)
+const categorizeEvents = new Function("isEventInWindow", `return function() {${match[1]}}`)(isEventInWindow);
 
 function categorize(allEvents, liveScores = {}) {
 	return categorizeEvents.call({ allEvents, liveScores });


### PR DESCRIPTION
## Summary
- Adds `isEventInWindow(event, start, end)` to `scripts/lib/helpers.js` — single source of truth for event time filtering that handles multi-day events (endTime) correctly
- Replaces 6+ manual time filters across the codebase with the centralized helper
- Adds the same function as a global in `docs/js/dashboard.js` for client-side use
- Documents the convention in CLAUDE.md so the autopilot follows it for new code
- 10 new tests for isEventInWindow, 789 total passing

## Why
The golf-disappearing-from-dashboard bug existed in 6+ places because the same time-filtering logic was copy-pasted everywhere, each copy missing endTime handling. Now there's one function — one place for the autopilot to fix if something goes wrong.

## Files changed (10)
- `scripts/lib/helpers.js` — new isEventInWindow export
- `docs/js/dashboard.js` — global isEventInWindow, updated categorizeEvents + brief filter
- `scripts/generate-featured.js` — 4 filters simplified
- `scripts/lib/ai-quality-gates.js` — filterTodayEvents simplified
- `scripts/lib/base-fetcher.js` — filterByTimeRange simplified
- `scripts/lib/filters.js` — filterByTimeRange + filterCurrentWeek simplified
- `scripts/pipeline-health.js` — findInvisibleEvents simplified
- `tests/helpers.test.js` — 10 new isEventInWindow tests
- `tests/categorize-events.test.js` — updated to inject isEventInWindow
- `CLAUDE.md` — documented convention

## Test plan
- [x] 789 tests pass (10 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)