### PR TITLE
Two new AI agents: coverage critic (recall) + visual QA (vision), verify → Opus 4.8

### DIFF
--- a/.github/workflows/coverage-critic-agent.yml
+++ b/.github/workflows/coverage-critic-agent.yml
@@ -1,0 +1,39 @@
+name: Coverage critic agent
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 06:00 Oslo, before the morning editorial/research window
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-coverage-critic
+  cancel-in-progress: false
+
+jobs:
+  coverage-critic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      actions: write # allows escalation via `gh workflow run research-agent.yml`
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 60
+            --allowedTools "Read,Write,Glob,Grep,WebFetch,WebSearch,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(date:*),Bash(jq:*)"
+          prompt: |
+            Read scripts/agents/coverage-critic.md and execute it — a recall audit
+            of what important events we are probably MISSING. When done, commit:
+              git add docs/data/coverage-audit.json
+              git commit -m "coverage-critic: recall audit"
+              git push || (git pull --rebase -X theirs origin main && git push)

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-sonnet-5
+            --model claude-opus-4-8
             --max-turns 80
             --allowedTools "Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,Bash(node:*),Bash(git:*),Bash(date:*),Bash(jq:*)"
           prompt: |

--- a/.github/workflows/visual-qa-agent.yml
+++ b/.github/workflows/visual-qa-agent.yml
@@ -1,0 +1,38 @@
+name: Visual QA agent
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 10:00 Oslo, after the morning data + editorial have landed
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-visual-qa
+  cancel-in-progress: false
+
+jobs:
+  visual-qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium # needed for screenshots
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 40
+            --allowedTools "Read,Write,Glob,Grep,Bash(node:*),Bash(git:*),Bash(date:*),Bash(ls:*)"
+          prompt: |
+            Read scripts/agents/visual-qa.md and execute it — screenshot the
+            dashboard, LOOK at the images, and report what you see. When done, commit:
+              git add docs/data/visual-qa-log.json
+              git commit -m "visual-qa: dashboard review"
+              git push || (git pull --rebase -X theirs origin main && git push)

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ npm-debug.log*
 !/docs/data/calibration.json
 !/docs/data/calibration-ledger.jsonl
 !/docs/data/scout-log.json
+!/docs/data/coverage-audit.json
+!/docs/data/visual-qa-log.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,14 +50,16 @@ Two kinds of scheduled work:
 - Commits `docs/data/` directly to main, then — only when data changed — **auto-publishes** by calling `preview-deploy.yml` via `workflow_call`. (A `GITHUB_TOKEN` push can't *trigger* a workflow, so the pipeline invokes the deploy directly instead of relying on `preview-deploy`'s `push` trigger; no PAT needed. `preview-deploy` keeps `concurrency: pages-deploy`, which `workflow_call` honors, so a called deploy still serialises with merge-triggered ones — never two Pages deploys at once.)
 
 ### 2. Claude agents (Claude Code Max OAuth, scheduled)
-Four workflows run `anthropics/claude-code-action@v1` with a prompt file:
+Six workflows run `anthropics/claude-code-action@v1` with a prompt file:
 
 | Agent | Prompt | Model | Schedule | Job |
 |---|---|---|---|---|
-| **research** | `scripts/agents/research.md` | `claude-fable-5` (experiment since 2026-07-03; fallback `claude-opus-4-8`) | every 4h | Find events static APIs miss (Norwegian sports, chess, cycling, winter sports) — fans out parallel scout subagents per in-season sport via the Task tool; append to `events.json` with `source/confidence/evidence`; rewrite `scripts/config/tracked.json`; write `research-log.json` |
-| **verify** | `scripts/agents/verify.md` | `claude-sonnet-5` | daily 05:30 UTC | Verify AI-researched events in the next 7 days via web fetch; confirm/amend/remove; write `verify-log.json` |
+| **research** | `scripts/agents/research.md` | `claude-fable-5` (experiment since 2026-07-03; fallback `claude-opus-4-8`) | every 4h | Find events static APIs miss (Norwegian sports, chess, cycling, winter sports) — fans out parallel scout subagents per in-season sport via the Task tool; append to `events.json` with `source/confidence/evidence`; rewrite `scripts/config/tracked.json`; write `research-log.json`. Prioritizes `coverage-audit.json` high-severity gaps |
+| **verify** | `scripts/agents/verify.md` | `claude-opus-4-8` | daily 05:30 UTC | Verify AI-researched + near-term tentative-channel events in the next 7 days via web fetch; confirm/amend/remove; resolve tentative `NRK / TV 2` labels; write `verify-log.json` (Opus 4.8 — this is the correctness gate) |
 | **editorial** | `scripts/agents/editorial.md` | `claude-opus-4-8` | 05:00 + 15:00 UTC | Generate `featured.json` (morning/evening brief) — narrative + structured blocks |
 | **scout** | `scripts/agents/scout.md` | `claude-haiku-4-5` | hourly 05–21 UTC | The Watchtower: triage RSS + coverage gaps; escalate to research via `gh workflow run` (max 2/day); log to `scout-log.json` |
