### PR TITLE
Complete the self-healing UI loop (visual-qa → ui-fix → PR)

### DIFF
--- a/.github/workflows/ui-fix-agent.yml
+++ b/.github/workflows/ui-fix-agent.yml
@@ -1,0 +1,50 @@
+name: UI fix agent
+
+# Closes the self-healing UI loop: reads the visual-qa findings and, if there are
+# real rendering problems, fixes the frontend ON A BRANCH, re-screenshots to prove
+# the fix + no regressions, runs the tests, and opens a PR for a human to merge.
+# It never changes the live site directly.
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # 11:00 Oslo — an hour after visual-qa (08:00 UTC) writes its findings
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-ui-fix
+  cancel-in-progress: false
+
+jobs:
+  ui-fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so the agent can branch/PR cleanly
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - run: npm ci
+      - id: usage
+        run: node scripts/usage-gate.js optional # a nice-to-have — skip under quota pressure
+      - run: npx playwright install --with-deps chromium # for before/after screenshots
+        if: steps.usage.outputs.run == 'true'
+      - if: steps.usage.outputs.run == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 80
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(date:*),Bash(jq:*)"
+          prompt: |
+            Read scripts/agents/ui-fix.md and execute it — turn visual-qa findings
+            into a screenshot-verified frontend fix, then open a PR (never merge,
+            never push to main).

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ npm-debug.log*
 !/docs/data/scout-log.json
 !/docs/data/coverage-audit.json
 !/docs/data/visual-qa-log.json
+!/docs/data/ui-fix-log.json
 !/docs/data/usage-state.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Two kinds of scheduled work:
 - Commits `docs/data/` directly to main, then — only when data changed — **auto-publishes** by calling `preview-deploy.yml` via `workflow_call`. (A `GITHUB_TOKEN` push can't *trigger* a workflow, so the pipeline invokes the deploy directly instead of relying on `preview-deploy`'s `push` trigger; no PAT needed. `preview-deploy` keeps `concurrency: pages-deploy`, which `workflow_call` honors, so a called deploy still serialises with merge-triggered ones — never two Pages deploys at once.)
 
 ### 2. Claude agents (Claude Code Max OAuth, scheduled)
-Six workflows run `anthropics/claude-code-action@v1` with a prompt file:
+Seven workflows run `anthropics/claude-code-action@v1` with a prompt file:
 
 | Agent | Prompt | Model | Schedule | Job |
 |---|---|---|---|---|
@@ -60,6 +60,7 @@ Six workflows run `anthropics/claude-code-action@v1` with a prompt file:
 | **scout** | `scripts/agents/scout.md` | `claude-haiku-4-5` | hourly 05–21 UTC | The Watchtower: triage RSS + coverage gaps; escalate to research via `gh workflow run` (max 2/day); log to `scout-log.json` |
 | **coverage-critic** | `scripts/agents/coverage-critic.md` | `claude-opus-4-8` | daily 04:00 UTC | Recall audit: reason adversarially about important events we're MISSING over a ~4-week horizon; write `coverage-audit.json`; escalate high-severity gaps to research (max 1/day) |
 | **visual-qa** | `scripts/agents/visual-qa.md` | `claude-sonnet-5` | daily 08:00 UTC | Vision QA: screenshot the dashboard at 375/393/900px, LOOK at the images, flag truncation/overflow/foreign-channel/calm-design issues; write `visual-qa-log.json` |
+| **ui-fix** | `scripts/agents/ui-fix.md` | `claude-opus-4-8` | daily 09:00 UTC | Self-heal: read visual-qa findings, fix the frontend ON A BRANCH, re-screenshot to prove the fix + no regressions, `npm test`, open a **PR** (never merges, never touches the live site directly). Closes the visual-qa loop |
 
 ### Quota governor (self-throttling on real Max usage)
 
@@ -124,7 +125,7 @@ no dashboard grid, no competing panels.
 `events.json`, `featured.json`, `standings.json`, `rss-digest.json`, `recent-results.json`,
 `tracked.json` (published copy), `research-log.json`, `verify-log.json`, `meta.json`,
 `coverage-gaps.json`, `coverage-audit.json` (coverage-critic), `visual-qa-log.json` (visual-qa),
