### PR TITLE
Fix: World Cup matches all showed both NRK + TV 2

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -140,7 +140,9 @@
 .ev-where a { border-bottom: 1px solid transparent; }
 .ev-where a:hover { border-bottom-color: var(--fg-3); color: var(--accent); }
 .ev-where.unknown { color: var(--fg-3); }
+.ev-where.tentative { color: var(--fg-3); font-style: italic; }
 .ev-where-more { color: var(--fg-3); font-size: 11px; margin-left: 4px; }
+.d-v .tbd { color: var(--fg-3); font-style: italic; }
 
 .ev-live {
 	color: var(--live);

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -114,8 +114,11 @@ class Dashboard {
 		const s = streams[0];
 		const p = escapeHtml(String(s.platform || s));
 		const extra = streams.length > 1 ? `<span class="ev-where-more">+${streams.length - 1}</span>` : '';
-		const inner = s.url ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
-		return `<span class="ev-where">${inner}${extra}</span>`;
+		// Tentative (shared rights, exact channel not yet confirmed) → plain text,
+		// no link — linking to one broadcaster when it may be the other misleads.
+		const inner = (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
+		const cls = s.tentative ? 'ev-where tentative' : 'ev-where';
+		return `<span class="${cls}">${inner}${extra}</span>`;
 	}
 
 	// ── Live now (quiet line at the top) ─────────────────────────────────────
@@ -229,7 +232,8 @@ class Dashboard {
 		if (streams.length) {
 			const chans = streams.map((s) => {
 				const p = escapeHtml(String(s.platform || s));
-				return s.url ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
+				const label = s.tentative ? `${p} <span class="tbd">(bekreftes)</span>` : p;
+				return (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
 			}).join(' · ');
 			add('Se på', chans);
 		}

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -25,11 +25,45 @@ const NATIONS = new Set([
 	"egypt", "cameroon", "poland", "austria", "serbia", "ecuador", "iran", "saudi arabia",
 	"qatar", "tunisia", "ivory coast", "algeria", "england", "scotland", "wales",
 ]);
+
+// Norwegian → English canonical nation names. ESPN emits English ("Morocco"),
+// tvkampen emits Norwegian ("Marokko"); without this map the two never match
+// and every national-team fixture falls back to the shared-rights guess.
+// Keys are pre-normalized the same way normTeam() normalizes (lowercase, no
+// punctuation — so "Sør-Korea" → "sørkorea").
+const NATION_CANON = {
+	marokko: "morocco", frankrike: "france", brasil: "brazil", norge: "norway",
+	spania: "spain", tyskland: "germany", sveits: "switzerland", danmark: "denmark",
+	østerrike: "austria", island: "iceland", belgia: "belgium", nederland: "netherlands",
+	sverige: "sweden", kroatia: "croatia", sørkorea: "south korea", "korea republic": "south korea",
+	japan: "japan", mexico: "mexico", portugal: "portugal", england: "england",
+	skottland: "scotland", wales: "wales", usa: "usa", "united states": "usa",
+	"forente stater": "usa", argentina: "argentina", egypt: "egypt", colombia: "colombia",
+	canada: "canada", paraguay: "paraguay", uruguay: "uruguay", ecuador: "ecuador",
+	australia: "australia", senegal: "senegal", nigeria: "nigeria", ghana: "ghana",
+	kamerun: "cameroon", algerie: "algeria", tunisia: "tunisia", elfenbenskysten: "ivory coast",
+	kappverde: "cape verde", "kapp verde": "cape verde", saudiarabia: "saudi arabia",
+	"saudi arabia": "saudi arabia", qatar: "qatar", iran: "iran", polen: "poland",
+	serbia: "serbia", italia: "italy", sørafrika: "south africa",
+};
+
 function isNationVsNation(ev) {
-	const h = (ev.homeTeam || "").trim().toLowerCase();
-	const a = (ev.awayTeam || "").trim().toLowerCase();
+	const h = normTeam(ev.homeTeam || "");
+	const a = normTeam(ev.awayTeam || "");
 	return NATIONS.has(h) && NATIONS.has(a);
 }
+
+// A World Cup fixture — ESPN sometimes labels these only "International", so we
+// also treat any nation-vs-nation match as WC-adjacent for channel resolution.
+function isWorldCup(ev) {
+	const hay = `${ev.tournament || ""} ${ev.context || ""} ${ev.meta || ""} ${ev.title || ""}`.toLowerCase();
+	return /world cup|fifa|\bvm\b/.test(hay) || isNationVsNation(ev);
+}
+
+// Norwegian WC 2026 rights are shared by NRK + TV 2 ONLY. When we can't confirm
+// which of the two carries a specific match, this single tentative label is more
+// honest (and calmer) than two chips that read as "airs on both".
+const WC_SHARED = { platform: "NRK / TV 2", url: "https://tv.nrk.no", tentative: true };
 
 /** The confident Norwegian rights for an event, or [] when we shouldn't guess. */
 export function norwegianRights(ev) {
@@ -39,12 +73,12 @@ export function norwegianRights(ev) {
 	const hay = `${comp} ${title}`;
 
 	if (sport === "football") {
-		if (/world cup|fifa|\bvm\b/.test(hay)) return [CH.nrk, CH.tv2]; // shared per-match
+		if (/world cup|fifa|\bvm\b/.test(hay)) return [WC_SHARED]; // NRK/TV 2 shared — exact channel TBD
 		if (/premier league/.test(hay)) return [CH.tv2];
 		if (/la\s?liga/.test(hay)) return [CH.tv2];
 		if (/champions|europa|conference/.test(hay)) return [CH.tv2];
 		if (/obos|eliteserie|norwegian|cup|nm\b/.test(hay)) return [CH.tv2];
-		if (isNationVsNation(ev)) return [CH.nrk, CH.tv2]; // landskamp / WC labelled only "International"
+		if (isNationVsNation(ev)) return [WC_SHARED]; // landskamp / WC labelled only "International"
 		return [];
 	}
 	if (sport === "golf") return /masters/.test(hay) ? [CH.discovery] : [CH.viaplay];
@@ -90,11 +124,12 @@ function urlForChannel(name) {
 }
 
 function normTeam(s) {
-	return (s || "").toLowerCase()
+	const n = (s || "").toLowerCase()
 		.replace(/\b(fc|fk|cf|afc|sk|if|il|bk|ff)\b/g, "")
 		.replace(/[^a-z0-9æøå ]/g, "")
 		.replace(/\s+/g, " ")
 		.trim();
+	return NATION_CANON[n] || n; // map Norwegian nation names to English canonical
 }
 function teamsMatch(a, b) {
 	const na = normTeam(a), nb = normTeam(b);
@@ -123,6 +158,29 @@ function listingStreaming(listing) {
 }
 
 /**
+ * For a World Cup fixture, keep only the actual Norwegian rights holders
+ * (NRK / TV 2) and collapse channel variants (NRK1, NRK TV → NRK; TV 2 Sport 1
+ * → TV 2 Play). tvkampen pads WC listings with aggregators (Viaplay/Eurosport/
+ * MAX) and foreign nets (SVT) that don't hold WC rights in Norway — drop them so
+ * a match resolves to its single true broadcaster instead of a noisy list.
+ */
+function worldCupChannels(channels) {
+	const out = [];
+	const seen = new Set();
+	for (const c of channels) {
+		const p = String(c.platform || c).toLowerCase();
+		let entry = null;
+		if (/nrk/.test(p)) entry = CH.nrk;
+		else if (/tv\s?2/.test(p)) entry = CH.tv2;
+		else continue; // not a WC rights holder → drop
+		if (seen.has(entry.platform)) continue;
+		seen.add(entry.platform);
+		out.push(entry);
+	}
+	return out;
+}
+
+/**
  * Resolve an event's streaming, preferring REAL scraped Norwegian TV listings
  * (tvkampen) for football, falling back to the deterministic rights map.
  * @param {object} ev
@@ -132,7 +190,9 @@ export function resolveStreaming(ev, tvListings) {
 	if ((ev.sport || "").toLowerCase() === "football") {
 		const listing = matchTvListing(ev, tvListings);
 		if (listing) {
-			const s = listingStreaming(listing);
+			let s = listingStreaming(listing);
+			// WC: trust the real listing to say WHICH of NRK/TV 2, drop aggregator noise.
+			if (isWorldCup(ev)) s = worldCupChannels(s);
 			if (s.length) return s;
 		}
 	}

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -3,9 +3,11 @@ import { describe, it, expect } from "vitest";
 import { norwegianRights, normalizeStreaming } from "../scripts/lib/norwegian-rights.js";
 
 describe("norwegianRights", () => {
-	it("World Cup football → NRK + TV 2, never a foreign net", () => {
+	it("World Cup football (no per-match data) → one tentative NRK / TV 2 label, never a foreign net", () => {
 		const r = norwegianRights({ sport: "football", tournament: "FIFA World Cup 2026", title: "Norway vs Brazil" });
-		expect(r.map((c) => c.platform)).toEqual(["NRK", "TV 2 Play"]);
+		expect(r.map((c) => c.platform)).toEqual(["NRK / TV 2"]); // shared rights, exact channel TBD
+		expect(r[0].tentative).toBe(true);
+		expect(JSON.stringify(r)).not.toMatch(/fox|espn/i);
 	});
 	it("F1 → Viaplay", () => {
 		expect(norwegianRights({ sport: "f1", tournament: "Belgian Grand Prix" })[0].platform).toBe("Viaplay");
@@ -21,7 +23,7 @@ describe("norwegianRights", () => {
 describe("normalizeStreaming", () => {
 	it("overrides a foreign broadcaster (FOX) with Norwegian rights", () => {
 		const s = normalizeStreaming({ sport: "football", tournament: "FIFA World Cup 2026", streaming: [{ platform: "FOX" }] });
-		expect(s.map((c) => c.platform)).toEqual(["NRK", "TV 2 Play"]);
+		expect(s.map((c) => c.platform)).toEqual(["NRK / TV 2"]);
 		expect(JSON.stringify(s)).not.toContain("FOX");
 	});
 	it("drops foreign nets when no rights mapping and keeps Norwegian ones", () => {
@@ -57,5 +59,48 @@ describe("tvkampen real-listing integration", () => {
 	it("non-football ignores listings and uses the map", () => {
 		const s = resolveStreaming({ sport: "f1", tournament: "Belgian Grand Prix" }, listings);
 		expect(s[0].platform).toBe("Viaplay");
+	});
+});
+
+describe("World Cup per-match channel resolution (English↔Norwegian nations)", () => {
+	// tvkampen lists nations in Norwegian and pads with aggregators; ESPN emits
+	// English nation names. Both bugs together made every WC match show NRK + TV 2.
+	const wcListings = [
+		{ homeTeam: "Canada", awayTeam: "Marokko", broadcasters: ["NRK1", "NRK TV", "Viaplay", "Eurosport Norge", "MAX"] },
+		{ homeTeam: "England", awayTeam: "Mexico", broadcasters: ["TV 2 Play", "TV 2 Sport 1", "Viaplay", "MAX"] },
+		{ homeTeam: "Paraguay", awayTeam: "Frankrike", broadcasters: ["Svt"] },
+	];
+
+	it("matches an English-named event to a Norwegian-named listing (Morocco↔Marokko)", () => {
+		const s = resolveStreaming(
+			{ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Canada", awayTeam: "Morocco" },
+			wcListings
+		);
+		expect(s.map((c) => c.platform)).toEqual(["NRK"]); // one true broadcaster, aggregators dropped
+	});
+
+	it("resolves a TV 2 WC match to a single TV 2 Play (drops NRK/aggregators absent)", () => {
+		const s = resolveStreaming(
+			{ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "England", awayTeam: "Mexico" },
+			wcListings
+		);
+		expect(s.map((c) => c.platform)).toEqual(["TV 2 Play"]);
+	});
+
+	it("falls back to tentative NRK / TV 2 when the listing has no Norwegian rights holder", () => {
+		const s = resolveStreaming(
+			{ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Paraguay", awayTeam: "France" },
+			wcListings
+		);
+		expect(s.map((c) => c.platform)).toEqual(["NRK / TV 2"]);
+		expect(s[0].tentative).toBe(true);
+	});
+
+	it("nation-vs-nation with no tournament label still resolves (never a foreign net)", () => {
+		const s = resolveStreaming(
+			{ sport: "football", tournament: "International", homeTeam: "Norway", awayTeam: "Brazil" },
+			[]
+		);
+		expect(s.map((c) => c.platform)).toEqual(["NRK / TV 2"]);
 	});
 });


### PR DESCRIPTION
## Problem
Every World Cup match on the agenda showed the same **NRK + TV 2** pair (as "NRK +1"), so the where-to-watch was identical for every fixture and read as "airs on both" — violating the core promise that *where to watch is correct*.

## Root cause — two compounding bugs
1. **Blanket rights guess.** `norwegianRights()` returned `[NRK, TV 2]` for every match matching `world cup|fifa|vm`, never saying which one.
2. **Real data couldn't match.** tvkampen has the actual per-match channel (e.g. `Canada v Marokko → NRK1/NRK TV`), but ESPN emits English nation names (`Morocco`) and tvkampen emits Norwegian (`Marokko`), so `teamsMatch` always failed → we fell back to the blanket.

## Fix
- **`normTeam()`** canonicalizes Norwegian nation names → English (`Marokko→Morocco`, `Frankrike→France`, …) so national-team fixtures match their real listing.
- **`worldCupChannels()`** keeps only the true Norwegian WC rights holders (NRK / TV 2), drops aggregator padding (Viaplay/Eurosport/MAX) and foreign nets (SVT), and collapses `NRK1`/`NRK TV` → a single `NRK`.
- When there's genuinely no per-match data yet (matches days out), show **one honest tentative `NRK / TV 2`** label instead of two chips. The dashboard renders tentative labels as plain italic text with no link (linking to one broadcaster when it may be the other misleads).

## Result (live data)
| Match | Before | After |
|---|---|---|
| Canada v Morocco | NRK + TV 2 | **NRK** (from real listing) |
| Brazil v Norway (days out) | NRK + TV 2 | **NRK / TV 2** *(tentative)* |

## Closing the loop
Added tests for English↔Norwegian matching, WC channel cleanup, and the tentative fallback, so this class of bug is caught automatically. Full suite: 162 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)