### PR TITLE
Fix day-strip highlight color in dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -197,6 +197,9 @@
 		.day-item.is-today {
 			background: var(--fg);
 		}
+		.dark .day-item.is-today {
+			background: var(--accent);
+		}
 		.day-item.is-past { opacity: 0.35; }
 		.day-item.is-selected:not(.is-today) { background: var(--bg-warm); box-shadow: inset 0 0 0 1.5px var(--accent); }
 		.day-label {


### PR DESCRIPTION
### Motivation
- The "today" day chip in the day-strip used the foreground color in dark mode, producing a low-contrast white-on-white appearance that made the calendar bar highlight hard to read.

### Description
- Added a dark-mode specific rule in `docs/index.html` to set `.dark .day-item.is-today { background: var(--accent); }` so the today chip uses the accent color in dark theme and improves contrast.

### Testing
- Ran the test suite with `npm test` (Vitest), which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a016a636f4832bb5dee27baa5c84d1)