### PR TITLE
Redesign: goal-driven hierarchy + Norwegian-media identity

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -1,71 +1,124 @@
-/* SportSync v2 — design tokens, reset, typography */
+/* SportSync — design tokens, reset, typography
+   Identity: a personal Norwegian sports paper. Display face is Schibsted Grotesk
+   (the house type of Norway's largest media group), so the character comes from
+   the subject, not a generic UI font. Times use a mono for a departure-board spine. */
 
 :root {
-	--bg: #000;
-	--surface: #0e0e10;
-	--surface-2: #16161a;
-	--border: #26262c;
-	--fg: #f5f5f7;
-	--fg-2: #a1a1aa;
-	--accent: #ff6b35;
-	--live: #ef4444;
-	--favorite: #fbbf24;
-	--radius: 16px;
-	--radius-sm: 10px;
-	--max-w: 1280px;
-	--font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-	--mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+	/* Dark = the late-night sports desk (default identity) */
+	--bg: #0b0d10;
+	--surface: #14171c;
+	--surface-2: #1b1f26;
+	--surface-3: #232830;
+	--border: #262c35;
+	--border-strong: #363d48;
+	--fg: #f3f5f8;
+	--fg-2: #98a2ae;
+	--fg-3: #6b7480;
+	--accent: #ff5c35;
+	--accent-soft: rgba(255, 92, 53, 0.14);
+	--live: #ff3b3b;
+	--favorite: #ffc233;
+
+	--font-display: "Schibsted Grotesk", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+	--font-body: "Schibsted Grotesk", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+	--font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+	--radius: 14px;
+	--radius-sm: 9px;
+	--radius-chip: 7px;
+	--max-w: 1180px;
+
+	--shadow-hero: 0 1px 0 rgba(255,255,255,0.03) inset, 0 8px 24px rgba(0,0,0,0.35);
+}
+
+/* Light = fresh newsprint, warm paper tint (not pure white) */
+:root[data-theme="light"] {
+	--bg: #f4f1ea;
+	--surface: #ffffff;
+	--surface-2: #efebe1;
+	--surface-3: #e7e2d6;
+	--border: #e0dacd;
+	--border-strong: #cfc8b8;
+	--fg: #17130d;
+	--fg-2: #635d51;
+	--fg-3: #8b8578;
+	--accent: #d8431a;
+	--accent-soft: rgba(216, 67, 26, 0.10);
+	--live: #d61f1f;
+	--favorite: #b8860b;
+	--shadow-hero: 0 1px 2px rgba(0,0,0,0.04), 0 10px 26px rgba(60,50,30,0.10);
 }
 
 @media (prefers-color-scheme: light) {
 	:root:not([data-theme="dark"]) {
-		--bg: #f7f6f3;
+		--bg: #f4f1ea;
 		--surface: #ffffff;
-		--surface-2: #f0efec;
-		--border: #e2e0db;
-		--fg: #17171a;
-		--fg-2: #6b6b70;
+		--surface-2: #efebe1;
+		--surface-3: #e7e2d6;
+		--border: #e0dacd;
+		--border-strong: #cfc8b8;
+		--fg: #17130d;
+		--fg-2: #635d51;
+		--fg-3: #8b8578;
+		--accent: #d8431a;
+		--accent-soft: rgba(216, 67, 26, 0.10);
+		--live: #d61f1f;
+		--favorite: #b8860b;
+		--shadow-hero: 0 1px 2px rgba(0,0,0,0.04), 0 10px 26px rgba(60,50,30,0.10);
 	}
 }
 
-:root[data-theme="light"] {
-	--bg: #f7f6f3;
-	--surface: #ffffff;
-	--surface-2: #f0efec;
-	--border: #e2e0db;
-	--fg: #17171a;
-	--fg-2: #6b6b70;
-}
-
 * { box-sizing: border-box; margin: 0; padding: 0; }
-
 html { -webkit-text-size-adjust: 100%; }
 
 body {
 	background: var(--bg);
 	color: var(--fg);
-	font-family: var(--font);
+	font-family: var(--font-body);
 	font-size: 16px;
 	line-height: 1.5;
 	font-weight: 400;
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
 	padding-bottom: env(safe-area-inset-bottom);
+	font-feature-settings: "ss01", "cv01";
 }
 
 img { max-width: 100%; display: inline-block; }
+a { color: inherit; text-decoration: none; }
+button { font: inherit; color: inherit; background: none; border: none; cursor: pointer; }
 
-a { color: inherit; }
-
-button {
-	font: inherit;
-	color: inherit;
-	background: none;
-	border: none;
-	cursor: pointer;
+/* Section headers — the editorial kicker system */
+.section-head {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	margin: 26px 0 12px;
+}
+.section-head h2 {
+	font-family: var(--font-display);
+	font-size: 13px;
+	font-weight: 800;
+	text-transform: uppercase;
+	letter-spacing: 0.13em;
+	color: var(--fg-2);
+}
+.section-head::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background: var(--border);
 }
 
-h1 { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; }
-h2 { font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); }
+.mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.muted { color: var(--fg-2); }
+[hidden] { display: none !important; }
 
