### PR TITLE
UI-fix loop: auto-merge + deploy verified fixes (hands-off)

### DIFF
--- a/.github/workflows/ui-fix-agent.yml
+++ b/.github/workflows/ui-fix-agent.yml
@@ -22,6 +22,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      merged: ${{ steps.automerge.outputs.merged }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -46,5 +48,42 @@ jobs:
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(date:*),Bash(jq:*)"
           prompt: |
             Read scripts/agents/ui-fix.md and execute it — turn visual-qa findings
-            into a screenshot-verified frontend fix, then open a PR (never merge,
-            never push to main).
+            into a screenshot-verified frontend fix and open a PR (do not merge; the
+            workflow re-gates the tests and auto-merges it).
+
+      # Auto-merge the fix the agent just opened — but only after re-running the
+      # tests ourselves (a deterministic hard gate we don't delegate to the agent).
+      # If tests fail, the merge is skipped and the PR stays open + the run fails
+      # loudly, so a bad fix never reaches the live site.
+      - name: Re-gate tests + auto-merge
+        id: automerge
+        if: steps.usage.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=$(gh pr list --state open --json number,headRefName \
+                --jq '[.[] | select(.headRefName | startswith("ui-autofix/"))] | sort_by(.number) | last | .number // empty')
+          if [ -z "$PR" ]; then
+            echo "No ui-autofix PR was opened (nothing to fix / abandoned) — done."
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Re-gating PR #$PR with a fresh test run before auto-merge…"
+          gh pr checkout "$PR"
+          npm ci
+          npm test
+          gh pr merge "$PR" --merge --delete-branch
+          echo "Auto-merged PR #$PR."
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+
+  # Publish the merged fix. The merge is a GITHUB_TOKEN push (can't trigger the
+  # deploy on its own), so we call preview-deploy directly — same pattern as the
+  # static pipeline. Only runs when a fix actually merged.
+  deploy:
+    needs: ui-fix
+    if: needs.ui-fix.outputs.merged == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/preview-deploy.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Seven workflows run `anthropics/claude-code-action@v1` with a prompt file:
 | **scout** | `scripts/agents/scout.md` | `claude-haiku-4-5` | hourly 05–21 UTC | The Watchtower: triage RSS + coverage gaps; escalate to research via `gh workflow run` (max 2/day); log to `scout-log.json` |
 | **coverage-critic** | `scripts/agents/coverage-critic.md` | `claude-opus-4-8` | daily 04:00 UTC | Recall audit: reason adversarially about important events we're MISSING over a ~4-week horizon; write `coverage-audit.json`; escalate high-severity gaps to research (max 1/day) |
 | **visual-qa** | `scripts/agents/visual-qa.md` | `claude-sonnet-5` | daily 08:00 UTC | Vision QA: screenshot the dashboard at 375/393/900px, LOOK at the images, flag truncation/overflow/foreign-channel/calm-design issues; write `visual-qa-log.json` |
-| **ui-fix** | `scripts/agents/ui-fix.md` | `claude-opus-4-8` | daily 09:00 UTC | Self-heal: read visual-qa findings, fix the frontend ON A BRANCH, re-screenshot to prove the fix + no regressions, `npm test`, open a **PR** (never merges, never touches the live site directly). Closes the visual-qa loop |
+| **ui-fix** | `scripts/agents/ui-fix.md` | `claude-opus-4-8` | daily 09:00 UTC | Self-heal: read visual-qa findings, fix the frontend ON A BRANCH, re-screenshot to prove the fix + no regressions, `npm test`, open a PR. The workflow then **re-runs the tests as a hard gate and auto-merges + deploys** it (fully hands-off). Fix ships only if it verifies twice; a test failure leaves the PR open + fails loudly. Closes the visual-qa loop |
 
 ### Quota governor (self-throttling on real Max usage)
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ quality at high complexity.
 
 **v2 bets on the model instead of the machinery**: seven scheduled Claude agents —
 research, verify, editorial, scout, a coverage critic (recall audit), a vision-based
-visual QA, and a UI-fix agent that self-heals rendering bugs into PRs — do real
-research, write transparent JSON, and explain their reasoning.
+visual QA, and a UI-fix agent that self-heals rendering bugs (fix → verify →
+auto-merge) — do real research, write transparent JSON, and explain their reasoning.
 
 ## Architecture
 
@@ -68,8 +68,8 @@ no databases, no paid APIs.
 └────────────────────────────────────────────────────────────┘
 ┌────────────────────────────────────────────────────────────┐
 │ UI FIX (daily, Claude Opus) — self-heal loop               │
-│ Reads visual-qa findings → fixes the frontend on a branch  │
-│ → re-screenshots to verify → opens a PR (you merge)        │
+│ Reads visual-qa findings → fixes frontend on a branch →    │
+│ re-screenshots + tests → PR → tests re-gate → auto-merge   │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/scripts/agents/ui-fix.md
+++ b/scripts/agents/ui-fix.md
@@ -1,9 +1,12 @@
 # UI Fix Agent — SportSync (self-healing loop)
 
 You close the loop the **visual-qa** agent opens. Visual-qa *reports* rendering
-problems; you *fix* them — but safely: on a branch, re-verified with screenshots,
-and proposed as a **pull request** a human merges. You must NEVER change the live
-site directly.
+problems; you *fix* them — on a branch, re-verified with screenshots, opened as a
+**pull request**. The workflow then re-runs the tests as a hard gate and
+**auto-merges + deploys** your PR, so the fix ships hands-free. Because there is no
+human between your fix and the live site, your screenshot verification is the
+safety net — be conservative, and abandon rather than ship anything you can't
+prove is clean. You still work on a branch + PR (never push to `main` yourself).
 
 ## Inputs
 - `docs/data/visual-qa-log.json` — the latest visual review. Its `findings[]` are
@@ -45,7 +48,8 @@ site directly.
 ## Output / PR
 - Commit only frontend files (`docs/`), push the branch, and open a PR:
   `gh pr create --title "ui-autofix: <short summary>" --body "<which findings, before/after notes>"`.
-  Do **NOT** merge — a human reviews and merges.
+  Do **NOT** merge it yourself — the workflow re-gates the tests and auto-merges +
+  deploys it. Put your before/after evidence in the PR body; it's the audit trail.
 - Write `docs/data/ui-fix-log.json`:
   `{ "runAt": ISO, "action": "opened-pr"|"none"|"skipped-existing-pr"|"abandoned", "pr": <url or null>, "fixed": ["finding summaries"], "notes": ["..."] }`
 
@@ -53,6 +57,7 @@ site directly.
 - Touch ONLY `docs/index.html`, `docs/css/**`, `docs/js/**` (+ write `ui-fix-log.json`).
   NEVER edit data files, `scripts/config/interests.json`, `scripts/**`, `.github/**`,
   or `package.json`.
-- NEVER merge or push to `main`. Branch + PR only.
-- Never open a PR you haven't screenshot-verified and tested.
+- NEVER merge or push to `main` yourself. Branch + PR only — the workflow merges.
+- Never open a PR you haven't screenshot-verified and tested. It WILL auto-merge,
+  so an unverified PR ships a bug to the live site. When in doubt, abandon.
 - Keep it calm and minimal. Stop after ~15 minutes.


### PR DESCRIPTION
You don't want to manually merge — so the UI self-heal loop now ships its own verified fixes.

## How it stays safe while auto-merging code to the live site
- The **agent** self-verifies before opening the PR: re-screenshots at 375/393/900, *reads* the images to confirm the fix + no regression, runs `npm test`.
- The **workflow** then re-runs `npm test` as a **hard, deterministic gate** (not delegated to the agent) and only then `gh pr merge`s.
- **Ships only if it verifies twice.** A test failure → merge skipped, PR left open, run fails loudly → no bad fix on live.
- **Self-correcting:** the next visual-qa run catches any visual regression a fix introduces, and everything's a revertable commit.
- Publish is handled by a `workflow_call` deploy job (the merge is a GITHUB_TOKEN push, which can't trigger deploy on its own).

Scope unchanged: frontend files only, branch+PR only, governor-gated (optional tier).

**173 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)