-`usage-state.json` (quota governor), `scout-log.json`, `calibration.json`, `tv-listings.json`,
+`ui-fix-log.json` (ui-fix), `usage-state.json` (quota governor), `scout-log.json`, `calibration.json`, `tv-listings.json`,
 per-sport source files (`football.json` …), `events.ics`.
 
 New data files must be whitelisted in `.gitignore` (which ignores `docs/data/*.json`

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ with an elaborate self-improving autonomy architecture (13 feedback loops, a nig
 multi-agent autopilot, 2000+ tests). It proved the concept — and produced stagnating
 quality at high complexity.
 
-**v2 bets on the model instead of the machinery**: six scheduled Claude agents —
-research, verify, editorial, scout, a coverage critic (recall audit), and a vision-based
-visual QA — do real research, write transparent JSON, and explain their reasoning.
+**v2 bets on the model instead of the machinery**: seven scheduled Claude agents —
+research, verify, editorial, scout, a coverage critic (recall audit), a vision-based
+visual QA, and a UI-fix agent that self-heals rendering bugs into PRs — do real
+research, write transparent JSON, and explain their reasoning.
 
 ## Architecture
 
@@ -64,6 +65,11 @@ no databases, no paid APIs.
 │ VISUAL QA (daily, Claude Sonnet) — vision review           │
 │ Screenshots the dashboard at phone+desktop widths and      │
 │ LOOKS at them → flags truncation/overflow/calm-design      │
+└────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ UI FIX (daily, Claude Opus) — self-heal loop               │
+│ Reads visual-qa findings → fixes the frontend on a branch  │
+│ → re-screenshots to verify → opens a PR (you merge)        │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/scripts/agents/ui-fix.md
+++ b/scripts/agents/ui-fix.md
@@ -1,0 +1,58 @@
+# UI Fix Agent — SportSync (self-healing loop)
+
+You close the loop the **visual-qa** agent opens. Visual-qa *reports* rendering
+problems; you *fix* them — but safely: on a branch, re-verified with screenshots,
+and proposed as a **pull request** a human merges. You must NEVER change the live
+site directly.
+
+## Inputs
+- `docs/data/visual-qa-log.json` — the latest visual review. Its `findings[]` are
+  what you fix. Each has `width`, `area`, `issue`, `severity`.
+- The frontend: `docs/index.html`, `docs/css/{base,layout,cards}.css`,
+  `docs/js/dashboard.js` (+ helpers). This is the ONLY code you may touch.
+
+## When to act (else exit cleanly, no PR)
+1. If `visual-qa-log.json` is missing, `verdict` is `"pass"`, or there are no
+   `high`/`medium` findings → write `ui-fix-log.json` with `action: "none"` and stop.
+2. If an open PR whose head starts with `ui-autofix` already exists
+   (`gh pr list --state open --json headRefName`) → stop (don't stack PRs). Log
+   `action: "skipped-existing-pr"`.
+3. Only fix findings that are genuinely **code-fixable** UI issues (truncation,
+   overflow, broken flags/logos, a foreign channel showing in the UI, calm-design
+   breaks). Ignore anything that's really a data problem — that's the other agents.
+
+## How to fix (safely)
+1. **Branch**: `git checkout -b ui-autofix/$(date -u +%Y%m%d-%H%M)`.
+2. **Baseline**: screenshot before touching anything, so you can compare:
+   `node scripts/screenshot.js /tmp/before-375.png --width=375 --full-page`
+   (also 393 and 900).
+3. **Make the SMALLEST change** that resolves the finding. Respect the calm design
+   (see CLAUDE.md → Frontend): one quiet single column (max 640px), each row is
+   `when · what · where`, near-black dark default, restrained accent, phone
+   breakpoint `<=460px`. Prefer CSS over JS; prefer a scoped rule over a broad one.
+   For the known truncation finding (long "Home – Away" names clipping the away
+   team to just a flag on narrow screens), a good fix is to let `.ev-title` wrap to
+   two lines on phones instead of single-line ellipsis — but choose whatever is
+   smallest and calmest.
+4. **Re-verify (the proof)**: screenshot again at 375/393/900 and READ the images.
+   Confirm (a) the reported finding is actually resolved, AND (b) nothing else
+   regressed — still calm, no new overflow/truncation, header/agenda/footer intact.
+   If you cannot confirm a clean fix, `git checkout .` to discard, do NOT open a
+   PR, and log `action: "abandoned"` with the reason. A missing fix beats a
+   regression on the live site.
+5. **Tests**: run `npm test` — it must pass.
+
+## Output / PR
+- Commit only frontend files (`docs/`), push the branch, and open a PR:
+  `gh pr create --title "ui-autofix: <short summary>" --body "<which findings, before/after notes>"`.
+  Do **NOT** merge — a human reviews and merges.
+- Write `docs/data/ui-fix-log.json`:
+  `{ "runAt": ISO, "action": "opened-pr"|"none"|"skipped-existing-pr"|"abandoned", "pr": <url or null>, "fixed": ["finding summaries"], "notes": ["..."] }`
+
+## Hard constraints
+- Touch ONLY `docs/index.html`, `docs/css/**`, `docs/js/**` (+ write `ui-fix-log.json`).
+  NEVER edit data files, `scripts/config/interests.json`, `scripts/**`, `.github/**`,
+  or `package.json`.
+- NEVER merge or push to `main`. Branch + PR only.
+- Never open a PR you haven't screenshot-verified and tested.
+- Keep it calm and minimal. Stop after ~15 minutes.

--- a/scripts/agents/visual-qa.md
+++ b/scripts/agents/visual-qa.md
@@ -63,7 +63,9 @@ Layout & calm design:
 ```
 `verdict` is `"issues"` if there is any `high`/`medium` finding, else `"pass"`.
 Keep findings specific ("X at width 375 is clipped after 'Nor'"), so a human can act
-without re-screenshotting.
+without re-screenshotting. The **ui-fix agent** reads this log and turns actionable
+`high`/`medium` findings into a screenshot-verified PR — so precise, code-fixable
+findings directly drive the self-healing loop.
 
 ## Constraints
 - Describe only what is visible in the screenshots — no speculation about code.

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -9,7 +9,7 @@ const wf = (f) => fs.readFileSync(path.resolve(process.cwd(), ".github", "workfl
 describe("v2 workflows", () => {
 	it("exactly the expected agent workflows exist (old autopilot removed)", () => {
 		const dir = fs.readdirSync(path.resolve(".github", "workflows"));
-		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "usage-monitor.yml"]) {
+		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "usage-monitor.yml", "ui-fix-agent.yml"]) {
 			expect(dir, f).toContain(f);
 		}
 		for (const f of ["claude-autopilot.yml", "update-sports-data.yml", "claude-maintenance.yml"]) {
@@ -34,6 +34,7 @@ describe("v2 workflows", () => {
 			["scout-agent.yml", "scripts/agents/scout.md"],
 			["coverage-critic-agent.yml", "scripts/agents/coverage-critic.md"],
 			["visual-qa-agent.yml", "scripts/agents/visual-qa.md"],
+			["ui-fix-agent.yml", "scripts/agents/ui-fix.md"],
 		]) {
 			const content = wf(file);
 			expect(content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
@@ -43,7 +44,7 @@ describe("v2 workflows", () => {
 	});
 
 	it("every agent gates on the usage governor, and the monitor feeds it", () => {
-		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml"]) {
+		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml"]) {
 			expect(wf(f), `${f} must run the usage gate`).toContain("scripts/usage-gate.js");
 			expect(wf(f), `${f} must condition the agent on the gate`).toContain("steps.usage.outputs.run == 'true'");
 		}
@@ -54,7 +55,7 @@ describe("v2 workflows", () => {
 	});
 
 	it("agent workflows have concurrency guards", () => {
-		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml"]) {
+		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml"]) {
 			expect(wf(f), f).toContain("concurrency:");
 		}
 	});


### PR DESCRIPTION
Closes the loop you flagged: visual-qa *reported* rendering bugs but nothing *fixed* them. Now a **ui-fix** agent does — safely.

## Why it's a PR loop, not auto-merge
The coverage loop self-heals by changing **data** (safe, validated, reversible). UI fixes change **code on the live site** — a much bigger blast radius, and often a design-taste call. So ui-fix does all the work but stops short of shipping unreviewed.

## The loop
**ui-fix** (daily 09:00, after visual-qa's 08:00, Opus 4.8):
1. Reads `visual-qa-log.json` findings.
2. Fixes the frontend **on a branch** (`docs/css|js|index.html` only — never data/config/workflows).
3. **Re-screenshots** at 375/393/900 and *reads* them to prove the finding is resolved **and nothing regressed**; discards + abandons if it can't verify a clean fix.
4. Runs `npm test`.
5. Opens a **PR** (never merges, never pushes to main) — you gate the ship.

Guards: skips when `verdict=pass`/no findings, or when an open `ui-autofix` PR already exists (no PR spam); gated by the usage governor (optional tier).

## Result
The system now **diagnoses → fixes → visually proves** UI issues on its own; you just click merge. Docs + coherence tests updated (ui-fix pinned to the gate and its prompt). **173 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)