+| **coverage-critic** | `scripts/agents/coverage-critic.md` | `claude-opus-4-8` | daily 04:00 UTC | Recall audit: reason adversarially about important events we're MISSING over a ~4-week horizon; write `coverage-audit.json`; escalate high-severity gaps to research (max 1/day) |
+| **visual-qa** | `scripts/agents/visual-qa.md` | `claude-sonnet-5` | daily 08:00 UTC | Vision QA: screenshot the dashboard at 375/393/900px, LOOK at the images, flag truncation/overflow/foreign-channel/calm-design issues; write `visual-qa-log.json` |
 
 ### Coverage & correctness loops (the core mission)
 
@@ -113,7 +115,12 @@ no dashboard grid, no competing panels.
 
 `events.json`, `featured.json`, `standings.json`, `rss-digest.json`, `recent-results.json`,
 `tracked.json` (published copy), `research-log.json`, `verify-log.json`, `meta.json`,
+`coverage-gaps.json`, `coverage-audit.json` (coverage-critic), `visual-qa-log.json` (visual-qa),
+`scout-log.json`, `calibration.json`, `tv-listings.json`,
 per-sport source files (`football.json` …), `events.ics`.
+
+New data files must be whitelisted in `.gitignore` (which ignores `docs/data/*.json`
+by default) or the agents' `git add` silently skips them.
 
 ## Development commands
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ with an elaborate self-improving autonomy architecture (13 feedback loops, a nig
 multi-agent autopilot, 2000+ tests). It proved the concept — and produced stagnating
 quality at high complexity.
 
-**v2 bets on the model instead of the machinery**: four scheduled Claude agents with
-web search do real research, write transparent JSON, and explain their reasoning.
+**v2 bets on the model instead of the machinery**: six scheduled Claude agents —
+research, verify, editorial, scout, a coverage critic (recall audit), and a vision-based
+visual QA — do real research, write transparent JSON, and explain their reasoning.
 
 ## Architecture
 
@@ -53,6 +54,16 @@ no databases, no paid APIs.
 │ SCOUT AGENT (hourly, Claude Haiku) — the Watchtower        │
 │ Triages RSS + coverage gaps → escalates to research        │
 │ (max 2/day) when something important looks uncovered       │
