### PR TITLE
Improve briefing UX: editorial context, Norwegian results, personalized content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,8 +217,8 @@
 
 		/* === Brief === */
 		#the-brief {
-			padding: 4px 20px 20px;
-			border-bottom: 1px solid var(--border);
+			padding: 4px 20px 24px;
+			border-bottom: 2px solid var(--border);
 			font-size: 0.84rem;
 			color: var(--fg);
 			line-height: 1.7;
@@ -286,9 +286,10 @@
 			padding: 4px 0;
 		}
 		.block-divider {
-			font-size: 0.55rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em;
-			color: var(--muted); margin: 12px 0 6px; padding-top: 10px; border-top: 1px solid var(--border);
+			font-size: 0.5rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.12em;
+			color: var(--muted-light); margin: 14px 0 4px; padding-top: 8px; border-top: 1px dashed var(--border-light);
 		}
+		.block-divider ~ .block-event-line { opacity: 0.65; font-size: 0.78rem; }
 		.editorial-line { padding: 3px 0; font-size: 0.84rem; }
 		.editorial-line.brief-headline { font-weight: 500; }
 		.editorial-line.brief-secondary { font-size: 0.78rem; color: var(--muted); }
@@ -306,7 +307,13 @@
 		.result-card-score { font-size: 1.1rem; font-weight: 700; letter-spacing: 1px; white-space: nowrap; }
 		.result-card-scorers { font-size: 0.7rem; color: var(--muted); margin-top: 4px; }
 		.result-card-league { font-size: 0.65rem; color: var(--muted); opacity: 0.7; margin-top: 2px; }
+		.block-match-preview { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0 6px; }
 		.block-match-preview strong { font-weight: 600; }
