### PR TITLE
Usage governor (part 1): /usage parser + monitor

### DIFF
--- a/.github/workflows/usage-monitor.yml
+++ b/.github/workflows/usage-monitor.yml
@@ -1,0 +1,52 @@
+name: Usage monitor
+
+# Reads REAL Claude Code Max quota via `claude -p "/usage"` and writes
+# docs/data/usage-state.json, which the scheduled agents gate on (skip / conserve
+# when the budget runs low) and the dashboard surfaces. This is the fuel gauge.
+
+on:
+  schedule:
+    - cron: "20 */2 * * *" # every 2h, offset from the other jobs
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-usage-monitor
+  cancel-in-progress: false
+
+jobs:
+  usage-monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Read /usage → usage-state.json
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          # /usage is a status read (not a model turn); capture it, fail SOFT so a
+          # hiccup keeps the previous state rather than blanking the gauge.
+          claude -p "/usage" > /tmp/usage.txt 2>/tmp/usage.err || echo "(claude /usage exited non-zero)"
+          echo "--- /usage raw output ---"; cat /tmp/usage.txt; echo "--- stderr ---"; cat /tmp/usage.err || true
+          if [ -s /tmp/usage.txt ]; then
+            node scripts/parse-usage.js < /tmp/usage.txt
+          else
+            echo "No /usage output — keeping previous usage-state.json"
+          fi
+      - name: Commit usage-state.json
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add docs/data/usage-state.json 2>/dev/null || true
+          if ! git diff --staged --quiet; then
+            git commit -m "usage-monitor: refresh quota state"
+            git push || (git pull --rebase -X theirs origin ${{ github.ref_name }} && git push)
+          else
+            echo "usage-state.json unchanged — nothing to commit"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ npm-debug.log*
 !/docs/data/scout-log.json
 !/docs/data/coverage-audit.json
 !/docs/data/visual-qa-log.json
+!/docs/data/usage-state.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/scripts/parse-usage.js
+++ b/scripts/parse-usage.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Parse the output of `claude -p "/usage"` into docs/data/usage-state.json so the
+ * scheduled agents can throttle themselves against REAL Claude Code Max quota,
+ * and the dashboard can show it. Driven by `.github/workflows/usage-monitor.yml`.
+ *
+ * `/usage` prints, e.g.:
+ *   Current session: 15% used · resets Jul 4 at 9:19pm (Europe/Oslo)
+ *   Current week (all models): 59% used · resets Jul 8 at 5:59pm (Europe/Oslo)
+ *
+ * We key throttling off the PERCENTAGES (robust); the reset strings are kept for
+ * display. No timestamp math needed — after a reset, the next poll simply reports
+ * a low %, so the state self-corrects.
+ */
+import fs from "fs";
+import path from "path";
+import { rootDataPath, iso } from "./lib/helpers.js";
+
+// Percent-of-window-used thresholds:
+export const AMBER = 75; // start conserving — optional agents skip
+export const RED = 90; // conserve hard
+export const NEAR_EXHAUSTED = 95; // skip everything; a run now would just fail
+
+/**
+ * Parse /usage text into a governor state object.
+ * @param {string} text - raw `/usage` output
+ * @param {string} nowIso - ISO timestamp for checkedAt
+ */
+export function parseUsage(text, nowIso) {
+	const src = String(text || "");
+	// `.*?` (no /s flag) stays on the same line and skips the "· " separator.
+	const sm = src.match(/current session:\s*(\d+)%\s*used\b.*?resets?\s+([^\n]+)/i);
+	const wm = src.match(/current week[^:\n]*:\s*(\d+)%\s*used\b.*?resets?\s+([^\n]+)/i);
+	const session = sm ? { percentUsed: Number(sm[1]), resetsAt: sm[2].trim() } : null;
+	const week = wm ? { percentUsed: Number(wm[1]), resetsAt: wm[2].trim() } : null;
+	const parsed = !!(session || week);
+
+	const maxPct = Math.max(session?.percentUsed ?? 0, week?.percentUsed ?? 0);
+	const sessionPct = session?.percentUsed ?? 0;
+	let status = "green";
+	if (maxPct >= RED) status = "red";
+	else if (maxPct >= AMBER) status = "amber";
+
+	// skipAll: the immediate (session) window is nearly gone — any run would fail.
+	// skipNiceToHave: conserve the weekly/session budget by dropping optional work.
+	const skipAll = parsed && sessionPct >= NEAR_EXHAUSTED;
+	const skipNiceToHave = parsed && (status === "amber" || status === "red");
+
+	return {
+		checkedAt: nowIso,
+		parsed,
+		session,
+		week,
+		status,
+		skipAll,
+		skipNiceToHave,
+		thresholds: { amber: AMBER, red: RED, nearExhausted: NEAR_EXHAUSTED },
+	};
+}
+
+// CLI: read /usage text on stdin → write docs/data/usage-state.json
+if (import.meta.url === `file://${process.argv[1]}`) {
+	let raw = "";
+	process.stdin.setEncoding("utf8");
+	process.stdin.on("data", (d) => (raw += d));
+	process.stdin.on("end", () => {
+		const state = parseUsage(raw, iso());
+		const out = path.join(rootDataPath(), "usage-state.json");
+		fs.writeFileSync(out, JSON.stringify(state, null, 2));
+		console.log(
+			`usage-state: status=${state.status} session=${state.session?.percentUsed ?? "?"}% ` +
+			`week=${state.week?.percentUsed ?? "?"}% skipAll=${state.skipAll} skipNiceToHave=${state.skipNiceToHave}`
+		);
+		if (!state.parsed) {
+			// Fail-soft: an unparseable /usage must not break the monitor. The gate
+			// treats a missing/unparsed state as "run" (fail-open), so we never let
+			// the governor itself block work.
+			console.error("WARNING: could not parse /usage output — wrote parsed:false state");
+			if (raw.trim()) console.error("--- raw /usage output ---\n" + raw.slice(0, 500));
+		}
+	});
+}

