### PR TITLE
Harmonize autonomy & preferences page design with dashboard

### DIFF
--- a/docs/autonomy.html
+++ b/docs/autonomy.html
@@ -2,36 +2,61 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 	<meta name="description" content="SportSync autonomy control center — feedback loops, pipeline runs, roadmap, strategy.">
-	<meta name="theme-color" content="#d97757">
+	<meta name="theme-color" content="#c25a34">
+	<!-- PWA manifest -->
+	<link rel="manifest" href="manifest.webmanifest">
+	<!-- iOS PWA support -->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+	<meta name="apple-mobile-web-app-title" content="SportSync">
+	<link rel="apple-touch-icon" href="icons/icon-180x180.png">
+	<!-- Favicon -->
+	<link rel="icon" type="image/png" href="favicon.png">
 	<title>SportSync — Autonomy</title>
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 	<style>
 		:root {
-			--bg: #faf9f5;
-			--bg-secondary: #f0efe8;
-			--fg: #3d3929;
-			--muted: #8b8580;
-			--border: #e8e5dc;
-			--border-strong: #3d3929;
-			--accent: #d97757;
-			--radius: 12px;
+			--bg: #faf9f6;
+			--bg-card: #fff;
+			--bg-warm: #f5f2eb;
+			--bg-secondary: #f5f2eb;
+			--bg-accent: rgba(194,90,52,0.04);
+			--fg: #1c1917;
+			--fg-2: #44403c;
+			--muted: #9c9589;
+			--muted-light: #c4bfb6;
+			--border: #e8e3da;
+			--border-light: #f0ece4;
+			--border-strong: #1c1917;
+			--accent: #c25a34;
+			--accent-warm: #a84e2e;
+			--radius: 14px;
+			--radius-sm: 8px;
 			--max-w: 480px;
-			--font: system-ui, -apple-system, sans-serif;
-			--font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', serif;
-			--shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+			--font: 'Inter', system-ui, -apple-system, sans-serif;
+			--font-serif: 'Inter', ui-serif, Georgia, serif;
+			--mono: 'JetBrains Mono', 'SF Mono', monospace;
+			--shadow: 0 1px 4px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.03);
 			--green: #2ecc71;
 			--amber: #f39c12;
 			--red: #e74c3c;
 		}
 		.dark {
 			--bg: #1a1816;
-			--bg-secondary: #242220;
-			--fg: #faf9f5;
-			--muted: #9a958e;
-			--border: #2d2a26;
-			--border-strong: #faf9f5;
-			--shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+			--bg-card: #242220;
+			--bg-warm: #2a2725;
+			--bg-secondary: #2a2725;
+			--bg-accent: rgba(194,90,52,0.08);
+			--fg: #f5f2eb;
+			--fg-2: #c4bfb6;
+			--muted: #8a857e;
+			--muted-light: #5a564f;
+			--border: #3a3632;
+			--border-light: #2f2c28;
+			--border-strong: #f5f2eb;
+			--shadow: 0 1px 4px rgba(0,0,0,0.15), 0 4px 16px rgba(0,0,0,0.12);
 		}
 		* { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -39,10 +64,19 @@
 			font-family: var(--font);
 			background: var(--bg);
 			color: var(--fg);
-			line-height: 1.6;
+			line-height: 1.55;
 			font-size: 15px;
-			font-weight: 400;
 			-webkit-font-smoothing: antialiased;
+		}
+
+		/* PWA standalone mode: safe area insets for notch/home indicator */
+		@supports (padding-top: env(safe-area-inset-top)) {
+			body {
+				padding-top: env(safe-area-inset-top);
+				padding-left: env(safe-area-inset-left);
+				padding-right: env(safe-area-inset-right);
+				padding-bottom: env(safe-area-inset-bottom);
+			}
 		}
 
 		.wrap {
@@ -58,10 +92,9 @@
 			margin-bottom: 8px;
 		}
 		header h1 {
-			font-family: var(--font-serif);
-			font-size: 1.15rem;
-			font-weight: 400;
-			letter-spacing: -0.01em;
+			font-size: 1.05rem;
+			font-weight: 700;
+			letter-spacing: -0.04em;
 			color: var(--fg);
 		}
 		header h1 a {
@@ -69,6 +102,10 @@
 			text-decoration: none;
 		}
 		header h1 a:hover { color: var(--accent); }