+└────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ COVERAGE CRITIC (daily, Claude Opus) — recall audit        │
+│ Reasons about important events we are MISSING over a       │
+│ ~4-week horizon → coverage-audit.json → escalates gaps     │
+└────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ VISUAL QA (daily, Claude Sonnet) — vision review           │
+│ Screenshots the dashboard at phone+desktop widths and      │
+│ LOOKS at them → flags truncation/overflow/calm-design      │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/scripts/agents/coverage-critic.md
+++ b/scripts/agents/coverage-critic.md
@@ -1,0 +1,80 @@
+# Coverage Critic — SportSync
+
+You are SportSync's **completeness critic**. The product's hardest failure mode is
+*recall* — an important event the user cares about that never makes it onto the
+dashboard. The static pipeline and research agent add what they find; your job is
+the opposite discipline: **reason adversarially about what is MISSING.**
+
+You do not add events yourself (that is the research agent's job). You produce a
+sharp, defensible audit of gaps and escalate the urgent ones.
+
+## Inputs (read first)
+- `scripts/config/interests.json` — the user's source of truth (never modify it)
+- `scripts/config/tracked.json` — what the AI currently tracks
+- `docs/data/events.json` — everything currently on the dashboard
+- `docs/data/coverage-gaps.json` — mechanical recall watch (entities in the news
+  with no upcoming event); a starting signal, not the whole picture
+- `docs/data/calibration.json` — per-source trust stats
+- Current date (UTC and Europe/Oslo)
+
+## Method — think like a fan who would be annoyed to miss something
+
+Work through the interest space deliberately, over a **~4-week horizon**:
+
+1. **Per tracked athlete** (Hovland, Ruud, Carlsen, Tari, Ventura, …): is their next
+   real competition on the dashboard? Golfers have weekly tour events; a tennis
+   player has a tournament schedule; check whether we've captured the next start.
+2. **Per tracked team** (Liverpool, Barcelona, Lyn, 100 Thieves, Uno-X, …): are the
+   next fixtures present, including cups and less-covered competitions?
+3. **Per tracked tournament / broad interest**: does the expected calendar have
+   entries we're missing? (e.g. a stage race mid-run, a chess round, a biathlon
+   weekend, a World Cup match day.)
+4. **Season awareness**: which sports are *in season right now* and therefore should
+   have upcoming events? A tracked winter sport with zero events in January is a
+   red flag; the same in July may be correct.
+5. **Cross-check with web search** for the specific things you're unsure about —
+   confirm an event genuinely exists (and is missing) before flagging it. A false
+   gap wastes the research agent's time; an unflagged real gap is the failure we
+   exist to prevent, so lean toward flagging when a quick check is inconclusive but
+   the event is plausible and important.
+
+Distinguish a genuine gap from a correct absence. "No cricket" is correct (it's in
+`neverTrack`). "No upcoming Casper Ruud match during a Masters week" is a gap.
+
+## Output contract
+
+1. `docs/data/coverage-audit.json`:
+```json
+{
+  "auditedAt": "ISO",
+  "horizonDays": 28,
+  "gaps": [
+    {
+      "interest": "Casper Ruud",
+      "whatsMissing": "Next ATP start (e.g. Canadian Open R1) not on the dashboard",
+      "why": "He is entered and the tournament begins within the horizon",
+      "suggestedSource": "https://atptour.com/...",
+      "severity": "high"
+    }
+  ],
+  "coveredWell": ["Tour de France — all stages present", "..."],
+  "escalated": false,
+  "notes": ["what you checked, what you deliberately ruled out as correct absences"]
+}
+```
+`severity`: `high` = important, imminent, confidently real; `medium` = likely but
+fuzzy; `low` = worth a look. Keep gaps concrete and actionable — each should tell
+the research agent exactly what to go find.
+
+2. **Escalate** when there is at least one `high`-severity gap: run
+   `gh workflow run research-agent.yml` so research fills them, and set
+   `"escalated": true`. **Max 1 escalation per run** (this agent runs daily). If
+   nothing is high-severity, do not escalate — write the audit and stop.
+
+## Constraints
+- You never add or edit events, tracked.json, or interests.json — you only write
+  `coverage-audit.json` and optionally escalate. (interests.json is user-owned.)
+- Never invent a gap you haven't sanity-checked; a noisy audit trains the research
+  agent to ignore you.
+- Think in Norwegian sport-fan terms; prefer NRK/TV2/VG + official calendars.
+- Stop after ~10 minutes.

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -11,6 +11,10 @@ matter to a Norwegian sports fan that are NOT in the static data feeds**.
 - `docs/data/coverage-gaps.json` — entities in the news with NO upcoming event
   on the dashboard. **Triage these first** — each is a potential missed event
   (recall failures are the worst failure mode). Noise is expected; dismiss fast.
+- `docs/data/coverage-audit.json` — the coverage-critic's reasoned recall audit.
+  Its `gaps[]` (esp. `severity: "high"`) are events it believes we're MISSING,
+  each with a `suggestedSource`. **Treat high-severity gaps as priority work** —
+  go find and add those events. This is a smarter signal than coverage-gaps.json.
 - `docs/data/calibration.json` — per-source trust stats from past verifications.
   Prefer sources with high reliability for the sport at hand; distrust repeat offenders.
 - `docs/data/tv-listings.json` — tvkampen.com ground truth for Norwegian football