-.mono, .score { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+::selection { background: var(--accent); color: #fff; }
 
-::selection { background: var(--accent); color: #000; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+@media (prefers-reduced-motion: no-preference) {
+	.section, .hero-card { animation: rise 0.4s cubic-bezier(0.2,0.7,0.2,1) both; }
+	@keyframes rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+}

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -1,189 +1,248 @@
-/* SportSync v2 — cards, editorial brief, live hero, tracked surface */
+/* SportSync — components: hero highlights, program timeline, channel chips,
+   later list, live cards, demoted brief, tracked surface, modal. */
 
-.card {
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: var(--radius);
-	padding: 14px 16px;
-	margin-bottom: 10px;
-	position: relative;
-}
-
-/* Event card */
-.event-card .card-top {
-	display: flex;
-	justify-content: space-between;
-	align-items: baseline;
-	gap: 8px;
-	margin-bottom: 6px;
-	font-size: 12px;
-	color: var(--fg-2);
-}
-.event-card .card-time { font-family: var(--mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
-.event-card .card-tournament { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-
-.event-card .card-title {
-	font-size: 15px;
-	font-weight: 600;
-	display: flex;
+/* ── Channel chip: the "hvor kan jeg se det" component, first-class everywhere ── */
+.chips { display: inline-flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.chip {
+	display: inline-flex;
 	align-items: center;
-	gap: 8px;
-	flex-wrap: wrap;
+	gap: 5px;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1;
+	padding: 5px 9px;
+	border-radius: var(--radius-chip);
+	background: var(--surface-3);
+	color: var(--fg);
+	border: 1px solid var(--border-strong);
+	white-space: nowrap;
 }
-.event-card .team-logo { width: 20px; height: 20px; object-fit: contain; vertical-align: -4px; }
+.chip .tv { font-size: 10px; opacity: 0.7; }
+a.chip:hover { border-color: var(--accent); color: var(--accent); }
+.chip.unknown { background: transparent; color: var(--fg-3); border-style: dashed; font-weight: 500; }
+.chip.big { font-size: 13px; padding: 7px 12px; }
 
-.event-card .card-detail {
-	margin-top: 6px;
-	font-size: 12.5px;
-	color: var(--fg-2);
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px 12px;
-}
-.event-card .streaming a { color: var(--fg-2); text-decoration: none; border-bottom: 1px dotted var(--border); }
-.event-card .streaming a:hover { color: var(--accent); }
-
-.event-card.must-watch { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
-.event-card.must-watch::before {
-	content: "";
-	position: absolute; inset: 0;
-	border-radius: var(--radius);
-	background: linear-gradient(120deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 55%);
-	pointer-events: none;
+/* ── Sport marker: small color dot/square as secondary signal ── */
+.sport-dot {
+	width: 9px; height: 9px;
+	border-radius: 2px;
+	background: var(--sport-color, var(--accent));
+	flex-shrink: 0;
+	display: inline-block;
 }
 
+/* ── Badges ── */
 .fav-star { color: var(--favorite); font-size: 13px; }
-.nor-flag { font-size: 13px; }
-
-/* AI provenance badge */
+.nor-flag { font-size: 12px; }
 .ai-badge {
-	font-size: 10px;
-	font-weight: 700;
-	letter-spacing: 0.06em;
-	padding: 2px 7px;
-	border-radius: 999px;
-	background: color-mix(in srgb, var(--accent) 16%, transparent);
-	color: var(--accent);
+	font-size: 9.5px; font-weight: 800; letter-spacing: 0.05em;
+	padding: 2px 6px; border-radius: 5px;
+	background: var(--accent-soft); color: var(--accent);
 	border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
 	cursor: pointer;
 }
-.ai-badge:hover { background: color-mix(in srgb, var(--accent) 28%, transparent); }
+.ai-badge:hover { background: color-mix(in srgb, var(--accent) 26%, transparent); }
 
-/* Live card */
+/* ── Highlights: the enlarged must-see cards ── */
+.highlights { display: grid; gap: 12px; }
+@media (min-width: 620px) and (max-width: 1023px) {
+	.highlights { grid-template-columns: 1fr 1fr; }
+}
+
+.hero-card {
+	position: relative;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	padding: 16px 18px 16px 20px;
+	box-shadow: var(--shadow-hero);
+	overflow: hidden;
+}
+.hero-card::before {
+	content: "";
+	position: absolute; left: 0; top: 0; bottom: 0;
+	width: 4px;
+	background: var(--sport-color, var(--accent));
+}
+.hero-card.must::after {
+	content: "";
+	position: absolute; inset: 0;
+	background: radial-gradient(120% 100% at 0% 0%, var(--accent-soft), transparent 55%);
+	pointer-events: none;
+}
+.hero-top {
+	display: flex; align-items: center; gap: 8px;
+	font-size: 11px; text-transform: uppercase; letter-spacing: 0.09em;
+	color: var(--fg-2); font-weight: 700;
+	margin-bottom: 10px;
+}
+.hero-top .sport-name { color: var(--fg-2); }
+.hero-top .spacer { flex: 1; }
+.hero-when {
+	display: flex; align-items: baseline; gap: 10px;
+	margin-bottom: 8px;
+}
+.hero-time {
+	font-family: var(--font-mono);
+	font-variant-numeric: tabular-nums;
+	font-size: 30px; font-weight: 700; letter-spacing: -0.02em;
+	color: var(--fg);
+	line-height: 1;
+}
+.hero-rel { font-size: 12.5px; color: var(--fg-2); }
+.hero-day { font-size: 12.5px; color: var(--accent); font-weight: 700; }
+.hero-title {
+	font-family: var(--font-display);
+	font-size: 19px; font-weight: 700; letter-spacing: -0.02em;
+	line-height: 1.2; text-wrap: balance;
+	display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+	margin-bottom: 4px;
+}
+.hero-title .team-logo { width: 24px; height: 24px; object-fit: contain; vertical-align: middle; }
+.hero-title .score { font-family: var(--font-mono); font-weight: 700; }
+.hero-meta { font-size: 13px; color: var(--fg-2); margin-bottom: 12px; }
+.hero-meta .dot-sep { opacity: 0.5; margin: 0 6px; }
+.hero-card .chips { margin-top: 2px; }
+
+/* ── Program timeline: chronological agenda, channel chip per row ── */
+.day-group { margin-bottom: 6px; }
+.day-label {
+	font-family: var(--font-display);
+	font-size: 12px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em;
+	color: var(--accent);
+	margin: 16px 0 8px;
+}
+.day-group:first-child .day-label { margin-top: 0; }
+
+.tl-row {
+	display: grid;
+	grid-template-columns: 58px 1fr;
+	gap: 13px;
+	padding: 11px 0;
+	border-bottom: 1px solid var(--border);
+	align-items: start;
+}
+.tl-row:last-child { border-bottom: none; }
+.tl-time {
+	font-family: var(--font-mono);
+	font-variant-numeric: tabular-nums;
+	font-size: 15px; font-weight: 700;
+	color: var(--fg);
+	padding-top: 1px;
+}
+.tl-time .tl-rel { display: block; font-size: 10px; font-weight: 500; color: var(--fg-3); margin-top: 2px; }
+.tl-body { min-width: 0; }
+.tl-head {
+	display: flex; align-items: center; gap: 8px;
+	margin-bottom: 5px;
+}
+.tl-title {
+	font-size: 14.5px; font-weight: 600;
+	display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+	min-width: 0;
+}
+.tl-title .team-logo { width: 17px; height: 17px; object-fit: contain; vertical-align: -3px; }
+.tl-title .score { font-family: var(--font-mono); font-weight: 700; color: var(--accent); }
+.tl-tournament { font-size: 11.5px; color: var(--fg-3); }
+.tl-row.is-live { background: linear-gradient(90deg, color-mix(in srgb, var(--live) 8%, transparent), transparent 60%); border-radius: 8px; margin: 0 -8px; padding-left: 8px; padding-right: 8px; }
+.tl-row.is-live .tl-time { color: var(--live); }
+
+/* ── Later this week: tightest list ── */
+.later-row {
+	display: grid;
+	grid-template-columns: 44px 1fr auto;
+	gap: 10px;
+	padding: 8px 0;
+	border-bottom: 1px solid var(--border);
+	align-items: center;
+	font-size: 13.5px;
+}
+.later-row:last-child { border-bottom: none; }
+.later-time { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: 12px; color: var(--fg-2); }
+.later-title { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.later-title span.t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.later-chip { font-size: 11px; color: var(--fg-3); white-space: nowrap; }
+
+.empty-state { color: var(--fg-2); font-size: 13.5px; padding: 10px 0; }
+
+/* ── Live cards (in the strip) ── */
 .live-card {
 	background: var(--surface);
 	border: 1px solid color-mix(in srgb, var(--live) 45%, var(--border));
 	border-radius: var(--radius);
-	padding: 16px;
+	padding: 15px 16px;
 }
-.live-card .live-league { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); margin-bottom: 10px; display: flex; align-items: center; gap: 6px; }
+.live-card .live-league { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); margin-bottom: 11px; display: flex; align-items: center; gap: 7px; font-weight: 700; }
 .live-card .live-teams { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 8px; }
 .live-card .live-side { display: flex; flex-direction: column; align-items: center; gap: 6px; font-size: 13px; font-weight: 600; text-align: center; }
-.live-card .live-side img { width: 34px; height: 34px; object-fit: contain; }
-.live-card .live-score { font-family: var(--mono); font-size: 28px; font-weight: 700; }
-.live-card .live-clock { text-align: center; margin-top: 8px; font-size: 12px; color: var(--live); font-weight: 600; }
-.live-card .live-detail { text-align: center; font-size: 12px; color: var(--fg-2); margin-top: 2px; }
+.live-card .live-side img { width: 32px; height: 32px; object-fit: contain; }
+.live-card .live-score { font-family: var(--font-mono); font-size: 27px; font-weight: 700; }
+.live-card .live-clock { text-align: center; margin-top: 9px; font-size: 12px; color: var(--live); font-weight: 700; }
+.live-card .live-detail { text-align: center; font-size: 12px; color: var(--fg-2); margin-top: 3px; }
+.live-card .block-schedule-item { font-size: 12.5px; padding: 2px 0; }
 
-.live-dot {
-	width: 8px; height: 8px;
-	background: var(--live);
-	border-radius: 50%;
-	display: inline-block;
-	animation: pulse 1.6s ease-in-out infinite;
-}
-@keyframes pulse {
-	0%, 100% { opacity: 1; transform: scale(1); }
-	50% { opacity: 0.35; transform: scale(0.8); }
+.live-dot { width: 8px; height: 8px; background: var(--live); border-radius: 50%; display: inline-block; box-shadow: 0 0 0 0 color-mix(in srgb, var(--live) 60%, transparent); }
+@media (prefers-reduced-motion: no-preference) {
+	.live-dot { animation: pulse 1.6s ease-in-out infinite; }
+	@keyframes pulse { 0%,100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--live) 55%, transparent); } 50% { opacity: 0.5; box-shadow: 0 0 0 5px transparent; } }
 }
 
-/* Editorial brief */
+/* ── Collapsible toggles (brief + tracked) ── */
+.disclosure-toggle {
+	width: 100%;
+	display: flex; align-items: center; justify-content: space-between;
+	padding: 13px 15px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	font-size: 13.5px; font-weight: 600;
+	text-align: left;
+	color: var(--fg);
+}
+.disclosure-toggle:hover { border-color: var(--border-strong); }
+.disclosure-toggle .chevron { transition: transform 0.2s; color: var(--fg-2); }
+.disclosure-toggle[aria-expanded="true"] .chevron { transform: rotate(180deg); }
+
+/* ── Editorial brief (demoted, inside disclosure) ── */
 .brief {
 	background: var(--surface);
 	border: 1px solid var(--border);
-	border-radius: var(--radius);
-	padding: 22px 24px;
+	border-top: none;
+	border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+	padding: 16px 18px 18px;
+	margin-top: -6px;
 }
-.brief-mode { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); font-weight: 700; margin-bottom: 8px; }
-.block-headline { font-size: 21px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.3; margin-bottom: 10px; }
-.block-narrative { color: var(--fg); font-size: 15px; margin-bottom: 12px; max-width: 68ch; }
-.block-divider {
-	font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em;
-	color: var(--fg-2); font-weight: 700;
-	margin: 16px 0 8px;
-	display: flex; align-items: center; gap: 10px;
-}
+.brief-mode { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.11em; color: var(--accent); font-weight: 800; margin-bottom: 8px; }
+.block-headline { font-family: var(--font-display); font-size: 18px; font-weight: 700; letter-spacing: -0.02em; line-height: 1.25; margin-bottom: 9px; text-wrap: balance; }
+.block-narrative { color: var(--fg); font-size: 14.5px; margin-bottom: 11px; max-width: 62ch; }
+.block-divider { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-2); font-weight: 800; margin: 14px 0 7px; display: flex; align-items: center; gap: 9px; }
 .block-divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
-.block-event-line, .editorial-line { font-size: 14px; padding: 5px 0; color: var(--fg); }
-.block-event-line .preview-rel, .preview-ctx, .block-standings-ctx { color: var(--fg-2); font-size: 12.5px; margin-left: 8px; }
-.preview-editorial { color: var(--fg-2); font-size: 13px; margin-top: 2px; }
-.brief-logo { width: 18px; height: 18px; object-fit: contain; vertical-align: -3px; margin-right: 3px; }
+.block-event-line, .editorial-line { font-size: 13.5px; padding: 4px 0; color: var(--fg); }
+.block-event-line .preview-rel, .preview-ctx, .block-standings-ctx { color: var(--fg-2); font-size: 12px; margin-left: 7px; }
+.preview-editorial { color: var(--fg-2); font-size: 12.5px; margin-top: 2px; }
+.brief-logo { width: 17px; height: 17px; object-fit: contain; vertical-align: -3px; margin-right: 3px; }
 .brief-headshot { border-radius: 50%; background: var(--surface-2); }
-
-.block-match-result {
-	background: var(--surface-2);
-	border-radius: var(--radius-sm);
-	padding: 12px 14px;
-	margin: 10px 0;
-}
+.block-match-result { background: var(--surface-2); border-radius: var(--radius-sm); padding: 11px 13px; margin: 9px 0; }
 .result-card-teams { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 8px; }
-.result-card-side { display: flex; align-items: center; gap: 8px; justify-content: center; font-weight: 600; font-size: 14px; }
-.result-card-logo { width: 22px; height: 22px; object-fit: contain; }
-.result-card-score { font-family: var(--mono); font-size: 20px; font-weight: 700; }
-.result-card-scorers, .result-card-league { text-align: center; font-size: 12px; color: var(--fg-2); margin-top: 6px; }
-
-.block-event-schedule { background: var(--surface-2); border-radius: var(--radius-sm); padding: 12px 14px; margin: 10px 0; }
-.block-schedule-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); font-weight: 700; margin-bottom: 6px; }
-.block-schedule-item { font-size: 13.5px; padding: 3px 0; }
+.result-card-side { display: flex; align-items: center; gap: 7px; justify-content: center; font-weight: 600; font-size: 13.5px; }
+.result-card-logo { width: 21px; height: 21px; object-fit: contain; }
+.result-card-score { font-family: var(--font-mono); font-size: 19px; font-weight: 700; }
+.result-card-scorers, .result-card-league { text-align: center; font-size: 11.5px; color: var(--fg-2); margin-top: 5px; }
+.block-event-schedule { background: var(--surface-2); border-radius: var(--radius-sm); padding: 11px 13px; margin: 9px 0; }
+.block-schedule-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); font-weight: 700; margin-bottom: 6px; }
+.block-schedule-item { font-size: 13px; padding: 3px 0; }
 .block-schedule-more { font-size: 12px; color: var(--fg-2); margin-top: 4px; }
 