+		.logo-sync {
+			font-weight: 400;
+			color: var(--muted);
+		}
 		#themeToggle {
 			background: none;
 			border: none;
@@ -124,25 +161,27 @@
 
 		/* --- Hero score --- */
 		.hero {
-			text-align: center;
-			padding: 24px 20px 20px;
+			display: flex;
+			align-items: baseline;
+			gap: 10px;
+			padding: 14px 20px;
+			flex-wrap: wrap;
 		}
 		.hero-score {
-			font-size: 3rem;
-			font-weight: 300;
+			font-size: 1.4rem;
+			font-weight: 600;
 			line-height: 1;
 			letter-spacing: -0.02em;
 		}
 		.hero-loops {
-			font-size: 0.82rem;
+			font-size: 0.75rem;
 			color: var(--muted);
-			margin-top: 4px;
 		}
 		.hero-status {
-			font-size: 0.72rem;
+			font-size: 0.68rem;
 			color: var(--muted);
-			margin-top: 8px;
 			font-style: italic;
+			width: 100%;
 		}
 
 		/* --- Loop cards --- */
@@ -178,17 +217,23 @@
 		}
 		.loop-card-phases {
 			display: flex;
+			flex-wrap: wrap;
 			gap: 6px;
 			font-size: 0.6rem;
 			color: var(--muted);
 			text-transform: uppercase;
 			letter-spacing: 0.04em;
 			margin-bottom: 4px;
+			overflow: hidden;
 		}
 		.loop-card-phases span {
 			padding: 1px 6px;
 			background: var(--bg);
 			border-radius: 4px;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			max-width: 100%;
 		}
 		.loop-card-detail {
 			font-size: 0.65rem;
@@ -517,7 +562,7 @@
 <body>
 	<div class="wrap">
 		<header>
-			<h1><a href="./">SportSync</a></h1>
+			<h1><a href="./">Sport<span class="logo-sync">Sync</span></a></h1>
 			<button id="themeToggle" aria-label="Toggle dark mode">&#127769;</button>
 		</header>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1257,7 +1257,7 @@
 			<div class="logo">Sport<span class="logo-sync">Sync</span></div>
 			<div class="masthead-right">
 				<div class="masthead-meta" id="masthead-meta"></div>
-				<a href="autonomy.html" class="status-link" title="Autonomy" aria-label="Autonomy" style="width:8px;height:8px;border-radius:50%;background:#2ecc71;display:inline-block;opacity:0.6;transition:opacity 0.15s;padding:10px;margin:-10px"></a>
+				<a href="autonomy.html" class="status-link" title="Autonomy" aria-label="Autonomy" style="font-size:0.85rem;text-decoration:none;color:var(--muted);opacity:0.5;transition:opacity 0.15s;padding:8px;margin:-8px;line-height:1">&#9881;</a>
 				<button id="themeToggle" aria-label="Toggle dark mode">&#127769;</button>
 			</div>
 		</div>

--- a/docs/preferences.html
+++ b/docs/preferences.html
@@ -2,36 +2,61 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 	<meta name="description" content="SportSync preferences — manage sports, favorites, and feedback.">
-	<meta name="theme-color" content="#d97757">
+	<meta name="theme-color" content="#c25a34">
+	<!-- PWA manifest -->
+	<link rel="manifest" href="manifest.webmanifest">
+	<!-- iOS PWA support -->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+	<meta name="apple-mobile-web-app-title" content="SportSync">
+	<link rel="apple-touch-icon" href="icons/icon-180x180.png">
+	<!-- Favicon -->
+	<link rel="icon" type="image/png" href="favicon.png">
 	<title>SportSync — Preferences</title>
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 	<style>
 		:root {
-			--bg: #faf9f5;
-			--bg-secondary: #f0efe8;
-			--fg: #3d3929;
-			--muted: #8b8580;
-			--border: #e8e5dc;
-			--border-strong: #3d3929;
-			--accent: #d97757;
-			--radius: 12px;
+			--bg: #faf9f6;
+			--bg-card: #fff;
+			--bg-warm: #f5f2eb;
+			--bg-secondary: #f5f2eb;
+			--bg-accent: rgba(194,90,52,0.04);
+			--fg: #1c1917;
+			--fg-2: #44403c;
+			--muted: #9c9589;
+			--muted-light: #c4bfb6;
+			--border: #e8e3da;
+			--border-light: #f0ece4;
+			--border-strong: #1c1917;
+			--accent: #c25a34;
+			--accent-warm: #a84e2e;
+			--radius: 14px;
+			--radius-sm: 8px;
 			--max-w: 480px;
-			--font: system-ui, -apple-system, sans-serif;
-			--font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', serif;
-			--shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+			--font: 'Inter', system-ui, -apple-system, sans-serif;
+			--font-serif: 'Inter', ui-serif, Georgia, serif;
+			--mono: 'JetBrains Mono', 'SF Mono', monospace;
+			--shadow: 0 1px 4px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.03);
 			--green: #2ecc71;
 			--amber: #f39c12;
 			--red: #e74c3c;
 		}
 		.dark {
 			--bg: #1a1816;
-			--bg-secondary: #242220;
-			--fg: #faf9f5;
-			--muted: #9a958e;
-			--border: #2d2a26;
-			--border-strong: #faf9f5;
-			--shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+			--bg-card: #242220;
+			--bg-warm: #2a2725;
+			--bg-secondary: #2a2725;
+			--bg-accent: rgba(194,90,52,0.08);
+			--fg: #f5f2eb;
+			--fg-2: #c4bfb6;
+			--muted: #8a857e;
+			--muted-light: #5a564f;
+			--border: #3a3632;
+			--border-light: #2f2c28;
+			--border-strong: #f5f2eb;
+			--shadow: 0 1px 4px rgba(0,0,0,0.15), 0 4px 16px rgba(0,0,0,0.12);
 		}
 		* { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -39,10 +64,19 @@
 			font-family: var(--font);
 			background: var(--bg);
 			color: var(--fg);
-			line-height: 1.6;
+			line-height: 1.55;
 			font-size: 15px;
-			font-weight: 400;
 			-webkit-font-smoothing: antialiased;
+		}
+
+		/* PWA standalone mode: safe area insets for notch/home indicator */
+		@supports (padding-top: env(safe-area-inset-top)) {
+			body {
+				padding-top: env(safe-area-inset-top);
+				padding-left: env(safe-area-inset-left);
+				padding-right: env(safe-area-inset-right);
+				padding-bottom: env(safe-area-inset-bottom);
+			}
 		}
 
 		.wrap {
@@ -58,10 +92,9 @@
 			margin-bottom: 8px;
 		}
 		header h1 {
-			font-family: var(--font-serif);
-			font-size: 1.15rem;
-			font-weight: 400;
-			letter-spacing: -0.01em;
+			font-size: 1.05rem;
+			font-weight: 700;
+			letter-spacing: -0.04em;
 			color: var(--fg);
 		}
 		header h1 a {
@@ -69,6 +102,10 @@
 			text-decoration: none;
 		}
 		header h1 a:hover { color: var(--accent); }