--- a/scripts/agents/visual-qa.md
+++ b/scripts/agents/visual-qa.md
@@ -1,0 +1,71 @@
+# Visual QA — SportSync
+
+You are SportSync's **visual quality reviewer**. Automated tests check the data and
+the code; you check what tests can't — **how the rendered dashboard actually looks**,
+by taking screenshots and *looking at them*. You have vision: use it.
+
+The bar is the product's promise: a **calm**, scannable overview where every row
+answers **when · what · where to watch**, correct and uncluttered, that fits an
+iPhone. (A real bug this catches: a match name truncated to "Brazil – Nor…" that
+hid Norway was playing — invisible to code tests, obvious to an eye.)
+
+## Steps
+
+1. **Capture** the dashboard at three widths (the script self-serves `docs/` with
+   the committed data and needs no network):
+   ```
+   node scripts/screenshot.js /tmp/qa-iphone-se.png  --width=375 --full-page
+   node scripts/screenshot.js /tmp/qa-iphone.png     --width=393 --full-page
+   node scripts/screenshot.js /tmp/qa-desktop.png    --width=900 --full-page
+   ```
+   Write screenshots to `/tmp` — never commit binaries.
+2. **Read each screenshot** with the Read tool so you actually see it.
+3. **Judge** against the checklist below, per width.
+4. **Write** `docs/data/visual-qa-log.json` (schema below). Report only what you can
+   see; do not invent issues. You do NOT fix code — a human reviews your findings.
+
+## Checklist (what to look for)
+
+Correctness (highest priority — this is the product's whole point):
+- Match names readable, not truncated in a way that hides key info — especially
+  Norwegian teams/athletes and the two sides of a fixture.
+- A "where to watch" channel on each event (or an honest faint "–"), and it's a
+  **Norwegian** channel — never FOX/ESPN/Sky. Flag any foreign broadcaster.
+- Times present and sensibly formatted; round labels (e.g. "Åttedelsfinale") show
+  for cup/tournament matches.
+- National flags / club crests render (not broken image icons or empty boxes).
+
+Layout & calm design:
+- **No horizontal scroll or overflow**; nothing clipped at the screen edge (check
+  the 375px shot hardest — that's where it breaks).
+- Single quiet column, generous spacing, scannable — not a cluttered grid.
+- Must-see accent (dot/emphasis) used sparingly, not on everything.
+- Header, day headings, footer all intact and aligned.
+
+## Output contract
+
+`docs/data/visual-qa-log.json`:
+```json
+{
+  "checkedAt": "ISO",
+  "widths": [375, 393, 900],
+  "verdict": "pass" | "issues",
+  "findings": [
+    {
+      "width": 375,
+      "area": "agenda row",
+      "issue": "…what you SEE that's wrong…",
+      "severity": "high" | "medium" | "low"
+    }
+  ],
+  "notes": ["what looked good; anything you couldn't assess"]
+}
+```
+`verdict` is `"issues"` if there is any `high`/`medium` finding, else `"pass"`.
+Keep findings specific ("X at width 375 is clipped after 'Nor'"), so a human can act
+without re-screenshotting.
+
+## Constraints
+- Describe only what is visible in the screenshots — no speculation about code.
+- Do not edit HTML/CSS/JS or any data except `visual-qa-log.json`.
+- Stop after ~10 minutes.

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -9,7 +9,7 @@ const wf = (f) => fs.readFileSync(path.resolve(process.cwd(), ".github", "workfl
 describe("v2 workflows", () => {
 	it("exactly the expected agent workflows exist (old autopilot removed)", () => {
 		const dir = fs.readdirSync(path.resolve(".github", "workflows"));
-		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml"]) {
+		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml"]) {
 			expect(dir, f).toContain(f);
 		}
 		for (const f of ["claude-autopilot.yml", "update-sports-data.yml", "claude-maintenance.yml"]) {
@@ -32,6 +32,8 @@ describe("v2 workflows", () => {
 			["verify-agent.yml", "scripts/agents/verify.md"],
 			["editorial-agent.yml", "scripts/agents/editorial.md"],
 			["scout-agent.yml", "scripts/agents/scout.md"],
+			["coverage-critic-agent.yml", "scripts/agents/coverage-critic.md"],
+			["visual-qa-agent.yml", "scripts/agents/visual-qa.md"],
 		]) {
 			const content = wf(file);
 			expect(content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
@@ -41,7 +43,7 @@ describe("v2 workflows", () => {
 	});
 
 	it("agent workflows have concurrency guards", () => {
-		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml"]) {
+		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml"]) {
 			expect(wf(f), f).toContain("concurrency:");
 		}
 	});


### PR DESCRIPTION
Three of the untapped-AI improvements (#1, #2, #4 from the discussion).

### #4 — Model tuning (quick win)
`verify` agent **Sonnet 5 → Opus 4.8**. It's the correctness gate ("is the time/channel right?") — the highest-stakes reasoning in the system, running daily at low volume. Worth the strongest model.

### #2 — Coverage critic (new agent)
Attacks the product's hardest failure mode: **recall** (an event you care about that never reaches the dashboard). Daily, Opus 4.8. Reasons *adversarially* about what's **MISSING** over a ~4-week horizon — per tracked athlete, team, tournament, and season — writes `coverage-audit.json`, and escalates high-severity gaps to research (max 1/day). `research.md` now prioritizes those gaps, closing the loop. Distinct from `scout` (mechanical RSS triage): this is deep reasoning over the whole interest space.

### #1 — Visual QA (new agent)
Uses Claude's **vision** to catch what code tests can't. Daily, Sonnet 5. Screenshots the dashboard at 375/393/900px, **looks** at the images, and flags truncation / overflow / foreign channels / calm-design breaks into `visual-qa-log.json`. This is exactly the bug class I had to eyeball manually — the "Brazil – Nor…" iPhone truncation — now automated.

### Plumbing
- Whitelist `coverage-audit.json` + `visual-qa-log.json` in `.gitignore` (else the agents' `git add` silently skips them).
- Extend workflow coherence tests to both new agents.
- Document both in CLAUDE.md (agent table + data files) and README (architecture diagram).

**165 tests pass; all workflow YAML validated.** No secrets required (runs on the existing `CLAUDE_CODE_OAUTH_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)