### PR TITLE
Add round/stage context (World Cup rounds etc.)

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -98,13 +98,20 @@
 	color: var(--fg-2);
 	white-space: nowrap;
 }
+.ev-main { min-width: 0; }
 .ev-title {
-	min-width: 0;
+	display: block;
 	font-size: 15.5px;
 	color: var(--fg);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+.ev-round {
+	display: block;
+	font-size: 12px;
+	color: var(--fg-3);
+	margin-top: 1px;
 }
 .ev-logo {
 	width: 18px; height: 18px;

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -186,10 +186,11 @@ class Dashboard {
 		const attrs = expandable
 			? ` role="button" tabindex="0" aria-expanded="false" data-event-id="${escapeHtml(e.id)}"`
 			: '';
+		const round = e.round ? `<span class="ev-round">${escapeHtml(e.round)}</span>` : '';
 		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${expandable ? ' expandable' : ''}"${attrs}>
 			${this.sportBadge(e)}
 			<span class="ev-time">${escapeHtml(this.osloTime(date))}</span>
-			<span class="ev-title">${this.eventTitle(e)}</span>
+			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${round}</span>
 			${where}
 			${caret}
 		</div><div class="ev-detail" hidden></div></div>`;

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -39,6 +39,7 @@ function pushEvent(ev, sport, tournament) {
 		homeTeam: ev.homeTeam || null,
 		awayTeam: ev.awayTeam || null,
 		isFavorite: ev.isFavorite || false,
+		round: ev.round || null,
 	};
 	if (ev.format) event.format = ev.format;
 	if (ev.stage) event.stage = ev.stage;

--- a/scripts/config/sports-config.js
+++ b/scripts/config/sports-config.js
@@ -16,7 +16,7 @@ export const sportsConfig = {
 					{ code: "nor.1", name: "Eliteserien" },
 					{ code: "nor.2", name: "OBOS-ligaen" },
 					{ code: "nor.cup", name: "Norwegian Cup" },
-					{ code: "fifa.world", name: "International" }
+					{ code: "fifa.world", name: "FIFA World Cup" }
 				]
 			},
 			{

--- a/scripts/lib/adapters/espn-adapter.js
+++ b/scripts/lib/adapters/espn-adapter.js
@@ -173,6 +173,10 @@ export class ESPNAdapter extends BaseFetcher {
 			streaming: this.extractStreaming(espnEvent, competition),
 			status: espnEvent.status?.type?.name
 		};
+
+		// Round / stage — e.g. World Cup season.slug "round-of-16" → "Åttedelsfinale".
+		const round = this.extractRound(espnEvent, competition);
+		if (round) event.round = round;
 		
 		if (competition.competitors && competition.competitors.length >= 2) {
 			const home = competition.competitors.find(c => c.homeAway === "home");
@@ -217,6 +221,37 @@ export class ESPNAdapter extends BaseFetcher {
 		}
 		
 		return "Unknown Event";
+	}
+
+	/**
+	 * Extract a human, Norwegian round label from ESPN data.
+	 * Cup rounds come via `season.slug` (round-of-16, quarterfinals, …); some
+	 * competitions put a headline (e.g. "Matchday 5", "Group A") in competition.notes.
+	 */
+	extractRound(espnEvent, competition) {
+		const slug = (espnEvent.season?.slug || "").toLowerCase();
+		const SLUG_NB = {
+			"final": "Finale",
+			"3rd-place": "Bronsefinale",
+			"third-place": "Bronsefinale",
+			"semifinals": "Semifinale",
+			"semi-finals": "Semifinale",
+			"quarterfinals": "Kvartfinale",
+			"quarter-finals": "Kvartfinale",
+			"round-of-16": "Åttedelsfinale",
+			"round-of-32": "16-delsfinale",
+			"group-stage": "Gruppespill",
+			"group-phase": "Gruppespill",
+			"playoff": "Playoff",
+			"knockout-round-playoffs": "Playoff",
+		};
+		if (SLUG_NB[slug]) return SLUG_NB[slug];
+		if (slug.includes("group")) return "Gruppespill";
+		if (slug.includes("final")) return "Finale";
+		// Fallback: a notes headline like "Group A" / "Matchday 5"
+		const headline = competition?.notes?.[0]?.headline;
+		if (headline && !/regular season/i.test(headline)) return headline;
+		return null;
 	}
 
 	extractMeta(espnEvent, competition) {

--- a/scripts/lib/event-normalizer.js
+++ b/scripts/lib/event-normalizer.js
@@ -28,6 +28,7 @@ export class EventNormalizer {
 				norwegianPlayers: event.norwegianPlayers || null,
 				totalPlayers: event.totalPlayers || null,
 				isFavorite: Boolean(event.isFavorite),
+				round: event.round ? this.sanitizeString(event.round) : undefined,
 				additional: this.extractAdditional(event)
 			};
 		} catch (error) {

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -58,6 +58,12 @@ describe("agenda event row", () => {
 		expect(html).toContain("🇧🇷");
 	});
 
+	it("shows round context when present (e.g. WC knockout round)", () => {
+		const html = dash.eventRow({ id: "w", sport: "football", homeTeam: "Brazil", awayTeam: "Norway", time: soon(), round: "Åttedelsfinale", tournament: "FIFA World Cup" });
+		expect(html).toContain("ev-round");
+		expect(html).toContain("Åttedelsfinale");
+	});
+
 	it("escapes HTML in event fields", () => {
 		const html = dash.eventRow({ id: "q", sport: "golf", title: "<script>alert(1)</script>", time: soon() });
 		expect(html).not.toContain("<script>alert");


### PR DESCRIPTION
Events now carry a round label from ESPN season.slug (Åttedelsfinale, Kvartfinale, …), shown as a quiet line under the match. fifa.world renamed FIFA World Cup. 158 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)