### PR TITLE
Make static pipeline auto-publish hourly data

### DIFF
--- a/.github/workflows/static-pipeline.yml
+++ b/.github/workflows/static-pipeline.yml
@@ -25,6 +25,16 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out with a PAT so the docs/data commit this job pushes TRIGGERS
+          # preview-deploy. Pushes made with the default GITHUB_TOKEN deliberately
+          # do NOT trigger workflows (anti-recursion), which meant hourly data
+          # landed on main but never auto-published. See pages-deploy-gotchas.
+          # Falls back to github.token when DEPLOY_PAT is unset — the workflow
+          # keeps working (just without auto-deploy) until the secret is added.
+          # No loop risk: this pipeline's own push trigger watches scripts/** only,
+          # not docs/**, so a data push won't re-run the pipeline.
+          token: ${{ secrets.DEPLOY_PAT || github.token }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
## Problem
The static pipeline commits `docs/data/**` every hour, but it pushed with the default `GITHUB_TOKEN`. GitHub deliberately does **not** trigger workflows from `GITHUB_TOKEN` pushes (anti-recursion), so `preview-deploy` never fired — fresh data landed on `main` but stayed unpublished until some unrelated deploy (a PR merge or manual dispatch) happened to pick it up. That's why the live site could lag behind correct data on `main`.

## Fix
Check out with a PAT so the pipeline's push is authenticated as a real user and triggers `preview-deploy`'s `push` trigger (`paths: docs/**`):

```yaml
- uses: actions/checkout@v4
  with:
    token: ${{ secrets.DEPLOY_PAT || github.token }}
```

- **Graceful:** falls back to `github.token` when the secret is absent, so the workflow keeps working (just without auto-deploy) until you add `DEPLOY_PAT`.
- **No loop risk:** this pipeline's own `push` trigger watches `scripts/**` only, not `docs/**`, so a data push won't re-run the pipeline. `preview-deploy` only deploys Pages (no commit), so it can't feed back either.

## Required secret
`DEPLOY_PAT` — a fine-grained PAT with **Contents: Read and write** on `CHaerem/SportSync`. Until it's added, behaviour is unchanged (fallback to `github.token`).

Once merged **and** the secret is set, every hourly run that changes data auto-publishes to the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)