### PR TITLE
Wire tvkampen.com real TV listings into build

### DIFF
--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -2,7 +2,7 @@
 import fs from "fs";
 import path from "path";
 import { readJsonIfExists, rootDataPath, MS_PER_DAY } from "./lib/helpers.js";
-import { normalizeStreaming } from "./lib/norwegian-rights.js";
+import { resolveStreaming } from "./lib/norwegian-rights.js";
 
 const dataDir = rootDataPath();
 
@@ -138,9 +138,20 @@ if (Array.isArray(previousEvents)) {
 	}
 }
 
-// Always normalize streaming to Norwegian channels (never show FOX/ESPN/etc.)
+// Resolve streaming to Norwegian channels — prefer REAL tvkampen.com listings
+// for football, fall back to the deterministic rights map (never FOX/ESPN).
+const tvListings = readJsonIfExists(path.join(dataDir, "tv-listings.json"))?.listings || [];
+let fromTv = 0;
 for (const e of all) {
-	e.streaming = normalizeStreaming(e);
+	const before = e.streaming;
+	e.streaming = resolveStreaming(e, tvListings);
+	if (e.sport === "football" && e.streaming !== before && e.streaming.length && tvListings.length) {
+		// count football events whose channel came from a real listing match
+		fromTv++;
+	}
+}
+if (tvListings.length) {
+	console.log(`Streaming: ${tvListings.length} tvkampen listing(s) available for football matching.`);
 }
 
 // Relevance filter — keep only what the user actually follows, so the agenda

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -72,3 +72,69 @@ export function normalizeStreaming(ev) {
 	if (mapped.length) return mapped;
 	return (ev.streaming || []).filter((s) => NORWEGIAN_RE.test(s.platform || s));
 }
+
+// ── Real Norwegian TV listings (tvkampen.com) — actual data over the static map ──
+
+const CHANNEL_URLS = [
+	["tv 2 play", "https://play.tv2.no"], ["tv2 play", "https://play.tv2.no"],
+	["tv 2 sport", "https://play.tv2.no"], ["tv 2", "https://play.tv2.no"],
+	["viaplay", "https://viaplay.no"], ["v sport", "https://viaplay.no"],
+	["nrk", "https://tv.nrk.no"],
+	["discovery", "https://www.discoveryplus.no"], ["eurosport", "https://www.eurosport.no"],
+	["max", "https://www.max.com"], ["vg", "https://www.vg.no/sport"],
+];
+function urlForChannel(name) {
+	const k = name.trim().toLowerCase();
+	for (const [needle, url] of CHANNEL_URLS) if (k.includes(needle)) return url;
+	return "";
+}
+
+function normTeam(s) {
+	return (s || "").toLowerCase()
+		.replace(/\b(fc|fk|cf|afc|sk|if|il|bk|ff)\b/g, "")
+		.replace(/[^a-z0-9æøå ]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+function teamsMatch(a, b) {
+	const na = normTeam(a), nb = normTeam(b);
+	return !!(na && nb && (na === nb || na.includes(nb) || nb.includes(na)));
+}
+
+/** Find the tvkampen listing for a football event by team names. */
+export function matchTvListing(ev, listings) {
+	if (!ev.homeTeam || !ev.awayTeam || !Array.isArray(listings)) return null;
+	return listings.find((l) => teamsMatch(l.homeTeam, ev.homeTeam) && teamsMatch(l.awayTeam, ev.awayTeam)) || null;
+}
+
+/** Convert a tvkampen listing's broadcasters to Norwegian streaming objects (drops foreign/betting). */
+function listingStreaming(listing) {
+	const seen = new Set();
+	const out = [];
+	for (const b of listing.broadcasters || []) {
+		const name = String(b).trim();
+		if (!NORWEGIAN_RE.test(name)) continue; // drop betting/foreign leftovers
+		const key = name.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push({ platform: name, url: urlForChannel(name) });
+	}
+	return out;
+}
+
+/**
+ * Resolve an event's streaming, preferring REAL scraped Norwegian TV listings
+ * (tvkampen) for football, falling back to the deterministic rights map.
+ * @param {object} ev
+ * @param {Array} tvListings - tv-listings.json `listings` array
+ */
+export function resolveStreaming(ev, tvListings) {
+	if ((ev.sport || "").toLowerCase() === "football") {
+		const listing = matchTvListing(ev, tvListings);
+		if (listing) {
+			const s = listingStreaming(listing);
+			if (s.length) return s;
+		}
+	}
+	return normalizeStreaming(ev);
+}

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -33,3 +33,29 @@ describe("normalizeStreaming", () => {
 		expect(s[0].platform).toBe("Twitch");
 	});
 });
+
+import { resolveStreaming, matchTvListing } from "../scripts/lib/norwegian-rights.js";
+
+describe("tvkampen real-listing integration", () => {
+	const listings = [
+		{ homeTeam: "Liverpool", awayTeam: "Arsenal", time: "18:30", broadcasters: ["TV 2 Play", "TV 2 Sport 1", "Coolbet"] },
+		{ homeTeam: "Ranheim", awayTeam: "Stabæk", time: "19:00", broadcasters: ["TV 2 Play", "Viaplay"] },
+	];
+	it("matches a football event to its listing by team names (ignoring FC suffixes)", () => {
+		const l = matchTvListing({ homeTeam: "Liverpool FC", awayTeam: "Arsenal FC" }, listings);
+		expect(l?.homeTeam).toBe("Liverpool");
+	});
+	it("uses the real listing's Norwegian broadcasters, dropping betting sites", () => {
+		const s = resolveStreaming({ sport: "football", homeTeam: "Liverpool FC", awayTeam: "Arsenal FC", tournament: "Premier League" }, listings);
+		expect(s.map((c) => c.platform)).toEqual(["TV 2 Play", "TV 2 Sport 1"]); // Coolbet dropped
+		expect(s[0].url).toContain("tv2.no");
+	});
+	it("falls back to the rights map when no listing matches", () => {
+		const s = resolveStreaming({ sport: "football", homeTeam: "Bodø/Glimt", awayTeam: "Molde", tournament: "Eliteserien" }, listings);
+		expect(s[0].platform).toBe("TV 2 Play"); // from map, not a listing
+	});
+	it("non-football ignores listings and uses the map", () => {
+		const s = resolveStreaming({ sport: "f1", tournament: "Belgian Grand Prix" }, listings);
+		expect(s[0].platform).toBe("Viaplay");
+	});
+});


### PR DESCRIPTION
Football streaming now prefers real scraped Norwegian TV listings (tvkampen.com), matched by team name, with the rights map as fallback. Betting/foreign entries dropped. Club matches get exact broadcasters; national teams fall back to NRK/TV 2. 157 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)