-/* Tracked surface ("Hva vi følger") */
-.tracked-toggle {
-	width: 100%;
-	display: flex; align-items: center; justify-content: space-between;
-	padding: 14px 16px;
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: var(--radius);
-	font-size: 14px; font-weight: 600;
-	text-align: left;
-}
-.tracked-toggle .chevron { transition: transform 0.2s; color: var(--fg-2); }
-.tracked-toggle[aria-expanded="true"] .chevron { transform: rotate(180deg); }
-.tracked-body { margin-top: 10px; }
-.tracked-group-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); font-weight: 700; margin: 12px 0 6px; }
-.tracked-item {
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: var(--radius-sm);
-	padding: 10px 14px;
-	margin-bottom: 6px;
-	font-size: 13.5px;
-}
-.tracked-item .reason { color: var(--fg-2); font-size: 12.5px; margin-top: 2px; }
-.tracked-item .provenance { color: var(--fg-2); font-size: 11px; margin-top: 4px; font-family: var(--mono); }
+/* ── Tracked surface ── */
+.tracked-body { margin-top: 8px; }
+.tracked-group-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-2); font-weight: 800; margin: 12px 0 6px; }
+.tracked-item { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 9px 13px; margin-bottom: 6px; font-size: 13px; }
+.tracked-item .reason { color: var(--fg-2); font-size: 12px; margin-top: 2px; }
+.tracked-item .provenance { color: var(--fg-3); font-size: 10.5px; margin-top: 4px; font-family: var(--font-mono); }
 