+		.logo-sync {
+			font-weight: 400;
+			color: var(--muted);
+		}
 		#themeToggle {
 			background: none;
 			border: none;
@@ -252,7 +289,7 @@
 <body>
 	<div class="wrap">
 		<header>
-			<h1><a href="./">SportSync</a></h1>
+			<h1><a href="./">Sport<span class="logo-sync">Sync</span></a></h1>
 			<button id="themeToggle" aria-label="Toggle dark mode">&#127769;</button>
 		</header>
 


### PR DESCRIPTION
## Summary
- Synced CSS variables (colors, borders, shadows, radius) across autonomy.html and preferences.html to match the dashboard
- Fixed dark mode for proper contrast on all pages
- Added Google Fonts (Inter), PWA metadata, and safe-area insets to sub-pages
- Compacted the oversized 100% hero section to a single-line layout
- Fixed loop card phase tag overflow with flex-wrap
- Matched logo style (Sport + muted Sync) consistently across all pages
- Replaced the oversized green status dot with a subtle gear icon on the dashboard

## Test plan
- [x] Visual check on autonomy.html — colors, hero, loop cards
- [x] Visual check on preferences.html — colors, logo
- [x] Visual check on index.html — gear icon in header
- [x] Dark mode verified on autonomy page
- [x] Mobile viewport (375px) verified
- [x] All 2281 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)