### PR TITLE
Self-repair + evolution loops (bounded, test-gated)

### DIFF
--- a/.github/workflows/improve-agent.yml
+++ b/.github/workflows/improve-agent.yml
@@ -1,0 +1,47 @@
+name: Improve agent
+
+# Evolution, proposal-only. Weekly, the system reviews its own logs and proposes
+# ONE evidenced improvement as a PR for a human to review — never auto-merged,
+# because "what should we do better" is a judgment call. Biased toward sharpening
+# what exists over adding machinery (the v1 complexity lesson).
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Mondays 09:00 Oslo
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-improve
+  cancel-in-progress: false
+
+jobs:
+  improve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - run: npm ci
+      - id: usage
+        run: node scripts/usage-gate.js optional
+      - if: steps.usage.outputs.run == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 80
+            --allowedTools "Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(date:*),Bash(jq:*)"
+          prompt: |
+            Read scripts/agents/improve.md and execute it — mine the logs for ONE
+            evidenced improvement and open a proposal PR. Do NOT merge (proposal-only).

--- a/.github/workflows/self-repair-agent.yml
+++ b/.github/workflows/self-repair-agent.yml
@@ -1,0 +1,92 @@
+name: Self-repair agent
+
+# The mechanic: keeps the system running. Detects real breakage (failed runs,
+# failing tests, validation errors, broken fetchers), fixes it ON A BRANCH,
+# proves it, and opens a PR. The workflow then re-runs the tests AND checks the
+# PR only touches SAFE paths before auto-merging; anything sensitive is left open
+# for a human. Fixes ship only if they verify twice and stay in bounds.
+
+on:
+  schedule:
+    - cron: "30 6 * * *" # daily 08:30 Oslo
+  workflow_dispatch:
+
+concurrency:
+  group: sportsync-self-repair
+  cancel-in-progress: false
+
+jobs:
+  self-repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read # read failed-run logs
+      id-token: write
+    outputs:
+      merged: ${{ steps.automerge.outputs.merged }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - run: npm ci
+      - id: usage
+        run: node scripts/usage-gate.js optional
+      - if: steps.usage.outputs.run == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 80
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(date:*),Bash(jq:*)"
+          prompt: |
+            Read scripts/agents/self-repair.md and execute it — find real breakage,
+            fix it on a branch, prove it, open a PR. Do not merge.
+
+      # Re-gate the fix ourselves, then auto-merge ONLY if it stays in safe paths.
+      - name: Re-gate + auto-merge (safe paths only)
+        id: automerge
+        if: steps.usage.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=$(gh pr list --state open --json number,headRefName \
+                --jq '[.[] | select(.headRefName | startswith("self-repair/"))] | sort_by(.number) | last | .number // empty')
+          if [ -z "$PR" ]; then
+            echo "No self-repair PR (nothing broken / abandoned)."; echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Deterministic guardrail: every changed file must be in a safe path,
+          # else a human reviews it (workflows/config/hooks/agent-prompts/package.json).
+          SAFE='^(scripts/fetch/|scripts/lib/|tests/|docs/js/|docs/css/|docs/index\.html$|docs/data/self-repair-log\.json$)'
+          RISKY=0
+          for f in $(gh pr view "$PR" --json files --jq '.files[].path'); do
+            echo "$f" | grep -qE "$SAFE" || { echo "risky path: $f"; RISKY=1; }
+          done
+          if [ "$RISKY" = "1" ]; then
+            echo "PR #$PR touches sensitive paths — leaving OPEN for human review."
+            gh pr edit "$PR" --add-label needs-review 2>/dev/null || true
+            echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "Re-gating PR #$PR (safe paths only) with fresh tests…"
+          gh pr checkout "$PR"
+          npm ci
+          npm test
+          node scripts/validate-events.js
+          gh pr merge "$PR" --merge --delete-branch
+          echo "Auto-merged PR #$PR."; echo "merged=true" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: self-repair
+    if: needs.self-repair.outputs.merged == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/preview-deploy.yml

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ npm-debug.log*
 !/docs/data/coverage-audit.json
 !/docs/data/visual-qa-log.json
 !/docs/data/ui-fix-log.json
+!/docs/data/self-repair-log.json
+!/docs/data/improve-log.json
 !/docs/data/usage-state.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Two kinds of scheduled work:
 - Commits `docs/data/` directly to main, then — only when data changed — **auto-publishes** by calling `preview-deploy.yml` via `workflow_call`. (A `GITHUB_TOKEN` push can't *trigger* a workflow, so the pipeline invokes the deploy directly instead of relying on `preview-deploy`'s `push` trigger; no PAT needed. `preview-deploy` keeps `concurrency: pages-deploy`, which `workflow_call` honors, so a called deploy still serialises with merge-triggered ones — never two Pages deploys at once.)
 
 ### 2. Claude agents (Claude Code Max OAuth, scheduled)
-Seven workflows run `anthropics/claude-code-action@v1` with a prompt file:
+Nine workflows run `anthropics/claude-code-action@v1` with a prompt file:
 
 | Agent | Prompt | Model | Schedule | Job |
 |---|---|---|---|---|
@@ -61,6 +61,8 @@ Seven workflows run `anthropics/claude-code-action@v1` with a prompt file:
 | **coverage-critic** | `scripts/agents/coverage-critic.md` | `claude-opus-4-8` | daily 04:00 UTC | Recall audit: reason adversarially about important events we're MISSING over a ~4-week horizon; write `coverage-audit.json`; escalate high-severity gaps to research (max 1/day) |
 | **visual-qa** | `scripts/agents/visual-qa.md` | `claude-sonnet-5` | daily 08:00 UTC | Vision QA: screenshot the dashboard at 375/393/900px, LOOK at the images, flag truncation/overflow/foreign-channel/calm-design issues; write `visual-qa-log.json` |
 | **ui-fix** | `scripts/agents/ui-fix.md` | `claude-opus-4-8` | daily 09:00 UTC | Self-heal: read visual-qa findings, fix the frontend ON A BRANCH, re-screenshot to prove the fix + no regressions, `npm test`, open a PR. The workflow then **re-runs the tests as a hard gate and auto-merges + deploys** it (fully hands-off). Fix ships only if it verifies twice; a test failure leaves the PR open + fails loudly. Closes the visual-qa loop |
+| **self-repair** | `scripts/agents/self-repair.md` | `claude-opus-4-8` | daily 08:30 UTC | The mechanic: detect real breakage (failed runs, failing tests, validation errors, broken fetchers), fix ON A BRANCH, prove it, open a PR. Workflow re-gates tests AND **auto-merges only if every changed file is in a safe path** (`scripts/fetch`, `scripts/lib`, `tests`, `docs/js`, `docs/css`, `index.html`); sensitive paths (workflows/config/hooks/agent-prompts/package.json) are left open for review. Ignores quota/transient failures |
+| **improve** | `scripts/agents/improve.md` | `claude-opus-4-8` | weekly Mon 07:00 UTC | Evolution, **proposal-only**: mine the logs for ONE evidenced improvement (source/skill/prompt/threshold/fetcher tuning), open a PR a human reviews. Never auto-merges. Biased toward sharpening what exists over adding machinery (the v1 lesson) |
 
 ### Quota governor (self-throttling on real Max usage)
 
@@ -125,7 +127,8 @@ no dashboard grid, no competing panels.
 `events.json`, `featured.json`, `standings.json`, `rss-digest.json`, `recent-results.json`,
 `tracked.json` (published copy), `research-log.json`, `verify-log.json`, `meta.json`,
 `coverage-gaps.json`, `coverage-audit.json` (coverage-critic), `visual-qa-log.json` (visual-qa),
-`ui-fix-log.json` (ui-fix), `usage-state.json` (quota governor), `scout-log.json`, `calibration.json`, `tv-listings.json`,
+`ui-fix-log.json` (ui-fix), `self-repair-log.json` (self-repair), `improve-log.json` (improve),
+`usage-state.json` (quota governor), `scout-log.json`, `calibration.json`, `tv-listings.json`,
 per-sport source files (`football.json` …), `events.ics`.
 
 New data files must be whitelisted in `.gitignore` (which ignores `docs/data/*.json`

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ with an elaborate self-improving autonomy architecture (13 feedback loops, a nig
 multi-agent autopilot, 2000+ tests). It proved the concept — and produced stagnating
 quality at high complexity.
 
-**v2 bets on the model instead of the machinery**: seven scheduled Claude agents —
-research, verify, editorial, scout, a coverage critic (recall audit), a vision-based
-visual QA, and a UI-fix agent that self-heals rendering bugs (fix → verify →
-auto-merge) — do real research, write transparent JSON, and explain their reasoning.
+**v2 bets on the model instead of the machinery**: nine scheduled Claude agents —
+research, verify, editorial, scout, a coverage critic, a vision-based visual QA, a
+UI-fix agent that self-heals rendering bugs (fix → verify → auto-merge), a
+self-repair "mechanic" that fixes its own broken code/tests, and a weekly improve
+agent that proposes its own upgrades — do real research, write transparent JSON,
+and explain their reasoning. Every self-fixing loop is narrow and test-gated —
+the deliberate opposite of v1's sprawling autopilot.
 
 ## Architecture
 
@@ -70,6 +73,16 @@ no databases, no paid APIs.
 │ UI FIX (daily, Claude Opus) — self-heal loop               │
 │ Reads visual-qa findings → fixes frontend on a branch →    │
 │ re-screenshots + tests → PR → tests re-gate → auto-merge   │
+└────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ SELF-REPAIR (daily, Claude Opus) — the mechanic            │
+│ Detects failed runs / broken tests / fetchers → fixes on   │
+│ a branch → re-gates tests → auto-merges SAFE paths only    │
+└────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────┐
+│ IMPROVE (weekly, Claude Opus) — evolution, proposal-only   │
+│ Mines the logs for one evidenced improvement → opens a     │
+│ PR you review (never auto-merged)                          │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/scripts/agents/improve.md
+++ b/scripts/agents/improve.md
@@ -1,0 +1,50 @@
+# Improve Agent — SportSync (evolution, proposal-only)
+
+Once a week you step back and ask: **what is this system doing poorly, and how
+could it do it better?** Then you propose ONE concrete improvement as a pull
+request a human reviews. You never auto-merge — evolution is a judgment call, so
+it stays human-gated.
+
+## Read the evidence (don't guess — mine the logs)
+- `scripts/config/interests.json` — what the user actually cares about (never edit it)
+- `docs/data/research-log.json`, `verify-log.json`, `coverage-audit.json`,
+  `visual-qa-log.json`, `scout-log.json`, `self-repair-log.json` — what the agents
+  have been finding, missing, fixing, and failing at
+- `docs/data/calibration.json` — which sources have proven reliable vs not
+- `docs/data/usage-state.json` — quota pressure (is anything getting starved?)
+- `docs/data/events.json`, `recent-results.json` — the actual output quality
+
+## Look for a real, evidenced improvement
+Patterns worth acting on (pick the ONE with the best evidence + payoff):
+- A **recurring coverage gap** research keeps failing to fill → propose a new
+  source, a `norwegian-rights`/`x-sources` skill update, or a small fetcher.
+- A **source calibration flags as unreliable** → propose dropping/replacing it in
+  the relevant prompt/skill.
+- **Repeated self-repair of the same thing** → propose the durable root-cause fix.
+- A **prompt or threshold that's misfiring** (e.g. confidence rules, governor
+  thresholds, relevance filter) → propose a tuning, with the evidence.
+- An **interest that's under-served** by the current fetchers/agents.
+
+## The bias that keeps this from becoming v1
+v2 exists because v1's "self-improving autonomy" **stagnated under its own
+complexity**. So:
+- **Prefer sharpening what exists over adding new machinery.** Improving a prompt,
+  skill, threshold, or fetcher beats adding a new agent/loop almost every time.
+- Propose the **smallest** change with the clearest evidence. One improvement per
+  run — depth over breadth.
+- If the best "improvement" is to REMOVE or simplify something, propose that.
+- If nothing has strong evidence this week, propose nothing (write `action: "none"`).
+
+## Output (proposal-only)
+- Make the change on a branch, run `npm test` (must pass), and open a PR:
+  `gh pr create --title "improve: <one line>" --body "<the evidence from the logs · what changes · expected effect · how we'll know it worked>"`.
+  Do **NOT** merge — a human decides. You may edit prompts (`scripts/agents/*.md`),
+  skills (`.claude/skills/**`), fetchers/libs (`scripts/fetch`, `scripts/lib`),
+  thresholds, and docs. **Never** `scripts/config/interests.json`.
+- `docs/data/improve-log.json`:
+  `{ "runAt": ISO, "action": "opened-pr"|"none", "pr": <url|null>, "proposal": "…", "evidence": ["…"] }`
+
+## Constraints
+- Proposal-only: branch + PR, never merge, never push to `main`.
+- Never edit `scripts/config/interests.json`.
+- One focused improvement per run; evidence over opinion. Stop after ~15 minutes.

--- a/scripts/agents/self-repair.md
+++ b/scripts/agents/self-repair.md
@@ -1,0 +1,59 @@
+# Self-Repair Agent — SportSync (the mechanic)
+
+You keep the system *running*. The other agents fix data, coverage, and UI; you
+fix the machine itself: broken fetchers, failing tests, validation errors,
+workflows that keep erroring. Same discipline as the ui-fix loop — fix on a
+branch, **prove it**, open a PR — and the workflow auto-merges only if the change
+is confined to safe paths.
+
+## Find what's actually broken
+Look for real, reproducible breakage (not quality opinions — coverage gaps belong
+to research, rendering nits to ui-fix):
+1. **Recent failed runs**: `gh run list --status failure --limit 20 --json name,conclusion,createdAt,databaseId`.
+   For a relevant failure, read `gh run view <id> --log-failed`.
+2. **Tests**: run `npm test` — any failure is in-scope.
+3. **Validation**: run `node scripts/validate-events.js` — fix schema/contract errors.
+4. **Broken fetchers**: a sport file in `docs/data/*.json` that's empty, malformed,
+   or errored in the pipeline log — the fetcher likely needs a fix.
+
+**Ignore non-bugs**: quota/rate-limit failures (check `docs/data/usage-state.json`
+— if the failures line up with `rejected`/near-exhausted, that's the governor's
+job, not yours), transient network blips (a single failure that already
+succeeded on the next run), and anything you cannot reproduce. Don't "fix" noise.
+
+## Fix it (safely)
+1. Reproduce the failure locally first (run the failing script/test) so you're
+   fixing the real cause, not guessing.
+2. `git checkout -b self-repair/$(date -u +%Y%m%d-%H%M)`.
+3. Make the **smallest** change that fixes the root cause.
+4. **Prove it**: re-run the exact thing that was broken (the test, the fetcher +
+   `validate-events.js`, etc.) AND run the full `npm test`. If you can't get to
+   green, `git checkout .`, do NOT open a PR, and log `action: "abandoned"` with
+   what you found. A known-broken thing beats a wrong fix merged unattended.
+5. Commit, push, open a PR:
+   `gh pr create --title "self-repair: <what broke>" --body "<root cause · fix · proof>"`.
+   Do NOT merge — the workflow re-gates and decides (see below).
+
+## What auto-merges vs waits for you
+The workflow re-runs the tests and inspects the PR's changed files:
+- **Auto-merges** only if EVERY changed file is in a safe path:
+  `scripts/fetch/**`, `scripts/lib/**`, `tests/**`, `docs/js/**`, `docs/css/**`, `docs/index.html`.
+- **Leaves the PR open for human review** if the fix touches anything sensitive —
+  `.github/workflows/**`, `package.json`, `scripts/config/**`, `scripts/hooks/**`,
+  `scripts/agents/**`. These change how the whole system behaves, so a human ships them.
+
+Prefer a fix that stays inside the safe paths when you can. If the only correct
+fix touches a sensitive path, still do it — it'll just wait for review; say so in
+the PR body.
+
+## Output
+- `docs/data/self-repair-log.json`:
+  `{ "runAt": ISO, "action": "opened-pr"|"none"|"skipped-existing-pr"|"abandoned", "pr": <url|null>, "diagnosed": "…", "fixed": ["…"], "autoMergeEligible": bool, "notes": ["…"] }`
+- If nothing is broken, write `action: "none"` and stop. If an open `self-repair/`
+  PR already exists, stop (`skipped-existing-pr`).
+
+## Hard constraints
+- NEVER edit `scripts/config/interests.json` (user-owned).
+- NEVER merge or push to `main` yourself — branch + PR only.
+- Fix real breakage only; never touch data the pipeline/agents own as content.
+- Stop after ~15 minutes.

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -9,7 +9,7 @@ const wf = (f) => fs.readFileSync(path.resolve(process.cwd(), ".github", "workfl
 describe("v2 workflows", () => {
 	it("exactly the expected agent workflows exist (old autopilot removed)", () => {
 		const dir = fs.readdirSync(path.resolve(".github", "workflows"));
-		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "usage-monitor.yml", "ui-fix-agent.yml"]) {
+		for (const f of ["static-pipeline.yml", "research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "usage-monitor.yml", "ui-fix-agent.yml", "self-repair-agent.yml", "improve-agent.yml"]) {
 			expect(dir, f).toContain(f);
 		}
 		for (const f of ["claude-autopilot.yml", "update-sports-data.yml", "claude-maintenance.yml"]) {
@@ -35,6 +35,8 @@ describe("v2 workflows", () => {
 			["coverage-critic-agent.yml", "scripts/agents/coverage-critic.md"],
 			["visual-qa-agent.yml", "scripts/agents/visual-qa.md"],
 			["ui-fix-agent.yml", "scripts/agents/ui-fix.md"],
+			["self-repair-agent.yml", "scripts/agents/self-repair.md"],
+			["improve-agent.yml", "scripts/agents/improve.md"],
 		]) {
 			const content = wf(file);
 			expect(content).toContain("CLAUDE_CODE_OAUTH_TOKEN");
@@ -44,7 +46,7 @@ describe("v2 workflows", () => {
 	});
 
 	it("every agent gates on the usage governor, and the monitor feeds it", () => {
-		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml"]) {
+		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml", "self-repair-agent.yml", "improve-agent.yml"]) {
 			expect(wf(f), `${f} must run the usage gate`).toContain("scripts/usage-gate.js");
 			expect(wf(f), `${f} must condition the agent on the gate`).toContain("steps.usage.outputs.run == 'true'");
 		}
@@ -55,7 +57,7 @@ describe("v2 workflows", () => {
 	});
 
 	it("agent workflows have concurrency guards", () => {
-		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml"]) {
+		for (const f of ["research-agent.yml", "verify-agent.yml", "editorial-agent.yml", "static-pipeline.yml", "scout-agent.yml", "coverage-critic-agent.yml", "visual-qa-agent.yml", "ui-fix-agent.yml", "self-repair-agent.yml", "improve-agent.yml"]) {
 			expect(wf(f), f).toContain("concurrency:");
 		}
 	});


### PR DESCRIPTION
Completes "the system evolves and fixes itself" — as two more **narrow, verifiable** loops (deliberately *not* a v1-style autopilot).

## self-repair — the mechanic (daily, auto-merge safe paths)
Fixes the machine itself, which nothing did before:
- Detects **real breakage**: failed workflow runs, failing `npm test`, `validate-events` errors, broken fetchers. Ignores quota/transient failures (not code bugs).
- Fixes on a branch, **proves it** (re-runs the broken thing + full tests), opens a PR.
- The workflow re-gates tests **and enforces a deterministic safe-path allowlist**: auto-merges only if every changed file is in `scripts/fetch`, `scripts/lib`, `tests`, `docs/js`, `docs/css`, or `index.html`. Anything sensitive (`.github/workflows`, config, hooks, agent prompts, `package.json`) → **PR left open for you**.

## improve — evolution (weekly, proposal-only)
- Mines the agents' logs + calibration for **one evidenced improvement** (a flaky source to drop, a skill/prompt/threshold to tune, an under-served interest) and opens a PR **you review** — never auto-merged, because "what should we do better" is a judgment call.
- Hard bias baked into the prompt: **sharpen what exists over adding machinery** — v1 died of complexity, and this loop is built to not repeat that.

## Guardrails
Both governor-gated (skip under quota pressure), branch+PR only, `interests.json` untouchable, pinned by coherence tests. Auto-merge is reserved for self-repair's safe paths + ui-fix; all capability/behavior changes stay human-gated. **173 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)