-/* AI evidence modal */
-.modal-backdrop {
-	position: fixed; inset: 0;
-	background: rgba(0, 0, 0, 0.6);
-	backdrop-filter: blur(4px);
-	z-index: 50;
-	display: grid; place-items: center;
-	padding: 24px;
-}
-.modal {
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: var(--radius);
-	padding: 20px;
-	max-width: 480px;
-	width: 100%;
-	max-height: 80vh;
-	overflow-y: auto;
-}
-.modal h3 { font-size: 16px; margin-bottom: 10px; }
+/* ── AI evidence modal ── */
+.modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); z-index: 50; display: grid; place-items: center; padding: 24px; }
+.modal { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; max-width: 460px; width: 100%; max-height: 80vh; overflow-y: auto; }
+.modal h3 { font-family: var(--font-display); font-size: 16px; margin-bottom: 10px; }
 .modal .evidence-link { display: block; font-size: 13px; color: var(--accent); word-break: break-all; margin: 6px 0; }
 .modal .modal-close { float: right; color: var(--fg-2); font-size: 18px; }
-
-/* Empty state */
-.empty-state { color: var(--fg-2); font-size: 13.5px; padding: 8px 0; }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -1,98 +1,96 @@
-/* SportSync v2 — page layout: header, container, responsive grid */
+/* SportSync — page frame: masthead, container, responsive two-column on desktop */
 
 .container {
 	max-width: var(--max-w);
 	margin: 0 auto;
-	padding: 0 16px;
+	padding: 0 18px;
 }
 
