### PR TITLE
Fit the agenda better on iPhone screens

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -184,6 +184,21 @@
 .followed-item .why { color: var(--fg-3); font-size: 12.5px; }
 .followed-item .until { color: var(--fg-3); font-size: 11.5px; }
 
+/* ── Phones: give match names room ────────────────────────────────────────
+   The desktop row reserves up to 116px for the channel, which starves the
+   title on a ~375px screen (e.g. "Brazil – Nor…" hid that Norway plays).
+   Tighten the grid, columns and gaps so the title (what's on) wins the space;
+   the channel stays readable at its real width ("NRK / TV 2", "TV 2 Play"). */
+@media (max-width: 460px) {
+	.ev {
+		grid-template-columns: 28px 42px 1fr auto 8px;
+		gap: 8px;
+	}
+	.ev-badge { width: 28px; height: 28px; font-size: 14px; }
+	.ev-where { max-width: 84px; font-size: 12.5px; }
+	.ev-detail { padding-left: 30px; }
+}
+
 /* AI provenance modal (kept, but invisible until asked for) */
 .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.55); backdrop-filter: blur(3px); z-index: 50; display: grid; place-items: center; padding: 24px; }
 .modal { background: var(--surface); border: 1px solid var(--line); border-radius: 14px; padding: 22px; max-width: 440px; width: 100%; max-height: 80vh; overflow-y: auto; }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -6,6 +6,10 @@
 	margin: 0 auto;
 	padding: 0 22px;
 }
+/* Phones: trim the side gutter so the agenda has more room for match names. */
+@media (max-width: 460px) {
+	.wrap { padding: 0 16px; }
+}
 
 .masthead {
 	padding-top: calc(env(safe-area-inset-top) + 26px);


### PR DESCRIPTION
## Problem
On phone widths (~375px) the event row reserved up to **116px for the channel**, which starved the match-name column to ~89px. The worst case: **"Brazil – Norway" rendered as "Brazil – Nor…"**, hiding that Norway — a must-see — was even playing.

## Fix — a phone breakpoint (`max-width: 460px`)
- Page gutter `22px → 16px`
- Row grid tightened: badge `30→28`, time `44→42`, caret `12→8`, gap `10→8`, channel column capped at `84px`

This roughly **doubles the title width** (~89px → ~150px at 375px). Team-vs-team names now fit; the channel stays readable (`NRK / TV 2`, `TV 2 Play`, `NRK`, `Viaplay`).

## Verified (Playwright, full-page)
| Width | Before | After |
|---|---|---|
| 375 (SE / 13 mini) | `Brazil – Nor…` | **`Brazil – 🇳🇴 Norway`** ✓ |
| 360 (12 mini) | cramped | fits, no overflow ✓ |
| 393 (15) | some clipping | clean ✓ |

Desktop/tablet layout unchanged. No horizontal scroll at any tested width; genuinely long names (tournaments, stage names) still ellipsize and expand on tap.

CSS-only — no JS or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)