--- a/tests/parse-usage.test.js
+++ b/tests/parse-usage.test.js
@@ -1,0 +1,49 @@
+// parse-usage.js — turns `claude -p "/usage"` text into the governor state.
+import { describe, it, expect } from "vitest";
+import { parseUsage } from "../scripts/parse-usage.js";
+
+const NOW = "2026-07-04T18:00:00Z";
+const REAL = `You are currently using your subscription to power your Claude Code usage
+
+Current session: 15% used · resets Jul 4 at 9:19pm (Europe/Oslo)
+Current week (all models): 59% used · resets Jul 8 at 5:59pm (Europe/Oslo)
+
+What's contributing to your limits usage?
+Last 24h · 657 requests · 1 session`;
+
+describe("parseUsage", () => {
+	it("extracts session + week percentages and reset strings", () => {
+		const s = parseUsage(REAL, NOW);
+		expect(s.parsed).toBe(true);
+		expect(s.session).toEqual({ percentUsed: 15, resetsAt: "Jul 4 at 9:19pm (Europe/Oslo)" });
+		expect(s.week).toEqual({ percentUsed: 59, resetsAt: "Jul 8 at 5:59pm (Europe/Oslo)" });
+		expect(s.status).toBe("green"); // max 59 < 75
+		expect(s.skipAll).toBe(false);
+		expect(s.skipNiceToHave).toBe(false);
+	});
+
+	it("goes amber (skip nice-to-have) at >=75% on either window", () => {
+		const s = parseUsage("Current session: 20% used · resets x\nCurrent week (all models): 80% used · resets y", NOW);
+		expect(s.status).toBe("amber");
+		expect(s.skipNiceToHave).toBe(true);
+		expect(s.skipAll).toBe(false); // session still low
+	});
+
+	it("goes red at >=90%", () => {
+		const s = parseUsage("Current session: 30% used · resets x\nCurrent week (all models): 92% used · resets y", NOW);
+		expect(s.status).toBe("red");
+		expect(s.skipNiceToHave).toBe(true);
+	});
+
+	it("skipAll when the session window is near exhausted (>=95%)", () => {
+		const s = parseUsage("Current session: 97% used · resets x\nCurrent week (all models): 60% used · resets y", NOW);
+		expect(s.skipAll).toBe(true);
+	});
+
+	it("fail-open on unparseable input (parsed:false, no skips)", () => {
+		const s = parseUsage("garbage with no usage lines", NOW);
+		expect(s.parsed).toBe(false);
+		expect(s.skipAll).toBe(false);
+		expect(s.skipNiceToHave).toBe(false);
+	});
+});


### PR DESCRIPTION
First half of the quota governor. Reads real Claude Code Max quota via `claude -p /usage` in CI → `docs/data/usage-state.json` (session%/week% + reset times, status green/amber/red). Inert until agents gate on it (part 2). Merging to main so the monitor can be dispatched (GitHub requires workflow_dispatch on the default branch) and probed to confirm `/usage` reports real numbers on a fresh runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)