-/* Header */
-.site-header {
+/* Masthead */
+.masthead {
 	position: sticky;
 	top: 0;
 	z-index: 20;
-	background: color-mix(in srgb, var(--bg) 85%, transparent);
-	backdrop-filter: blur(12px);
-	-webkit-backdrop-filter: blur(12px);
+	background: color-mix(in srgb, var(--bg) 88%, transparent);
+	backdrop-filter: blur(14px) saturate(1.2);
+	-webkit-backdrop-filter: blur(14px) saturate(1.2);
 	border-bottom: 1px solid var(--border);
 	padding-top: env(safe-area-inset-top);
 }
-
-.site-header .container {
+.masthead-inner {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	height: 56px;
+	height: 58px;
 }
-
-.site-title { display: flex; align-items: baseline; gap: 10px; }
-.site-title .date { color: var(--fg-2); font-size: 13px; }
-
-.header-actions { display: flex; gap: 4px; }
-.header-btn {
-	width: 36px; height: 36px;
+.brand { display: flex; align-items: baseline; gap: 12px; min-width: 0; }
+.wordmark {
+	font-family: var(--font-display);
+	font-weight: 800;
+	font-size: 22px;
+	letter-spacing: -0.035em;
+	color: var(--fg);
+}
+.wordmark .sync { color: var(--accent); }
+.masthead-date {
+	font-size: 12.5px;
+	color: var(--fg-2);
+	text-transform: capitalize;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.icon-btn {
+	width: 38px; height: 38px;
 	display: grid; place-items: center;
 	border-radius: 50%;
 	font-size: 17px;
 	color: var(--fg-2);
+	flex-shrink: 0;
 }
-.header-btn:hover { background: var(--surface-2); color: var(--fg); }
+.icon-btn:hover { background: var(--surface-2); color: var(--fg); }
 
-/* Sections */
-main { padding: 20px 0 48px; }
-section { margin-bottom: 32px; }
-section > .container > h2 { margin-bottom: 12px; }
+/* Layout: single column mobile, two columns ≥1024 */
+.layout { padding-top: 4px; padding-bottom: 56px; }
+.col-main { min-width: 0; }
+.col-aside { min-width: 0; }
 
-/* Sport grid: 1 col mobile → 2 col ≥768 → 3 col ≥1200 */
-.sports-grid {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: 24px;
-}
-@media (min-width: 768px) {
-	.sports-grid { grid-template-columns: repeat(2, 1fr); }
-}
-@media (min-width: 1200px) {
-	.sports-grid { grid-template-columns: repeat(3, 1fr); }
+@media (min-width: 1024px) {
+	.layout {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 340px;
+		gap: 40px;
+		align-items: start;
+	}
+	.col-aside {
+		position: sticky;
+		top: 74px;
+	}
+	/* first section header in each column shouldn't push extra top margin */
+	.col-main > section:first-child .section-head,
+	.col-aside > section:first-child .section-head { margin-top: 14px; }
 }
 
-.sport-section { min-width: 0; }
-.sport-heading {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-bottom: 10px;
-	font-size: 14px;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
-	color: var(--fg-2);
-	border-left: 3px solid var(--sport-color, var(--accent));
-	padding-left: 10px;
-}
-.sport-heading .count { font-weight: 400; opacity: 0.7; }
-
-/* Live hero strip: horizontal scroll of big cards */
+/* Live strip: horizontal scroll of cards */
 .live-strip {
 	display: flex;
 	gap: 12px;
 	overflow-x: auto;
 	scroll-snap-type: x mandatory;
-	padding-bottom: 4px;
+	padding-bottom: 6px;
 	scrollbar-width: none;
 }
 .live-strip::-webkit-scrollbar { display: none; }
-.live-strip > * { scroll-snap-align: start; flex: 0 0 min(320px, 85vw); }
+.live-strip > * { scroll-snap-align: start; flex: 0 0 min(300px, 82vw); }
 
 /* Footer */
 .site-footer {
 	border-top: 1px solid var(--border);
-	padding: 16px 0 32px;
+	margin-top: 40px;
+	padding: 16px 0 34px;
 	color: var(--fg-2);
 	font-size: 12px;
 }
-.site-footer .container { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; }
-
-/* Utility */
-[hidden] { display: none !important; }
-.muted { color: var(--fg-2); }
+.site-footer .container { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+.site-footer a { border-bottom: 1px dotted var(--border-strong); }
+.site-footer a:hover { color: var(--accent); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,70 +3,82 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
-	<meta name="description" content="Personlig sportsdashboard — fotball, golf, tennis, F1, sjakk, sykkel og esport med norsk perspektiv.">
-	<meta name="theme-color" content="#000000">
-	<!-- PWA manifest -->
+	<meta name="description" content="Personlig sportsdashboard — når det skjer og hvor du ser det. Fotball, golf, tennis, F1, sjakk, sykkel og vintersport med norsk perspektiv.">
+	<meta name="theme-color" content="#0b0d10" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#f4f1ea" media="(prefers-color-scheme: light)">
 	<link rel="manifest" href="manifest.webmanifest">
-	<!-- iOS PWA support -->
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 	<meta name="apple-mobile-web-app-title" content="SportSync">
 	<link rel="apple-touch-icon" href="icons/icon-180x180.png">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>SportSync</title>
-	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/base.css">
 	<link rel="stylesheet" href="css/layout.css">
 	<link rel="stylesheet" href="css/cards.css">
 </head>
 <body>
-	<header class="site-header">
-		<div class="container">
-			<div class="site-title">
-				<h1>SportSync</h1>
-				<span class="date" id="header-date"></span>
+	<header class="masthead">
+		<div class="container masthead-inner">
+			<div class="brand">
+				<span class="wordmark">Sport<span class="sync">Sync</span></span>
+				<span class="masthead-date" id="header-date"></span>
 			</div>
-			<div class="header-actions">
-				<button class="header-btn" id="theme-toggle" title="Bytt tema" aria-label="Bytt tema">◐</button>
-			</div>
+			<button class="icon-btn" id="theme-toggle" title="Bytt tema" aria-label="Bytt tema">◐</button>
 		</div>
 	</header>
 
-	<main>
-		<section id="live-section" hidden>
-			<div class="container">
-				<h2><span class="live-dot"></span> Direkte nå</h2>
+	<main class="container layout">
+		<div class="col-main">
+			<section id="live-section" hidden>
+				<div class="section-head"><span class="live-dot"></span><h2>Direkte nå</h2></div>
 				<div class="live-strip" id="live-strip"></div>
-			</div>
-		</section>
+			</section>
 
-		<section id="brief-section" hidden>
-			<div class="container">
-				<div class="brief" id="brief"></div>
-			</div>
-		</section>
+			<section id="highlights-section" hidden>
+				<div class="section-head"><h2 id="highlights-title">Dagens viktigste</h2></div>
+				<div class="highlights" id="highlights"></div>
+			</section>
 
-		<section id="sports-section">
-			<div class="container">
-				<div class="sports-grid" id="sports-grid"></div>
-			</div>
-		</section>
+			<section id="program-section">
+				<div class="section-head"><h2>Program</h2></div>
+				<div class="timeline" id="timeline"></div>
+			</section>
+		</div>
 
-		<section id="tracked-section" hidden>
-			<div class="container">
-				<button class="tracked-toggle" id="tracked-toggle" aria-expanded="false">
-					<span>Hva vi følger</span>
+		<aside class="col-aside">
+			<section id="later-section" hidden>
+				<div class="section-head"><h2>Senere denne uka</h2></div>
+				<div class="later" id="later"></div>
+			</section>
+
+			<section id="brief-section" hidden>
+				<div class="section-head"><h2>Brief</h2></div>
+				<button class="disclosure-toggle" id="brief-toggle" aria-expanded="false">
+					<span id="brief-toggle-label">Redaksjonens brief</span>
+					<span class="chevron">▾</span>
+				</button>
+				<div class="brief" id="brief" hidden></div>
+			</section>
+
+			<section id="tracked-section" hidden>
+				<div class="section-head"><h2>Hva vi følger</h2></div>
+				<button class="disclosure-toggle" id="tracked-toggle" aria-expanded="false">
+					<span>Se hva systemet sporer og hvorfor</span>
 					<span class="chevron">▾</span>
 				</button>
 				<div class="tracked-body" id="tracked-body" hidden></div>
-			</div>
-		</section>
+			</section>
+		</aside>
 	</main>
 
 	<footer class="site-footer">
 		<div class="container">
 			<span id="footer-updated"></span>
-			<a href="data/events.ics" download style="text-decoration:none;">📅 Kalender (.ics)</a>
+			<a href="data/events.ics" download>📅 Legg til i kalender</a>
 		</div>
 	</footer>
 

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -1,6 +1,8 @@
-// SportSync v2 — dashboard controller
-// Loads pre-built JSON data, renders: live hero, editorial brief (blocks),
-// per-sport card grid, tracked-entities surface. Polls ESPN for live scores.
+// SportSync — dashboard controller
+// Goal-driven hierarchy: live now → dagens viktigste (must-see hero cards) →
+// program (chronological today+tomorrow agenda, channel chip per row) →
+// senere denne uka → demoted editorial brief → tracked surface.
+// Channel info ("hvor kan jeg se det") is a first-class chip everywhere.
 // Depends on: shared-constants.js, sport-config.js, asset-maps.js, block-renderers.js
 
 class Dashboard {
@@ -23,7 +25,8 @@ class Dashboard {
 		await this.loadData();
 		this.render();
 		this.startLivePolling();
-		this.bindTrackedToggle();
+		this.bindDisclosure('brief-toggle', 'brief');
+		this.bindDisclosure('tracked-toggle', 'tracked-body');
 		this.bindAiBadges();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
@@ -63,8 +66,10 @@ class Dashboard {
 
 	render() {
 		this.renderLive();
+		this.renderHighlights();
+		this.renderTimeline();
+		this.renderLater();
 		this.renderBrief();
-		this.renderSportsGrid();
 		this.renderTracked();
 		this.renderFooter();
 	}
@@ -175,7 +180,9 @@ class Dashboard {
 			html += this.renderBlock(block, ctx) || '';
 		}
 		container.innerHTML = html;
-		section.hidden = false;
+		const label = document.getElementById('brief-toggle-label');
+		if (label) label.textContent = `Redaksjonens ${modeLabel.toLowerCase()}`;
+		section.hidden = false; // content stays collapsed until the disclosure is opened
 	}
 
 	renderBlock(block, ctx) {
@@ -203,100 +210,210 @@ class Dashboard {
 		}
 	}
 
-	// ── Sport card grid ───────────────────────────────────────────────────────
+	// ── Shared event helpers ────────────────────────────────────────────────────
 
-	renderSportsGrid() {
-		const grid = document.getElementById('sports-grid');
-		if (!grid) return;
+	sportCfg(e) {
+		const id = normalizeClientSportId(e.sport);
+		return SPORT_CONFIG.find((s) => s.id === id) || { emoji: '🏆', name: e.sport, color: 'var(--accent)' };
+	}
 
-		const now = Date.now();
-		const horizon = now + 7 * SS_CONSTANTS.MS_PER_DAY;
-		const visible = this.allEvents.filter((e) => isEventInWindow(e, now - SS_CONSTANTS.MS_PER_HOUR * 4, horizon));
+	/** Must-see = matches the goal's priority: favorite, high importance, or Norwegian participation. */
+	isMustSee(e) {
+		return !!(e.isFavorite || (e.importance || 0) >= 4 || (e.norwegian && e.norwegianPlayers?.length));
+	}
 
-		// Group by sport, ordered by soonest event
-		const bySport = new Map();
-		for (const e of visible) {
-			const key = normalizeClientSportId(e.sport);
-			if (!bySport.has(key)) bySport.set(key, []);
-			bySport.get(key).push(e);
+	osloTime(date) {
+		return date.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Oslo' });
+	}
+	osloDayKey(date) {
+		return date.toLocaleDateString('en-CA', { timeZone: 'Europe/Oslo' });
+	}
+
+	/** The "hvor kan jeg se det" component — consistent channel chips everywhere. */
+	channelChips(e, { big = false } = {}) {
+		const streams = Array.isArray(e.streaming) ? e.streaming : [];
+		if (streams.length === 0) {
+			return `<span class="chip unknown${big ? ' big' : ''}">Kanal ukjent</span>`;
 		}
-		const sections = [...bySport.entries()]
-			.map(([sport, events]) => {
-				events.sort((a, b) => new Date(a.time) - new Date(b.time));
-				return { sport, events, first: new Date(events[0].time).getTime() };
-			})
-			.sort((a, b) => a.first - b.first);
-
-		if (sections.length === 0) {
-			grid.innerHTML = `<div class="empty-state">Ingen kommende arrangementer de neste 7 dagene.</div>`;
-			return;
-		}
-
-		grid.innerHTML = sections.map(({ sport, events }) => {
-			const cfg = SPORT_CONFIG.find((s) => s.id === sport) || { emoji: '🏆', name: sport, color: 'var(--accent)' };
-			const cards = events.slice(0, 8).map((e) => this.eventCard(e)).join('');
-			const more = events.length > 8 ? `<div class="empty-state">+${events.length - 8} flere</div>` : '';
-			return `<div class="sport-section" style="--sport-color:${cfg.color}">
-				<div class="sport-heading">${cfg.emoji} ${escapeHtml(cfg.name)} <span class="count">${events.length}</span></div>
-				${cards}${more}
-			</div>`;
+		return streams.slice(0, 3).map((s) => {
+			const platform = escapeHtml(String(s.platform || s));
+			const inner = `<span class="tv">▮</span>${platform}`;
+			return s.url
+				? `<a class="chip${big ? ' big' : ''}" href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${inner}</a>`
+				: `<span class="chip${big ? ' big' : ''}">${inner}</span>`;
 		}).join('');
 	}
 
-	eventCard(e) {
-		const date = new Date(e.time);
-		const now = new Date();
-		const sameDay = date.toDateString() === now.toDateString();
-		const dayStr = sameDay
-			? ''
-			: date.toLocaleDateString('nb-NO', { weekday: 'short', timeZone: 'Europe/Oslo' }) + ' ';
-		const timeStr = date.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Oslo' });
-		const rel = this.relativeTime(date);
+	badges(e) {
+		const b = [];
+		if (e.isFavorite) b.push('<span class="fav-star" title="Favoritt">★</span>');
+		if (e.norwegian || e.norwegianPlayers?.length) b.push('<span class="nor-flag" title="Norsk deltakelse">🇳🇴</span>');
+		if (e.source === 'ai-research') {
+			b.push(`<button class="ai-badge" data-event-id="${escapeHtml(e.id)}" title="Funnet av AI-research — klikk for kilder">AI</button>`);
+		}
+		return b.join(' ');
+	}
 
-		// Title: teams with logos for matches, plain title otherwise
-		let title;
+	/** Match title: teams+logos (with live/final score if present) or plain title. */
+	matchTitle(e, { logoClass = 'team-logo' } = {}) {
 		if (e.homeTeam && e.awayTeam) {
 			const hLogo = getTeamLogo(e.homeTeam);
 			const aLogo = getTeamLogo(e.awayTeam);
 			const live = this.liveScores[e.id];
 			const mid = live && live.state !== 'pre'
 				? `<span class="score">${live.home}–${live.away}</span>`
-				: '<span class="muted">–</span>';
-			title = `${hLogo ? `<img class="team-logo" src="${hLogo}" alt="" loading="lazy">` : ''}${escapeHtml(ssShortName(e.homeTeam))} ${mid} ${aLogo ? `<img class="team-logo" src="${aLogo}" alt="" loading="lazy">` : ''}${escapeHtml(ssShortName(e.awayTeam))}`;
-		} else {
-			title = escapeHtml(e.title);
+				: 'mot';
+			return `${hLogo ? `<img class="${logoClass}" src="${hLogo}" alt="" loading="lazy">` : ''}${escapeHtml(ssShortName(e.homeTeam))} ${mid} ${aLogo ? `<img class="${logoClass}" src="${aLogo}" alt="" loading="lazy">` : ''}${escapeHtml(ssShortName(e.awayTeam))}`;
+		}
+		return escapeHtml(e.title);
+	}
+
+	// ── Dagens viktigste (enlarged must-see cards) ──────────────────────────────
+
+	renderHighlights() {
+		const section = document.getElementById('highlights-section');
+		const wrap = document.getElementById('highlights');
+		if (!section || !wrap) return;
+
+		const now = Date.now();
+		const horizon = now + 36 * SS_CONSTANTS.MS_PER_HOUR; // today + into tomorrow
+		const picks = this.allEvents
+			.filter((e) => isEventInWindow(e, now - 2 * SS_CONSTANTS.MS_PER_HOUR, horizon))
+			.filter((e) => this.isMustSee(e))
+			.sort((a, b) => new Date(a.time) - new Date(b.time))
+			.slice(0, 3);
+
+		this._highlightIds = new Set(picks.map((e) => e.id));
+
+		if (picks.length === 0) { section.hidden = true; return; }
+		wrap.innerHTML = picks.map((e) => this.heroCard(e)).join('');
+		section.hidden = false;
+	}
+
+	heroCard(e) {
+		const cfg = this.sportCfg(e);
+		const date = new Date(e.time);
+		const todayKey = this.osloDayKey(new Date());
+		const isToday = this.osloDayKey(date) === todayKey;
+		const dayStr = isToday ? '' : `<span class="hero-day">${escapeHtml(date.toLocaleDateString('nb-NO', { weekday: 'long', timeZone: 'Europe/Oslo' }))}</span>`;
+		const rel = this.relativeTime(date);
+		const meta = [];
+		if (e.venue && e.venue !== 'TBD') meta.push(escapeHtml(e.venue));
+		if (e.norwegianPlayers?.length) meta.push(escapeHtml(e.norwegianPlayers.slice(0, 3).map((p) => p.name || p).join(', ')));
+		const must = (e.importance || 0) >= 4;
+		return `<article class="hero-card${must ? ' must' : ''}" style="--sport-color:${cfg.color}">
+			<div class="hero-top"><span class="sport-dot"></span><span class="sport-name">${cfg.emoji} ${escapeHtml(cfg.name)} · ${escapeHtml(e.tournament || '')}</span><span class="spacer"></span>${this.badges(e)}</div>
+			<div class="hero-when"><span class="hero-time">${escapeHtml(this.osloTime(date))}</span>${dayStr}${rel ? `<span class="hero-rel">${escapeHtml(rel)}</span>` : ''}</div>
+			<div class="hero-title">${this.matchTitle(e, { logoClass: 'team-logo' })}</div>
+			${meta.length ? `<div class="hero-meta">${meta.join('<span class="dot-sep">·</span>')}</div>` : ''}
+			<div class="chips">${this.channelChips(e, { big: true })}</div>
+		</article>`;
+	}
+
+	// ── Program (chronological agenda: today + tomorrow) ────────────────────────
+
+	renderTimeline() {
+		const container = document.getElementById('timeline');
+		if (!container) return;
+		const now = Date.now();
+		const start = now - 4 * SS_CONSTANTS.MS_PER_HOUR;
+		const horizon = now + 2 * SS_CONSTANTS.MS_PER_DAY;
+		const highlightIds = this._highlightIds || new Set();
+
+		const events = this.allEvents
+			.filter((e) => isEventInWindow(e, start, horizon))
+			.filter((e) => !highlightIds.has(e.id))
+			.sort((a, b) => new Date(a.time) - new Date(b.time));
+
+		if (events.length === 0 && highlightIds.size === 0) {
+			container.innerHTML = `<div class="empty-state">Ingen arrangementer i dag eller i morgen.</div>`;
+			return;
+		}
+		if (events.length === 0) {
+			container.innerHTML = `<div class="empty-state">Alt dagens er løftet fram over. Se «Senere denne uka».</div>`;
+			return;
 		}
 
-		const badges = [];
-		if (e.isFavorite) badges.push('<span class="fav-star" title="Favoritt">★</span>');
-		if (e.norwegian || e.norwegianPlayers?.length) badges.push('<span class="nor-flag" title="Norsk deltakelse">🇳🇴</span>');
-		if (e.source === 'ai-research') {
-			badges.push(`<button class="ai-badge" data-event-id="${escapeHtml(e.id)}" title="Funnet av AI-research — klikk for kilder">AI</button>`);
+		const todayKey = this.osloDayKey(new Date());
+		const tomorrowKey = this.osloDayKey(new Date(Date.now() + SS_CONSTANTS.MS_PER_DAY));
+		const groups = new Map();
+		for (const e of events) {
+			const key = this.osloDayKey(new Date(e.time));
+			if (!groups.has(key)) groups.set(key, []);
+			groups.get(key).push(e);
 		}
 
-		const details = [];
-		if (e.venue && e.venue !== 'TBD') details.push(`<span>${escapeHtml(e.venue)}</span>`);
-		if (e.norwegianPlayers?.length) {
-			details.push(`<span>${escapeHtml(e.norwegianPlayers.slice(0, 3).map((p) => p.name || p).join(', '))}</span>`);
+		let html = '';
+		for (const [key, evs] of groups) {
+			let label;
+			if (key === todayKey) label = 'I dag';
+			else if (key === tomorrowKey) label = 'I morgen';
+			else label = new Date(evs[0].time).toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/Oslo' });
+			html += `<div class="day-group"><div class="day-label">${escapeHtml(label)}</div>${evs.map((e) => this.timelineRow(e)).join('')}</div>`;
 		}
-		const streams = (e.streaming || []).slice(0, 2)
-			.map((s) => {
-				const platform = s.platform || s;
-				return s.url
-					? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${escapeHtml(platform)}</a>`
-					: escapeHtml(String(platform));
-			});
-		if (streams.length) details.push(`<span class="streaming">📺 ${streams.join(' · ')}</span>`);
-		if (e.summary) details.push(`<span>${escapeHtml(e.summary)}</span>`);
+		container.innerHTML = html;
+	}
 
-		const mustWatch = (e.importance || 0) >= 4;
-		return `<div class="card event-card${mustWatch ? ' must-watch' : ''}">
-			<div class="card-top">
-				<span class="card-time">${escapeHtml(dayStr)}${escapeHtml(timeStr)}${rel ? ` · ${escapeHtml(rel)}` : ''}</span>
-				<span class="card-tournament">${escapeHtml(e.tournament || '')}</span>
+	timelineRow(e) {
+		const cfg = this.sportCfg(e);
+		const date = new Date(e.time);
+		const rel = this.relativeTime(date);
+		const live = this.liveScores[e.id];
+		const isLive = live && live.state === 'in';
+		const relShort = rel.replace(/^om /, ''); // "om 54 min" → "54 min" to fit the time column
+		return `<div class="tl-row${isLive ? ' is-live' : ''}" style="--sport-color:${cfg.color}">
+			<div class="tl-time">${escapeHtml(this.osloTime(date))}${rel ? `<span class="tl-rel">${escapeHtml(isLive ? 'pågår' : relShort)}</span>` : ''}</div>
+			<div class="tl-body">
+				<div class="tl-head"><span class="sport-dot"></span><span class="tl-title">${this.matchTitle(e, { logoClass: 'team-logo' })}</span> ${this.badges(e)}</div>
+				<div class="tl-tournament">${escapeHtml([cfg.name, e.tournament].filter(Boolean).join(' · '))}</div>
+				<div class="chips" style="margin-top:6px;">${this.channelChips(e)}</div>
 			</div>
-			<div class="card-title">${title} ${badges.join(' ')}</div>
-			${details.length ? `<div class="card-detail">${details.join('')}</div>` : ''}
+		</div>`;
+	}
+
+	// ── Senere denne uka (tight list, grouped by weekday) ───────────────────────
+
+	renderLater() {
+		const section = document.getElementById('later-section');
+		const container = document.getElementById('later');
+		if (!section || !container) return;
+		const now = Date.now();
+		const start = now + 2 * SS_CONSTANTS.MS_PER_DAY;
+		const horizon = now + 7 * SS_CONSTANTS.MS_PER_DAY;
+		const events = this.allEvents
+			.filter((e) => isEventInWindow(e, start, horizon))
+			.sort((a, b) => new Date(a.time) - new Date(b.time));
+
+		if (events.length === 0) { section.hidden = true; return; }
+
+		const groups = new Map();
+		for (const e of events) {
+			const key = this.osloDayKey(new Date(e.time));
+			if (!groups.has(key)) groups.set(key, []);
+			groups.get(key).push(e);
+		}
+
+		let html = '';
+		for (const [, evs] of groups) {
+			const label = new Date(evs[0].time).toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'short', timeZone: 'Europe/Oslo' });
+			html += `<div class="day-group"><div class="day-label">${escapeHtml(label)}</div>${evs.map((e) => this.laterRow(e)).join('')}</div>`;
+		}
+		container.innerHTML = html;
+		section.hidden = false;
+	}
+
+	laterRow(e) {
+		const cfg = this.sportCfg(e);
+		const date = new Date(e.time);
+		const streams = Array.isArray(e.streaming) ? e.streaming : [];
+		const chan = streams.length ? escapeHtml(String(streams[0].platform || streams[0])) : '';
+		const titleText = e.homeTeam && e.awayTeam
+			? `${escapeHtml(ssShortName(e.homeTeam))} – ${escapeHtml(ssShortName(e.awayTeam))}`
+			: escapeHtml(e.title);
+		return `<div class="later-row" style="--sport-color:${cfg.color}">
+			<span class="later-time">${escapeHtml(this.osloTime(date))}</span>
+			<span class="later-title"><span class="sport-dot" title="${escapeHtml(cfg.name)}"></span><span class="t">${titleText}</span></span>
+			<span class="later-chip">${chan}</span>
 		</div>`;
 	}
 
@@ -330,9 +447,9 @@ class Dashboard {
 		section.hidden = false;
 	}
 
-	bindTrackedToggle() {
-		const btn = document.getElementById('tracked-toggle');
-		const body = document.getElementById('tracked-body');
+	bindDisclosure(toggleId, bodyId) {
+		const btn = document.getElementById(toggleId);
+		const body = document.getElementById(bodyId);
 		if (!btn || !body) return;
 		btn.addEventListener('click', () => {
 			const open = btn.getAttribute('aria-expanded') === 'true';
@@ -400,7 +517,8 @@ class Dashboard {
 		try {
 			await Promise.all([this.pollFootballScores(), this.pollGolfScores()]);
 			this.renderLive();
-			this.renderSportsGrid();
+			this.renderHighlights();
+			this.renderTimeline();
 		} catch {
 			// Silent fail — live scores are a nice-to-have
 		}

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -15,8 +15,8 @@ beforeAll(() => {
 });
 
 describe("dashboard event cards", () => {
-	it("renders a match card with both team names", () => {
-		const html = dash.eventCard({
+	it("renders a match row with both team names", () => {
+		const html = dash.timelineRow({
 			id: "x", sport: "football", tournament: "Premier League",
 			homeTeam: "Liverpool FC", awayTeam: "Arsenal FC",
 			title: "Liverpool vs Arsenal",
@@ -28,13 +28,13 @@ describe("dashboard event cards", () => {
 		expect(html).toContain("Viaplay");
 	});
 
-	it("marks must-watch events (importance >= 4)", () => {
-		const html = dash.eventCard({ id: "y", sport: "golf", title: "The Open", time: new Date().toISOString(), importance: 5 });
-		expect(html).toContain("must-watch");
+	it("marks must-see hero events (importance >= 4)", () => {
+		const html = dash.heroCard({ id: "y", sport: "golf", title: "The Open", time: new Date().toISOString(), importance: 5 });
+		expect(html).toContain("hero-card must");
 	});
 
 	it("adds an AI badge for ai-research events", () => {
-		const html = dash.eventCard({
+		const html = dash.timelineRow({
 			id: "z", sport: "biathlon", title: "Sprint",
 			time: new Date().toISOString(),
 			source: "ai-research", confidence: "high", evidence: ["https://a.no", "https://b.no"],
@@ -43,8 +43,22 @@ describe("dashboard event cards", () => {
 	});
 
 	it("escapes HTML in event fields", () => {
-		const html = dash.eventCard({ id: "q", sport: "golf", title: "<script>alert(1)</script>", time: new Date().toISOString() });
+		const html = dash.timelineRow({ id: "q", sport: "golf", title: "<script>alert(1)</script>", time: new Date().toISOString() });
 		expect(html).not.toContain("<script>alert");
+	});
+
+	it("channel chips answer 'hvor kan jeg se det' — link when url, honest when unknown", () => {
+		const withUrl = dash.channelChips({ streaming: [{ platform: "NRK 1", url: "https://tv.nrk.no" }] });
+		expect(withUrl).toContain("NRK 1");
+		expect(withUrl).toContain("tv.nrk.no");
+		const none = dash.channelChips({ streaming: [] });
+		expect(none).toContain("Kanal ukjent");
+	});
+
+	it("timeline row carries a channel chip for every event", () => {
+		const html = dash.timelineRow({ id: "t", sport: "golf", title: "Round 1", time: new Date().toISOString(), streaming: [{ platform: "Viaplay" }] });
+		expect(html).toContain("chip");
+		expect(html).toContain("Viaplay");
 	});
 });
 


### PR DESCRIPTION
Rebuilds the dashboard around the actual goal — know what's on, when (Oslo time), and where to watch — replacing the flat sport-grouped layout where everything looked equally important and streaming was buried.

## What changed
- **Hierarchy**: live now → **Dagens viktigste** (1-3 must-see hero cards: favorite / importance≥4 / Norwegian) → **Program** (chronological today+tomorrow agenda, not sport-grouped) → **Senere denne uka** → brief + tracked demoted to collapsible disclosures.
- **Channel info is first-class**: a chip on every event (hero, timeline, later), honest "Kanal ukjent" when unknown.
- **Identity via typography**: Schibsted Grotesk (Norway's largest media house's house type) + JetBrains Mono departure-board time column. Warm-newsprint light theme, OLED-near-black dark theme, one accent. Off generic Inter.
- **Desktop**: two-column (program + sticky right rail). Mobile-first.
- Tests updated for new render methods (heroCard/timelineRow/channelChips); 150 pass.

Verified with mobile + desktop screenshots in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)