+		.preview-main { white-space: nowrap; }
+		.preview-ctx { font-size: 0.7rem; color: var(--muted); }
+		.preview-ctx::before { content: '\00b7'; margin-right: 4px; }
+		.preview-rel { font-size: 0.6rem; color: var(--muted); opacity: 0.7; }
+		.preview-editorial { width: 100%; font-size: 0.78rem; color: var(--fg); opacity: 0.7; font-style: italic; margin-top: 2px; line-height: 1.4; }
 		.block-standings-ctx { font-size: 0.7rem; color: var(--muted); }
 		.block-event-schedule {
 			background: var(--bg-card); border-radius: var(--radius); padding: 14px 16px; margin: 8px 0; box-shadow: var(--shadow);
@@ -869,16 +876,27 @@
 		.news-toggle:hover { opacity: 0.7; }
 		.news-content { display: none; }
 		.news-content.open { display: block; }
-		.news-grid { display: flex; flex-direction: column; gap: 8px; margin-bottom: 8px; }
+		.news-grid { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
 		.news-card {
-			display: flex; gap: 12px; padding: 12px 14px;
+			display: flex; gap: 10px; padding: 8px 12px;
 			background: var(--bg-card); border-radius: var(--radius-sm);
-			box-shadow: 0 1px 3px rgba(0,0,0,0.03); cursor: pointer; transition: box-shadow 0.15s; align-items: flex-start;
+			box-shadow: 0 1px 2px rgba(0,0,0,0.02); cursor: pointer; transition: box-shadow 0.15s; align-items: flex-start;
 		}
 		.news-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+		.news-more-items { display: none; }
+		.news-more-items.open { display: contents; }
+		.news-show-more {
+			background: none; border: none; color: var(--muted); font-size: 0.62rem;
+			cursor: pointer; padding: 6px 0 2px; font-family: var(--font); font-weight: 500;
+			transition: color 0.15s;
+		}
+		.news-show-more:hover { color: var(--accent); }
 		.news-sport-bar { width: 3px; min-height: 32px; border-radius: 2px; flex-shrink: 0; align-self: stretch; }
 		.news-body { flex: 1; min-width: 0; }
-		.news-headline { font-size: 0.78rem; font-weight: 500; line-height: 1.4; margin-bottom: 4px; color: var(--fg); }
+		.news-headline {
+			font-size: 0.75rem; font-weight: 500; line-height: 1.35; margin-bottom: 2px; color: var(--fg);
+			display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+		}
 		.news-meta { font-size: 0.58rem; color: var(--muted); display: flex; align-items: center; gap: 6px; }
 		.news-src-tag { font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; }
 		.news-time { font-family: var(--mono); font-size: 0.54rem; }
@@ -1010,7 +1028,7 @@
 	<script src="js/asset-maps.js?v=2026022007"></script>
 	<script src="js/preferences-manager.js?v=2026022007"></script>
 	<script src="js/feedback-manager.js?v=2026022007"></script>
-	<script src="js/dashboard.js?v=2026022007"></script>
+	<script src="js/dashboard.js?v=2026022501"></script>
 
 	<script>
 		if ('serviceWorker' in navigator) {

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -10,6 +10,24 @@ function isEventInWindow(event, windowStart, windowEnd) {
 	return start < we && end >= ws;
 }
 
+/** Norwegian clubs that appear in European competitions (ESPN naming) */
+const NORWEGIAN_CLUBS = [
+	"bodo/glimt", "bodø/glimt", "molde", "rosenborg", "viking",
+	"brann", "lillestrøm", "lillestrom", "tromsø", "tromso",
+	"vålerenga", "valerenga", "sarpsborg", "odd", "lyn",
+];
+const UEFA_COMPETITION_CODES = ["uefa.champions", "uefa.europa", "uefa.europa.conf"];
+
+/** Check if a football result involves a Norwegian club in a UEFA competition */
+function isNoteworthyNorwegianResult(match) {
+	const home = (match.homeTeam || "").toLowerCase();
+	const away = (match.awayTeam || "").toLowerCase();
+	const isNorwegian = NORWEGIAN_CLUBS.some(club => home.includes(club) || away.includes(club));
+	if (!isNorwegian) return false;
+	const code = (match.leagueCode || "").toLowerCase();
+	return UEFA_COMPETITION_CODES.some(comp => code.includes(comp));
+}
+
 class Dashboard {
 	constructor() {
 		this.allEvents = [];
@@ -786,7 +804,8 @@ class Dashboard {
 			blocks = lines.map(line => ({ type: 'event-line', text: line }));
 		}
 
-		// Client-side result surfacing: if no result lines in blocks but we have favorite results
+		// Client-side result surfacing: if no result lines in blocks but we have noteworthy results
+		// Surfaces both favorite team results AND Norwegian clubs in UEFA competitions
 		if (this.recentResults?.football?.length > 0) {
 			const hasResultLine = blocks.some(b => b.type === 'event-line' && /\bFT:/.test(b.text || ''))
 				|| blocks.some(b => b.type === 'match-result');
@@ -794,7 +813,7 @@ class Dashboard {
 				const now = new Date();
 				const cutoff = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
 				const favResults = this.recentResults.football
-					.filter(m => m.isFavorite && new Date(m.date) >= cutoff)
+					.filter(m => (m.isFavorite || isNoteworthyNorwegianResult(m)) && new Date(m.date) >= cutoff)
 					.sort((a, b) => new Date(b.date) - new Date(a.date))
 					.slice(0, 2);
 				if (favResults.length > 0) {
@@ -843,8 +862,13 @@ class Dashboard {
 		let briefHtml = briefOnly.map(block => this.renderBlock(block)).join('');
 
 		// Auto-generate narrative when LLM didn't produce one (fallback provider)
+		// Skip if brief already has match-preview/result blocks — they ARE the narrative
 		const hasNarrative = briefOnly.some(b => b.type === 'narrative');
-		if (!hasNarrative && this._isViewingToday()) {
+		const hasComponentBlocks = briefOnly.some(b =>
+			b.type === 'match-preview' || b.type === 'match-result'
+			|| (b.type === 'event-line' && /\bFT:/.test(b.text || b._fallbackText || ''))
+		);
+		if (!hasNarrative && !hasComponentBlocks && this._isViewingToday()) {
 			const autoNarrative = this._generateAutoNarrative();
 			if (autoNarrative) {
 				briefHtml += `<p class="brief-narrative">${autoNarrative}</p>`;
@@ -868,7 +892,8 @@ class Dashboard {
 		}
 		briefEl.innerHTML = briefHtml;
 
-		// Section blocks no longer rendered — event cards handle sports grouping
+		// Featured sections: skip for today (match-previews + event cards already cover them)
+		// For date-specific briefings, sections are rendered in renderEditorial(dateBriefing)
 		sectionsEl.innerHTML = '';
 	}
 
@@ -994,10 +1019,28 @@ class Dashboard {
 			}
 		}
 
-		const relHtml = rel ? ` <span class="row-rel">${this.esc(rel)}</span>` : '';
-		const tourCtx = event.tournament ? `, ${this.esc(event.tournament)}` : '';
+		const relHtml = rel ? `<span class="preview-rel">${this.esc(rel)}</span>` : '';
+		const tourCtx = event.tournament ? `<span class="preview-ctx">${this.esc(event.tournament)}</span>` : '';
 
-		return `<div class="block-event-line editorial-line block-match-preview">⚽ ${hImg}${this.esc(this.shortName(event.homeTeam))} v ${aImg}${this.esc(this.shortName(event.awayTeam))}, ${this.esc(timeStr)}${relHtml}${tourCtx}${standingsHtml}</div>`;
+		// Extract editorial context from _fallbackText (text after " — " beyond team/time info)
+		let editorialHtml = '';
+		if (block._fallbackText) {
+			const parts = block._fallbackText.split(' — ');
+			// Editorial context is after the first " — " (skip "Team v Team, HH:MM, Tournament")
+			if (parts.length >= 2) {
+				const editorial = parts.slice(1).join(' — ').trim();
+				// Only show if it's actual editorial (not just team names or short fragments)
+				const lowerEd = editorial.toLowerCase();
+				const hasTeamNames = lowerEd.includes(block.homeTeam?.toLowerCase()) || lowerEd.includes(block.awayTeam?.toLowerCase());
+				const isJustTeams = hasTeamNames && editorial.length < 40;
+				const isEditorial = editorial.length > 20 && !isJustTeams;
+				if (isEditorial) {
+					editorialHtml = `<div class="preview-editorial">${this.esc(editorial)}</div>`;
+				}
+			}
+		}
+
+		return `<div class="block-event-line editorial-line block-match-preview"><span class="preview-main">⚽ ${hImg}${this.esc(this.shortName(event.homeTeam))} v ${aImg}${this.esc(this.shortName(event.awayTeam))}, ${this.esc(timeStr)}</span>${relHtml}${tourCtx}${standingsHtml}${editorialHtml}</div>`;
 	}
 
 	/** event-schedule component: renders filtered events from allEvents as a card */
@@ -1427,32 +1470,23 @@ class Dashboard {
 			olympics: 'var(--sport-olympics)',
 		};
 
+		// Show 3 items by default, rest behind "show more"
+		const visibleCount = 3;
+		const visibleItems = items.slice(0, visibleCount);
+		const hiddenItems = items.slice(visibleCount);
+
 		// Build news cards
 		let contentHtml = '<div class="news-grid">';
-		for (const item of items) {
-			const sport = item.sport || 'general';
-			const barColor = sportColors[sport] || 'var(--muted)';
-			const source = item.source || '';
-			const title = item.title || '';
-			const link = item.link || '#';
-
-			// Relative time
-			let timeAgo = '';
-			if (item.pubDate) {
-				const diff = (Date.now() - new Date(item.pubDate).getTime()) / 60000;
-				if (diff < 60) timeAgo = `${Math.round(diff)}m ago`;
-				else if (diff < 1440) timeAgo = `${Math.round(diff / 60)}h ago`;
-				else timeAgo = `${Math.round(diff / 1440)}d ago`;
+		for (const item of visibleItems) {
+			contentHtml += this._renderNewsCard(item, sportColors);
+		}
+		if (hiddenItems.length > 0) {
+			contentHtml += '<div class="news-more-items">';
+			for (const item of hiddenItems) {
+				contentHtml += this._renderNewsCard(item, sportColors);
 			}
-
-			contentHtml += `<a href="${this.esc(link)}" target="_blank" rel="noopener noreferrer" class="news-card" style="text-decoration:none">`;
-			contentHtml += `<div class="news-sport-bar" style="background:${barColor}"></div>`;
-			contentHtml += `<div class="news-body">`;
-			contentHtml += `<div class="news-headline">${this.esc(title)}</div>`;
-			contentHtml += `<div class="news-meta">`;
-			contentHtml += `<span class="news-src-tag">${this.esc(source)}</span>`;
-			if (timeAgo) contentHtml += `<span class="news-time">${this.esc(timeAgo)}</span>`;
-			contentHtml += `</div></div></a>`;
+			contentHtml += '</div>';
+			contentHtml += `<button class="news-show-more">${hiddenItems.length} more headlines</button>`;
 		}
 		contentHtml += '</div>';
 
@@ -1461,6 +1495,46 @@ class Dashboard {
 		html += contentHtml;
 
 		container.innerHTML = html;
+
+		// Bind show-more toggle
+		const showMore = container.querySelector('.news-show-more');
+		if (showMore) {
+			showMore.addEventListener('click', () => {
+				const hidden = container.querySelector('.news-more-items');
+				if (hidden) {
+					const isHidden = hidden.classList.toggle('open');
+					showMore.textContent = isHidden
+						? 'Show less'
+						: `${hiddenItems.length} more headlines`;
+				}
+			});
+		}
+	}
+
+	_renderNewsCard(item, sportColors) {
+		const sport = item.sport || 'general';
+		const barColor = sportColors[sport] || 'var(--muted)';
+		const source = item.source || '';
+		const title = item.title || '';
+		const link = item.link || '#';
+
+		let timeAgo = '';
+		if (item.pubDate) {
+			const diff = (Date.now() - new Date(item.pubDate).getTime()) / 60000;
+			if (diff < 60) timeAgo = `${Math.round(diff)}m ago`;
+			else if (diff < 1440) timeAgo = `${Math.round(diff / 60)}h ago`;
+			else timeAgo = `${Math.round(diff / 1440)}d ago`;
+		}
+
+		let html = `<a href="${this.esc(link)}" target="_blank" rel="noopener noreferrer" class="news-card" style="text-decoration:none">`;
+		html += `<div class="news-sport-bar" style="background:${barColor}"></div>`;
+		html += `<div class="news-body">`;
+		html += `<div class="news-headline">${this.esc(title)}</div>`;
+		html += `<div class="news-meta">`;
+		html += `<span class="news-src-tag">${this.esc(source)}</span>`;
+		if (timeAgo) html += `<span class="news-time">${this.esc(timeAgo)}</span>`;
+		html += `</div></div></a>`;
+		return html;
 	}
 
 	// --- Temporal band event layout ---

--- a/scripts/evaluate-ux.js
+++ b/scripts/evaluate-ux.js
@@ -177,13 +177,24 @@ const { chromium } = require('playwright');
 			return { score: Math.max(0, 100 - Math.min(long * 5, 20)), details: long + " long text line(s)", issues: ri };
 		}
 
+		function checkBriefFormatting() {
+			let problems = 0; const fi = [];
+			for (const el of document.querySelectorAll("#the-brief .block-event-line, #the-brief .block-match-preview")) {
+				for (const node of el.childNodes) {
+					if (node.nodeType === 3) { const t = node.textContent.trim(); if (t.length > 0 && t.length < 20 && /^[,;·–—]/.test(t)) { problems++; if (problems <= 3) fi.push({ severity: "warning", code: "orphaned_brief_text", message: "Orphaned text: " + t.slice(0, 30) }); } }
+				}
+			}
+			const brief = document.querySelector("#the-brief"); const news = document.querySelector("#news");
+			if (brief && news && brief.offsetHeight > 0 && news.offsetHeight > 0 && news.offsetHeight > brief.offsetHeight * 2) { problems++; fi.push({ severity: "info", code: "headlines_dominate", message: "Headlines " + news.offsetHeight + "px > 2x brief " + brief.offsetHeight + "px" }); }
+			return { score: Math.max(0, 100 - problems * 20), details: problems + " formatting issue(s)", issues: fi };
+		}
 		const metrics = {
 			emptySections: checkEmptySections(), brokenImages: checkBrokenImages(),
 			contentOverflow: checkContentOverflow(), contrastRatio: checkContrastRatio(),
 			touchTargets: checkTouchTargets(), loadCompleteness: checkLoadCompleteness(),
-			textReadability: checkTextReadability(),
+			textReadability: checkTextReadability(), briefFormatting: checkBriefFormatting(),
 		};
-		const weights = { loadCompleteness: 0.25, emptySections: 0.20, brokenImages: 0.15, contentOverflow: 0.15, contrastRatio: 0.10, touchTargets: 0.10, textReadability: 0.05 };
+		const weights = { loadCompleteness: 0.25, emptySections: 0.20, brokenImages: 0.15, contentOverflow: 0.15, contrastRatio: 0.10, touchTargets: 0.05, textReadability: 0.05, briefFormatting: 0.05 };
 		let ws = 0; const allIssues = [];
 		for (const [k, m] of Object.entries(metrics)) { ws += m.score * (weights[k] || 0); allIssues.push(...m.issues); }
 		return { score: Math.round(ws), metrics, issues: allIssues };

--- a/scripts/generate-featured.js
+++ b/scripts/generate-featured.js
@@ -16,7 +16,7 @@
 import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
-import { readJsonIfExists, rootDataPath, writeJsonPretty, isEventInWindow, MS_PER_DAY, formatDateKey, parseCliJsonOutput } from "./lib/helpers.js";
+import { readJsonIfExists, rootDataPath, writeJsonPretty, isEventInWindow, MS_PER_DAY, formatDateKey, parseCliJsonOutput, isNorwegianClubResult, UEFA_COMPETITIONS } from "./lib/helpers.js";
 import { LLMClient } from "./lib/llm-client.js";
 import { validateFeaturedContent, evaluateEditorialQuality, evaluateWatchPlanQuality, buildQualitySnapshot, buildAdaptiveHints, evaluateResultsQuality, buildResultsHints, buildSanityHints, computeRollingAverages } from "./lib/ai-quality-gates.js";
 import { buildWatchPlan, computeFeedbackAdjustments } from "./lib/watch-plan.js";
@@ -614,11 +614,40 @@ function sportEmoji(sport) {
 	return map[sport] || "🏆";
 }
 
-function generateFallbackThisWeek(events, now, sectionSports = []) {
+/** Guess the sport of a fallback section from its emoji, id, or title. */
+function guessSectionSport(section) {
+	const emojiMap = { "⚽": "football", "⛳": "golf", "🎾": "tennis", "🏎️": "formula1", "♟️": "chess", "🎮": "esports", "🏅": "olympics" };
+	if (section.emoji && emojiMap[section.emoji]) return emojiMap[section.emoji];
+	const text = `${section.id || ""} ${section.title || ""}`.toLowerCase();
+	// Specific sports first (before football's broad "champion" pattern)
+	if (/biathlon/.test(text)) return "biathlon";
+	if (/nordic|cross.country/.test(text)) return "nordic";
+	if (/alpine|ski/.test(text)) return "alpine";
+	if (/olympic/.test(text)) return "olympics";
+	if (/golf|pga|masters/.test(text)) return "golf";
+	if (/tennis|grand slam|atp|wta/.test(text)) return "tennis";
+	if (/f1|formula/.test(text)) return "formula1";
+	if (/chess/.test(text)) return "chess";
+	if (/esport|cs2|counter/.test(text)) return "esports";
+	if (/football|champions?\sleague|premier|la\sliga|europa/.test(text)) return "football";
+	return "unknown";
+}
+
+function generateFallbackThisWeek(events, now, sectionSports = [], { followedSports, favoriteOrgs } = {}) {
 	const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
 	const upcoming = events
 		.filter((event) => new Date(event.time) >= todayEnd)
 		.filter((event) => !sectionSports.includes(event.sport))
+		.filter((event) => {
+			// Filter to followed sports if preferences exist
+			if (followedSports && followedSports.size > 0 && !followedSports.has(event.sport)) return false;
+			// For esports, only include events involving favorite orgs
+			if (event.sport === "esports" && favoriteOrgs && favoriteOrgs.length > 0) {
+				const title = (event.title || "").toLowerCase();
+				return favoriteOrgs.some(org => title.includes(org));
+			}
+			return true;
+		})
 		.sort((a, b) => new Date(a.time) - new Date(b.time));
 
 	const parts = [];
@@ -677,8 +706,8 @@ export function buildFallbackHeadline(events, now, recentResults, standings, sec
 		return "Medal day in Milano-Cortina";
 	}
 
-	// Check for recent favorite team results (last 48h)
-	const favResults = getFavoriteResults(recentResults, now);
+	// Check for recent noteworthy results — favorites + Norwegian clubs in UEFA (last 48h)
+	const favResults = getNoteworthyResults(recentResults, now);
 	if (favResults.length > 0) {
 		const r = favResults[0];
 		const winner = r.homeScore > r.awayScore ? r.homeTeam : r.homeScore < r.awayScore ? r.awayTeam : null;
@@ -731,7 +760,7 @@ export function buildFallbackNarrative(events, now, recentResults, standings, se
 	}
 
 	// Major result narrative: upset or high-scoring game
-	const favResults = getFavoriteResults(recentResults, now);
+	const favResults = getNoteworthyResults(recentResults, now);
 	if (favResults.length > 0) {
 		const r = favResults[0];
 		const totalGoals = (r.homeScore || 0) + (r.awayScore || 0);
@@ -751,22 +780,35 @@ export function buildFallbackNarrative(events, now, recentResults, standings, se
 }
 
 /**
- * Get recent results for favorite teams within the last 48h.
+ * Get recent noteworthy results within the last 48h.
+ * Includes favorite team results AND Norwegian club results in UEFA competitions.
+ * This ensures big Norwegian results (e.g. Bodø/Glimt in CL) surface even
+ * when the fallback provider is used and the team isn't a user favorite.
  */
-function getFavoriteResults(recentResults, now) {
+function getNoteworthyResults(recentResults, now) {
 	if (!recentResults?.football?.length) return [];
 	const cutoff = new Date(now.getTime() - 2 * MS_PER_DAY);
 	return recentResults.football
-		.filter((m) => m.isFavorite && new Date(m.date) >= cutoff)
+		.filter((m) => {
+			if (new Date(m.date) < cutoff) return false;
+			if (m.isFavorite) return true;
+			// Norwegian clubs in UEFA competitions are always noteworthy
+			if (isNorwegianClubResult(m)) {
+				const code = (m.leagueCode || "").toLowerCase();
+				return UEFA_COMPETITIONS.some(comp => code.includes(comp));
+			}
+			return false;
+		})
 		.sort((a, b) => new Date(b.date) - new Date(a.date));
 }
 
 /**
- * Build event-line blocks for recent favorite team results.
+ * Build event-line blocks for recent noteworthy results.
+ * Includes favorites and Norwegian clubs in UEFA competitions.
  * Max 2 result lines from the last 48h.
  */
 export function buildFallbackResultLines(recentResults, now) {
-	const favResults = getFavoriteResults(recentResults, now);
+	const favResults = getNoteworthyResults(recentResults, now);
 	if (favResults.length === 0) return [];
 
 	return favResults.slice(0, 2).map((r) => {
@@ -784,11 +826,21 @@ export function buildFallbackResultLines(recentResults, now) {
 	});
 }
 
-export function buildFallbackFeatured(events, now, { recentResults, standings, rssDigest } = {}) {
+export function buildFallbackFeatured(events, now, { recentResults, standings, rssDigest, userContext } = {}) {
 	const blocks = [];
+	const prefs = userContext?.sportPreferences || {};
+	const followedSports = new Set(Object.keys(prefs));
+	const favoriteOrgs = (userContext?.favoriteEsportsOrgs || []).map(o => o.toLowerCase());
 
-	// Sections for major events (compute early so we can dedupe event-lines)
-	const sections = buildFallbackSections(events, now);
+	// Sections for major events — filtered to sports the user follows
+	const allSections = buildFallbackSections(events, now);
+	const sections = followedSports.size > 0
+		? allSections.filter((s) => {
+			// Map section sport from its events or id — keep if user follows it
+			const sectionSport = s._sport || guessSectionSport(s);
+			return followedSports.has(sectionSport) || sectionSport === "olympics";
+		})
+		: allSections;
 	const sectionSports = sections.map((s) => {
 		if (/olympic/i.test(s.id || s.title)) return "olympics";
 		return null;
@@ -800,7 +852,7 @@ export function buildFallbackFeatured(events, now, { recentResults, standings, r
 		blocks.push({ type: "headline", text: headline });
 	}
 
-	// Recent favorite results as match-result component blocks (last 48h)
+	// Recent noteworthy results as match-result component blocks (last 48h)
 	const resultBlocks = buildFallbackResultLines(recentResults, now);
 	for (const block of resultBlocks) {
 		blocks.push(block);
@@ -813,7 +865,8 @@ export function buildFallbackFeatured(events, now, { recentResults, standings, r
 	}
 
 	// Today event lines — football events become match-preview components, others stay as text
-	const todayBlocks = generateFallbackTodayBlocks(events, now, sectionSports);
+	// Esports filtered to events involving favorite orgs only
+	const todayBlocks = generateFallbackTodayBlocks(events, now, sectionSports, favoriteOrgs);
 	for (const block of todayBlocks) {
 		blocks.push(block);
 	}
@@ -858,8 +911,8 @@ export function buildFallbackFeatured(events, now, { recentResults, standings, r
 		});
 	}
 
-	// This week — football events become match-preview components
-	const thisWeekItems = generateFallbackThisWeek(events, now, sectionSports);
+	// This week — football events become match-preview components, filtered by preferences
+	const thisWeekItems = generateFallbackThisWeek(events, now, sectionSports, { followedSports, favoriteOrgs });
 	if (thisWeekItems.length > 0) {
 		blocks.push({ type: "divider", text: "This Week" });
 		for (const item of thisWeekItems) {
@@ -877,13 +930,21 @@ export function buildFallbackFeatured(events, now, { recentResults, standings, r
 /**
  * Generate today's event blocks — football as match-preview components, others as text event-lines.
  */
-function generateFallbackTodayBlocks(events, now, sectionSports = []) {
+function generateFallbackTodayBlocks(events, now, sectionSports = [], favoriteOrgs = []) {
 	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 	const todayEnd = new Date(todayStart.getTime() + MS_PER_DAY);
 
 	const todayEvents = events
 		.filter((e) => isEventInWindow(e, todayStart, todayEnd))
-		.filter((e) => !sectionSports.includes(e.sport));
+		.filter((e) => !sectionSports.includes(e.sport))
+		.filter((e) => {
+			// For esports, only include events involving favorite orgs
+			if (e.sport === "esports" && favoriteOrgs.length > 0) {
+				const title = (e.title || "").toLowerCase();
+				return favoriteOrgs.some(org => title.includes(org));
+			}
+			return true;
+		});
 
 	if (todayEvents.length === 0) return [];
 
@@ -1222,7 +1283,7 @@ async function main() {
 	if (!featured) {
 		console.log("Using deterministic fallback for featured content.");
 		provider = "fallback";
-		featured = buildFallbackFeatured(events, now, { recentResults, standings, rssDigest });
+		featured = buildFallbackFeatured(events, now, { recentResults, standings, rssDigest, userContext });
 		qualityResult = validateFeaturedContent(featured, { events });
 		featured = qualityResult.normalized;
 	}

--- a/scripts/lib/helpers.js
+++ b/scripts/lib/helpers.js
@@ -8,6 +8,38 @@ export const MS_PER_MINUTE = 60_000;
 export const MS_PER_HOUR = 3_600_000;
 export const MS_PER_DAY = 86_400_000;
 
+/** Norwegian football clubs that appear in European competitions (ESPN naming) */
+export const NORWEGIAN_CLUBS = [
+	"bodo/glimt", "bodø/glimt", "molde", "rosenborg", "viking",
+	"brann", "lillestrøm", "lillestrom", "tromsø", "tromso",
+	"vålerenga", "valerenga", "sarpsborg", "odd", "lyn",
+];
+
+/** UEFA competition league codes where Norwegian club results are noteworthy */
+export const UEFA_COMPETITIONS = [
+	"uefa.champions", "uefa.europa", "uefa.europa.conf",
+];
+
+/**
+ * Check if a football result involves a Norwegian club.
+ * Matches team names against NORWEGIAN_CLUBS (case-insensitive, substring match).
+ */
+export function isNorwegianClubResult(result) {
+	const home = (result.homeTeam || "").toLowerCase();
+	const away = (result.awayTeam || "").toLowerCase();
+	return NORWEGIAN_CLUBS.some(club => home.includes(club) || away.includes(club));
+}
+
+/**
+ * Check if a result is noteworthy for a Norwegian-focused dashboard.
+ * A result is noteworthy if it involves a Norwegian club in a UEFA competition.
+ */
+export function isNoteworthyNorwegianResult(result) {
+	if (!isNorwegianClubResult(result)) return false;
+	const code = (result.leagueCode || "").toLowerCase();
+	return UEFA_COMPETITIONS.some(comp => code.includes(comp));
+}
+
 export function iso(d = Date.now()) {
 	return new Date(d).toISOString();
 }

--- a/scripts/lib/ux-heuristics.js
+++ b/scripts/lib/ux-heuristics.js
@@ -224,6 +224,50 @@ export async function runUxHeuristics(page) {
 			return { score, details: `${longLines} long text line(s)`, issues: readIssues };
 		}
 
+		// 8. Brief formatting — orphaned text fragments and section dominance
+		function checkBriefFormatting() {
+			const fmtIssues = [];
+			let problems = 0;
+
+			// Check for orphaned punctuation-leading text in brief lines
+			const briefLines = document.querySelectorAll('#the-brief .block-event-line, #the-brief .block-match-preview');
+			for (const el of briefLines) {
+				// Walk direct child text nodes for orphaned fragments like ", Champions League"
+				for (const node of el.childNodes) {
+					if (node.nodeType === 3) { // text node
+						const text = node.textContent.trim();
+						if (text.length > 0 && text.length < 20 && /^[,;·–—]/.test(text)) {
+							problems++;
+							if (problems <= 3) {
+								fmtIssues.push({
+									severity: 'warning',
+									code: 'orphaned_brief_text',
+									message: `Orphaned text fragment in brief: "${text.slice(0, 30)}"`,
+								});
+							}
+						}
+					}
+				}
+			}
+
+			// Check if headlines section dominates the briefing
+			const brief = document.querySelector('#the-brief');
+			const news = document.querySelector('#news');
+			if (brief && news && brief.offsetHeight > 0 && news.offsetHeight > 0) {
+				if (news.offsetHeight > brief.offsetHeight * 2) {
+					problems++;
+					fmtIssues.push({
+						severity: 'info',
+						code: 'headlines_dominate',
+						message: `Headlines section (${news.offsetHeight}px) is >2x taller than briefing (${brief.offsetHeight}px)`,
+					});
+				}
+			}
+
+			const score = Math.max(0, 100 - problems * 20);
+			return { score, details: `${problems} formatting issue(s)`, issues: fmtIssues };
+		}
+
 		// Run all heuristics
 		const metrics = {
 			emptySections: checkEmptySections(),
@@ -233,6 +277,7 @@ export async function runUxHeuristics(page) {
 			touchTargets: checkTouchTargets(),
 			loadCompleteness: checkLoadCompleteness(),
 			textReadability: checkTextReadability(),
+			briefFormatting: checkBriefFormatting(),
 		};
 
 		// Weighted average
@@ -242,8 +287,9 @@ export async function runUxHeuristics(page) {
 			brokenImages: 0.15,
 			contentOverflow: 0.15,
 			contrastRatio: 0.10,
-			touchTargets: 0.10,
+			touchTargets: 0.05,
 			textReadability: 0.05,
+			briefFormatting: 0.05,
 		};
 
 		let weightedSum = 0;

--- a/tests/generate-featured.test.js
+++ b/tests/generate-featured.test.js
@@ -302,6 +302,23 @@ describe("buildFallbackHeadline()", () => {
 		expect(headline).toContain("Barcelona");
 	});
 
+	it("returns Norwegian club UEFA result as headline", () => {
+		const now = new Date();
+		const events = [
+			{ sport: "football", title: "Some match", time: futureTime() },
+		];
+		const recentResults = {
+			football: [{
+				homeTeam: "Internazionale", awayTeam: "Bodo/Glimt", homeScore: 1, awayScore: 2,
+				date: new Date(now.getTime() - 6 * 3600000).toISOString(),
+				leagueCode: "uefa.champions",
+				isFavorite: false,
+			}],
+		};
+		const headline = buildFallbackHeadline(events, now, recentResults, null);
+		expect(headline).toContain("Bodo/Glimt");
+	});
+
 	it("returns must-watch event headline when no results", () => {
 		const events = [
 			{ sport: "football", title: "Arsenal vs Liverpool", time: futureTime(), homeTeam: "Arsenal", awayTeam: "Liverpool", importance: 5, tournament: "Premier League" },
@@ -353,12 +370,42 @@ describe("buildFallbackResultLines()", () => {
 		expect(blocks[0]._fallbackText).toContain("Beltrán");
 	});
 
-	it("skips non-favorite results", () => {
+	it("skips non-favorite non-Norwegian results", () => {
 		const now = new Date();
 		const results = {
 			football: [{
 				homeTeam: "Arsenal", awayTeam: "Liverpool", homeScore: 1, awayScore: 0,
 				date: new Date(now.getTime() - 6 * 3600000).toISOString(),
+				leagueCode: "eng.1",
+				isFavorite: false,
+			}],
+		};
+		expect(buildFallbackResultLines(results, now)).toEqual([]);
+	});
+
+	it("includes Norwegian club results in UEFA competitions", () => {
+		const now = new Date();
+		const results = {
+			football: [{
+				homeTeam: "Internazionale", awayTeam: "Bodo/Glimt", homeScore: 1, awayScore: 2,
+				date: new Date(now.getTime() - 6 * 3600000).toISOString(),
+				leagueCode: "uefa.champions",
+				isFavorite: false,
+			}],
+		};
+		const blocks = buildFallbackResultLines(results, now);
+		expect(blocks.length).toBe(1);
+		expect(blocks[0].type).toBe("match-result");
+		expect(blocks[0]._fallbackText).toContain("Bodo/Glimt");
+	});
+
+	it("skips Norwegian club results in domestic leagues", () => {
+		const now = new Date();
+		const results = {
+			football: [{
+				homeTeam: "Rosenborg", awayTeam: "Molde", homeScore: 2, awayScore: 1,
+				date: new Date(now.getTime() - 6 * 3600000).toISOString(),
+				leagueCode: "nor.1",
 				isFavorite: false,
 			}],
 		};

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { iso, normalizeToUTC, hasEvents, countEvents, mergePrimaryAndOpen, isEventInWindow, parseCliJsonOutput, parseSessionUsage } from "../scripts/lib/helpers.js";
+import { iso, normalizeToUTC, hasEvents, countEvents, mergePrimaryAndOpen, isEventInWindow, parseCliJsonOutput, parseSessionUsage, isNorwegianClubResult, isNoteworthyNorwegianResult, NORWEGIAN_CLUBS, UEFA_COMPETITIONS } from "../scripts/lib/helpers.js";
 
 describe("iso()", () => {
 	it("returns valid ISO string for current time", () => {
@@ -273,5 +273,75 @@ describe("parseSessionUsage()", () => {
 		} finally {
 			fs.rmSync(testProjectDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("Norwegian club helpers", () => {
+	describe("isNorwegianClubResult()", () => {
+		it("detects Norwegian home team", () => {
+			expect(isNorwegianClubResult({ homeTeam: "Bodo/Glimt", awayTeam: "Inter" })).toBe(true);
+		});
+
+		it("detects Norwegian away team", () => {
+			expect(isNorwegianClubResult({ homeTeam: "Inter", awayTeam: "Molde" })).toBe(true);
+		});
+
+		it("is case-insensitive", () => {
+			expect(isNorwegianClubResult({ homeTeam: "ROSENBORG", awayTeam: "Celtic" })).toBe(true);
+		});
+
+		it("returns false for non-Norwegian teams", () => {
+			expect(isNorwegianClubResult({ homeTeam: "Arsenal", awayTeam: "Liverpool" })).toBe(false);
+		});
+
+		it("handles missing team names", () => {
+			expect(isNorwegianClubResult({})).toBe(false);
+			expect(isNorwegianClubResult({ homeTeam: null })).toBe(false);
+		});
+	});
+
+	describe("isNoteworthyNorwegianResult()", () => {
+		it("returns true for Norwegian club in Champions League", () => {
+			expect(isNoteworthyNorwegianResult({
+				homeTeam: "Inter", awayTeam: "Bodo/Glimt", leagueCode: "uefa.champions",
+			})).toBe(true);
+		});
+
+		it("returns true for Norwegian club in Europa League", () => {
+			expect(isNoteworthyNorwegianResult({
+				homeTeam: "Molde", awayTeam: "Ajax", leagueCode: "uefa.europa",
+			})).toBe(true);
+		});
+
+		it("returns true for Norwegian club in Conference League", () => {
+			expect(isNoteworthyNorwegianResult({
+				homeTeam: "Bodø/Glimt", awayTeam: "Roma", leagueCode: "uefa.europa.conf",
+			})).toBe(true);
+		});
+
+		it("returns false for Norwegian club in domestic league", () => {
+			expect(isNoteworthyNorwegianResult({
+				homeTeam: "Rosenborg", awayTeam: "Molde", leagueCode: "nor.1",
+			})).toBe(false);
+		});
+
+		it("returns false for non-Norwegian club in UEFA", () => {
+			expect(isNoteworthyNorwegianResult({
+				homeTeam: "Arsenal", awayTeam: "PSG", leagueCode: "uefa.champions",
+			})).toBe(false);
+		});
+	});
+
+	it("NORWEGIAN_CLUBS list covers key teams", () => {
+		expect(NORWEGIAN_CLUBS).toContain("bodo/glimt");
+		expect(NORWEGIAN_CLUBS).toContain("rosenborg");
+		expect(NORWEGIAN_CLUBS).toContain("lyn");
+		expect(NORWEGIAN_CLUBS.length).toBeGreaterThanOrEqual(10);
+	});
+
+	it("UEFA_COMPETITIONS covers all three tiers", () => {
+		expect(UEFA_COMPETITIONS).toContain("uefa.champions");
+		expect(UEFA_COMPETITIONS).toContain("uefa.europa");
+		expect(UEFA_COMPETITIONS).toContain("uefa.europa.conf");
 	});
 });

--- a/tests/ux-heuristics.test.js
+++ b/tests/ux-heuristics.test.js
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
 import { computeTrend } from "../scripts/lib/ux-heuristics.js";
 
 describe("computeTrend()", () => {
@@ -58,5 +60,39 @@ describe("computeTrend()", () => {
 	it("handles null/undefined input", () => {
 		expect(computeTrend(null)).toBe("insufficient");
 		expect(computeTrend(undefined)).toBe("insufficient");
+	});
+});
+
+describe("briefFormatting heuristic registration", () => {
+	it("ux-heuristics.js includes briefFormatting in metrics and weights", () => {
+		const src = fs.readFileSync(
+			path.resolve(process.cwd(), "scripts/lib/ux-heuristics.js"),
+			"utf-8"
+		);
+		expect(src).toContain("checkBriefFormatting");
+		expect(src).toContain("briefFormatting: checkBriefFormatting()");
+		expect(src).toContain("briefFormatting: 0.05");
+	});
+
+	it("evaluate-ux.js includes briefFormatting in inline metrics and weights", () => {
+		const src = fs.readFileSync(
+			path.resolve(process.cwd(), "scripts/evaluate-ux.js"),
+			"utf-8"
+		);
+		expect(src).toContain("checkBriefFormatting");
+		expect(src).toContain("briefFormatting: checkBriefFormatting()");
+		expect(src).toContain("briefFormatting: 0.05");
+	});
+
+	it("weights sum to approximately 1.0 in ux-heuristics.js", () => {
+		const src = fs.readFileSync(
+			path.resolve(process.cwd(), "scripts/lib/ux-heuristics.js"),
+			"utf-8"
+		);
+		const weightBlock = src.match(/const weights = \{([^}]+)\}/);
+		expect(weightBlock).not.toBeNull();
+		const nums = weightBlock[1].match(/[\d.]+/g).map(Number);
+		const sum = nums.reduce((a, b) => a + b, 0);
+		expect(sum).toBeCloseTo(1.0, 2);
 	});
 });


### PR DESCRIPTION
## Summary
- **Norwegian team surfacing**: Bodø/Glimt's CL win (and any Norwegian club in UEFA) now appears in the briefing even when not a favorite team — both server-side (`getNoteworthyResults`) and client-side
- **Editorial context**: Match previews show aggregate-score narrative from `_fallbackText` (e.g. "PSG lead 3-2 but Monaco are very much in this French derby")
- **Personalized fallback**: Sections and events filtered by `user-context.json` sportPreferences + favoriteEsportsOrgs — no biathlon, no generic esports
- **Cleaner layout**: Compact headlines with show-more toggle, softer This Week divider, no redundant section boxes, no duplicate auto-narrative
- **Closes the loop**: `briefFormatting` UX heuristic added for autonomous layout regression detection
- 15 new tests (1922 total, all passing)

## Test plan
- [x] `npm test` — 1922 tests pass
- [x] Visual verification via live preview (light mode)
- [x] Bodø/Glimt CL result surfaces in briefing headline + result card
- [x] Editorial context shows under CL match previews
- [x] Biathlon section filtered out, only 100 Thieves esports events shown
- [x] This Week shows golf, Liverpool, F1 — no ESL Pro League or biathlon
- [x] No JS console errors from changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)