### PR TITLE
Harden pipeline commit against concurrent-run push races

### DIFF
--- a/.github/workflows/static-pipeline.yml
+++ b/.github/workflows/static-pipeline.yml
@@ -63,7 +63,20 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "Update sports data $(date -u +%H:%MZ)"
-            git push || (git pull --rebase origin ${{ github.ref_name }} && git push)
+            # A scripts/** push can race the hourly cron: two runs regenerate the
+            # same data files and both try to commit. On rejection, rebase onto
+            # the latest remote and AUTO-RESOLVE the regenerated-data conflicts
+            # in our favour (both snapshots are equally fresh) instead of failing
+            # the way a plain `pull --rebase` did. Files only the other run
+            # changed (e.g. agent outputs like featured.json) don't conflict and
+            # are preserved. Retry a few times, then fail loudly if still stuck.
+            pushed=""
+            for attempt in 1 2 3 4 5; do
+              if git push; then pushed=1; break; fi
+              echo "push rejected — rebasing onto latest ${{ github.ref_name }} (attempt $attempt)"
+              git pull --rebase -X theirs origin ${{ github.ref_name }} || git rebase --abort || true
+            done
+            [ -n "$pushed" ] || { echo "::error::could not push data after 5 attempts"; exit 1; }
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Problem
When a `scripts/**` push (e.g. a PR merge) coincides with the hourly cron, two `static-pipeline` runs regenerate the same `docs/data` files and race to commit. The old fallback:

```sh
git push || (git pull --rebase origin main && git push)
```

failed because the rebase hit **content conflicts** in the regenerated JSON — so the losing run errored (spurious failure email; no deploy from it). Observed live: the PR #184 merge triggered a `[push]` pipeline at the same minute the `[schedule]` cron fired; `[push]` published fine, `[schedule]` failed on exactly this race.

## Fix
A retry loop that rebases onto the latest remote and **auto-resolves the regenerated-data conflicts** (`-X theirs`) instead of failing. Both runs' snapshots are equally fresh, so either wins cleanly. Files only the *other* run changed (e.g. agent outputs like `featured.json`) don't conflict and are preserved. Fails loudly only if it still can't push after 5 attempts.

```sh
git commit -m "Update sports data $(date -u +%H:%MZ)"
pushed=""
for attempt in 1 2 3 4 5; do
  if git push; then pushed=1; break; fi
  git pull --rebase -X theirs origin main || git rebase --abort || true
done
[ -n "$pushed" ] || { echo "::error::could not push data after 5 attempts"; exit 1; }
```

Validated: YAML parses, `bash -n` clean, workflow coherence tests pass. `.github/**`-only — the merge triggers neither a deploy nor the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)