### PR TITLE
"Hva vi følger": two-layer view (your interests + AI-discovered)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ npm-debug.log*
 !/docs/data/verify-log.json
 !/docs/data/meta.json
 !/docs/data/tracked.json
+!/docs/data/interests.json
 !/docs/data/tv-listings.json
 !/docs/data/coverage-gaps.json
 !/docs/data/calibration.json

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -170,10 +170,17 @@
 .followed summary::-webkit-details-marker { display: none; }
 .followed summary::before { content: "› "; color: var(--fg-3); }
 .followed[open] summary::before { content: "⌄ "; }
-.followed-body { margin-top: 12px; }
-.followed-group { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-3); margin: 14px 0 6px; }
+.followed-body { margin-top: 14px; }
+.followed-layer { margin-bottom: 22px; }
+.followed-head { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); margin-bottom: 10px; }
+.chips-row { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.chip-follow { font-size: 13px; padding: 3px 10px; border-radius: 999px; background: var(--surface); border: 1px solid var(--line); color: var(--fg); }
+.followed-note { font-size: 12.5px; color: var(--fg-3); line-height: 1.5; margin-top: 4px; }
+.followed-hint { font-size: 12.5px; color: var(--fg-3); font-style: italic; margin-top: 10px; }
+.followed-group { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-3); margin: 12px 0 5px; }
 .followed-item { font-size: 14px; padding: 4px 0; color: var(--fg); }
 .followed-item .why { color: var(--fg-3); font-size: 12.5px; }
+.followed-item .until { color: var(--fg-3); font-size: 11.5px; }
 
 /* AI provenance modal (kept, but invisible until asked for) */
 .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.55); backdrop-filter: blur(3px); z-index: 50; display: grid; place-items: center; padding: 24px; }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -30,8 +30,8 @@ class Dashboard {
 
 	async loadData() {
 		const load = (f) => fetch(`data/${f}?t=${Date.now()}`).then((r) => (r.ok ? r.json() : null)).catch(() => null);
-		const [events, featured, standings, results, tracked, meta] = await Promise.all([
-			load('events.json'), load('featured.json'), load('standings.json'), load('recent-results.json'), load('tracked.json'), load('meta.json'),
+		const [events, featured, standings, results, tracked, interests, meta] = await Promise.all([
+			load('events.json'), load('featured.json'), load('standings.json'), load('recent-results.json'), load('tracked.json'), load('interests.json'), load('meta.json'),
 		]);
 		this.allEvents = Array.isArray(events) ? events : [];
 		this.allEvents.forEach((e, i) => { e.id = `${e.sport}|${e.title}|${e.time}|${i}`; });
@@ -39,6 +39,7 @@ class Dashboard {
 		this.standings = standings;
 		this.recentResults = results;
 		this.tracked = tracked;
+		this.interests = interests;
 		this.meta = meta;
 	}
 
@@ -306,14 +307,42 @@ class Dashboard {
 		const body = document.getElementById('followed-body');
 		if (!wrap || !body) return;
 		const t = this.tracked;
-		if (!t || (!t.tournaments?.length && !t.leagues?.length && !t.athletes?.length)) { wrap.hidden = true; return; }
+		const i = this.interests;
+		const hasTracked = t && (t.tournaments?.length || t.leagues?.length || t.athletes?.length);
+		const hasInterests = i && (i.alwaysTrack || i.interests);
+		if (!hasTracked && !hasInterests) { wrap.hidden = true; return; }
+
+		// Layer 1 — DU FØLGER: what you asked for (interests.json, user-owned)
+		const chips = (items) => (items || []).length
+			? `<div class="chips-row">${items.map((x) => `<span class="chip-follow">${escapeHtml(x)}</span>`).join('')}</div>` : '';
+		let du = '';
+		if (hasInterests) {
+			const at = i.alwaysTrack || {};
+			du += `<div class="followed-layer"><div class="followed-head">Du følger</div>`;
+			du += chips(at.athletes);
+			du += chips(at.teams);
+			du += chips(at.tournaments);
+			if (Array.isArray(i.interests) && i.interests.length) {
+				du += `<div class="followed-note">${i.interests.map((s) => escapeHtml(s)).join(' · ')}</div>`;
+			}
+			du += `<div class="followed-hint">Vil du følge noe mer? Si det til Claude, så oppdateres denne lista.</div></div>`;
+		}
+
+		// Layer 2 — AI HAR FUNNET: what the research agent discovered (tracked.json)
 		const group = (label, items) => {
 			if (!items?.length) return '';
-			return `<div class="followed-group">${label}</div>` + items.map((i) =>
-				`<div class="followed-item">${escapeHtml(i.name)}${i.reason ? ` <span class="why">— ${escapeHtml(i.reason)}</span>` : ''}</div>`
+			return `<div class="followed-group">${label}</div>` + items.map((x) =>
+				`<div class="followed-item">${escapeHtml(x.name)}${x.reason ? ` <span class="why">— ${escapeHtml(x.reason)}</span>` : ''}${x.expires ? ` <span class="until">· ut ${escapeHtml(x.expires.slice(0, 10))}</span>` : ''}</div>`
 			).join('');
 		};
-		body.innerHTML = group('Turneringer', t.tournaments) + group('Ligaer', t.leagues) + group('Utøvere', t.athletes);
+		let ai = '';
+		if (hasTracked) {
+			ai = `<div class="followed-layer"><div class="followed-head">AI har funnet</div>`
+				+ group('Turneringer', t.tournaments) + group('Ligaer', t.leagues) + group('Utøvere', t.athletes)
+				+ `</div>`;
+		}
+
+		body.innerHTML = du + ai;
 		wrap.hidden = false;
 	}
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // SportSync v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-1';
+const CACHE_NAME = 'sportsync-v2-2';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -193,9 +193,12 @@ console.log(
 	`Aggregated ${kept.length} events (filtered ${all.length - kept.length} past/irrelevant, of which ${droppedIrrelevant} off-interest) into events.json`
 );
 
-// Publish tracked.json so the dashboard's "Hva vi følger" surface can read it
-const trackedSrc = path.join(configDir, "tracked.json");
-if (fs.existsSync(trackedSrc)) {
-	fs.copyFileSync(trackedSrc, path.join(dataDir, "tracked.json"));
-	console.log("Published tracked.json to docs/data/");
+// Publish tracked.json + interests.json so the dashboard's "Hva vi følger"
+// surface can show both what you asked for and what the AI discovered.
+for (const name of ["tracked.json", "interests.json"]) {
+	const src = path.join(configDir, name);
+	if (fs.existsSync(src)) {
+		fs.copyFileSync(src, path.join(dataDir, name));
+		console.log(`Published ${name} to docs/data/`);
+	}
 }


### PR DESCRIPTION
The 'Hva vi følger' disclosure now shows both layers: **Du følger** (interests.json as chips, with a hint that edits go through Claude) and **AI har funnet** (tracked.json with reasons + expiry). interests.json is now published to docs/data. Read-only surface per the agreed plan (write path later). 158 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)