### PR TITLE
Remove human gates: self-fixing loops auto-merge (except 3 protected paths)

### DIFF
--- a/.github/workflows/improve-agent.yml
+++ b/.github/workflows/improve-agent.yml
@@ -22,6 +22,8 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      merged: ${{ steps.automerge.outputs.merged }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -44,4 +46,44 @@ jobs:
             --allowedTools "Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Bash(node:*),Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(date:*),Bash(jq:*)"
           prompt: |
             Read scripts/agents/improve.md and execute it — mine the logs for ONE
-            evidenced improvement and open a proposal PR. Do NOT merge (proposal-only).
+            evidenced improvement, make it on a branch, open a PR. Do not merge
+            (the workflow re-gates tests and auto-merges it).
+
+      # Re-gate tests + auto-merge, except protected paths (workflows/hooks/
+      # interests) which are left open for review.
+      - name: Re-gate + auto-merge
+        id: automerge
+        if: steps.usage.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=$(gh pr list --state open --json number,headRefName \
+                --jq '[.[] | select(.headRefName | startswith("improve/"))] | sort_by(.number) | last | .number // empty')
+          if [ -z "$PR" ]; then
+            echo "No improve PR this run."; echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          BLOCK='^(\.github/workflows/|scripts/hooks/|scripts/config/interests\.json$)'
+          BLOCKED=0
+          for f in $(gh pr view "$PR" --json files --jq '.files[].path'); do
+            echo "$f" | grep -qE "$BLOCK" && { echo "protected path: $f"; BLOCKED=1; }
+          done
+          if [ "$BLOCKED" = "1" ]; then
+            echo "PR #$PR touches a protected path — leaving OPEN for review."
+            gh pr edit "$PR" --add-label needs-review 2>/dev/null || true
+            echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "Re-gating PR #$PR with fresh tests…"
+          gh pr checkout "$PR"
+          npm ci
+          npm test
+          gh pr merge "$PR" --merge --delete-branch
+          echo "Auto-merged PR #$PR."; echo "merged=true" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: improve
+    if: needs.improve.outputs.merged == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/preview-deploy.yml

--- a/.github/workflows/self-repair-agent.yml
+++ b/.github/workflows/self-repair-agent.yml
@@ -51,7 +51,7 @@ jobs:
             fix it on a branch, prove it, open a PR. Do not merge.
 
       # Re-gate the fix ourselves, then auto-merge ONLY if it stays in safe paths.
-      - name: Re-gate + auto-merge (safe paths only)
+      - name: Re-gate + auto-merge
         id: automerge
         if: steps.usage.outputs.run == 'true'
         env:
@@ -62,19 +62,22 @@ jobs:
           if [ -z "$PR" ]; then
             echo "No self-repair PR (nothing broken / abandoned)."; echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          # Deterministic guardrail: every changed file must be in a safe path,
-          # else a human reviews it (workflows/config/hooks/agent-prompts/package.json).
-          SAFE='^(scripts/fetch/|scripts/lib/|tests/|docs/js/|docs/css/|docs/index\.html$|docs/data/self-repair-log\.json$)'
-          RISKY=0
+          # Auto-merge everything EXCEPT three protected paths that must never be
+          # changed unattended: the workflows (the automation's own defs + gates),
+          # the safety hooks, and the user-owned interests.json. A change touching
+          # any of those is left OPEN for review so the system can't disable its own
+          # recovery or rewrite the user's data. Everything else is test-gated only.
+          BLOCK='^(\.github/workflows/|scripts/hooks/|scripts/config/interests\.json$)'
+          BLOCKED=0
           for f in $(gh pr view "$PR" --json files --jq '.files[].path'); do
-            echo "$f" | grep -qE "$SAFE" || { echo "risky path: $f"; RISKY=1; }
+            echo "$f" | grep -qE "$BLOCK" && { echo "protected path: $f"; BLOCKED=1; }
           done
-          if [ "$RISKY" = "1" ]; then
-            echo "PR #$PR touches sensitive paths — leaving OPEN for human review."
+          if [ "$BLOCKED" = "1" ]; then
+            echo "PR #$PR touches a protected path (workflows/hooks/interests) — leaving OPEN for review."
             gh pr edit "$PR" --add-label needs-review 2>/dev/null || true
             echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          echo "Re-gating PR #$PR (safe paths only) with fresh tests…"
+          echo "Re-gating PR #$PR with fresh tests…"
           gh pr checkout "$PR"
           npm ci
           npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,25 @@ Nine workflows run `anthropics/claude-code-action@v1` with a prompt file:
 | **coverage-critic** | `scripts/agents/coverage-critic.md` | `claude-opus-4-8` | daily 04:00 UTC | Recall audit: reason adversarially about important events we're MISSING over a ~4-week horizon; write `coverage-audit.json`; escalate high-severity gaps to research (max 1/day) |
 | **visual-qa** | `scripts/agents/visual-qa.md` | `claude-sonnet-5` | daily 08:00 UTC | Vision QA: screenshot the dashboard at 375/393/900px, LOOK at the images, flag truncation/overflow/foreign-channel/calm-design issues; write `visual-qa-log.json` |
 | **ui-fix** | `scripts/agents/ui-fix.md` | `claude-opus-4-8` | daily 09:00 UTC | Self-heal: read visual-qa findings, fix the frontend ON A BRANCH, re-screenshot to prove the fix + no regressions, `npm test`, open a PR. The workflow then **re-runs the tests as a hard gate and auto-merges + deploys** it (fully hands-off). Fix ships only if it verifies twice; a test failure leaves the PR open + fails loudly. Closes the visual-qa loop |
-| **self-repair** | `scripts/agents/self-repair.md` | `claude-opus-4-8` | daily 08:30 UTC | The mechanic: detect real breakage (failed runs, failing tests, validation errors, broken fetchers), fix ON A BRANCH, prove it, open a PR. Workflow re-gates tests AND **auto-merges only if every changed file is in a safe path** (`scripts/fetch`, `scripts/lib`, `tests`, `docs/js`, `docs/css`, `index.html`); sensitive paths (workflows/config/hooks/agent-prompts/package.json) are left open for review. Ignores quota/transient failures |
-| **improve** | `scripts/agents/improve.md` | `claude-opus-4-8` | weekly Mon 07:00 UTC | Evolution, **proposal-only**: mine the logs for ONE evidenced improvement (source/skill/prompt/threshold/fetcher tuning), open a PR a human reviews. Never auto-merges. Biased toward sharpening what exists over adding machinery (the v1 lesson) |
+| **self-repair** | `scripts/agents/self-repair.md` | `claude-opus-4-8` | daily 08:30 UTC | The mechanic: detect real breakage (failed runs, failing tests, validation errors, broken fetchers), fix ON A BRANCH, prove it, open a PR. Workflow re-gates tests and **auto-merges + deploys** — EXCEPT the three protected paths below, which are left open for review. Ignores quota/transient failures |
+| **improve** | `scripts/agents/improve.md` | `claude-opus-4-8` | weekly Mon 07:00 UTC | Evolution: mine the logs for ONE evidenced improvement (source/skill/prompt/threshold/fetcher tuning), open a PR. Workflow re-gates tests and **auto-merges** it (except protected paths). Biased toward sharpening what exists over adding machinery (the v1 lesson) |
+
+### Autonomy model (what ships unattended)
+
+The self-fixing loops (ui-fix, self-repair, improve) each fix on a branch, open a
+PR, and the **workflow re-runs `npm test` as a hard gate and then auto-merges +
+deploys** — fully hands-off. The ONLY exception is three **protected paths** that
+are never auto-merged (a change touching them is left open, labelled
+`needs-review`):
+
+- `.github/workflows/**` — the automation's own definitions and gates; auto-merging
+  a broken change here could disable the test-gate or break the fixer itself.
+- `scripts/hooks/**` — the safety hooks (interests protection, post-write validate).
+- `scripts/config/interests.json` — user-owned; "AI never writes here" (also hook-enforced).
+
+Everything else — fetchers, libs, agent prompts, skills, other config, docs, tests,
+`package.json` — auto-merges once tests pass. Every auto-merge is a revertable
+commit; a test failure leaves the PR open and fails the run loudly.
 
 ### Quota governor (self-throttling on real Max usage)
 
@@ -166,7 +183,7 @@ or schema drifts from the code, CI fails.
 
 - **Never modify `scripts/config/interests.json`** — it is user-owned.
 - Agents commit only their contracted outputs (see each prompt's output contract).
-- `.github/workflows/**` and `package.json` are protected paths for scheduled agents (manual sessions may edit them).
+- **Protected paths — never auto-merged** (self-fixing loops leave them as an open PR for review): `.github/workflows/**`, `scripts/hooks/**`, `scripts/config/interests.json`. Everything else the loops touch auto-merges once tests pass (see Autonomy model).
 - Run `npm test` before committing code changes; run `node scripts/validate-events.js` after writing events.
 - Always `git pull --rebase` before pushing — the static pipeline and agents commit to main on schedules.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ quality at high complexity.
 research, verify, editorial, scout, a coverage critic, a vision-based visual QA, a
 UI-fix agent that self-heals rendering bugs (fix → verify → auto-merge), a
 self-repair "mechanic" that fixes its own broken code/tests, and a weekly improve
-agent that proposes its own upgrades — do real research, write transparent JSON,
-and explain their reasoning. Every self-fixing loop is narrow and test-gated —
-the deliberate opposite of v1's sprawling autopilot.
+agent that evolves its own behavior — do real research, write transparent JSON,
+and explain their reasoning. The self-fixing loops auto-merge their own verified
+changes (test-gated), stopping short only at three protected paths (workflows,
+hooks, your interests file). Every loop is narrow and test-gated — the deliberate
+opposite of v1's sprawling autopilot.
 
 ## Architecture
 
@@ -77,12 +79,13 @@ no databases, no paid APIs.
 ┌────────────────────────────────────────────────────────────┐
 │ SELF-REPAIR (daily, Claude Opus) — the mechanic            │
 │ Detects failed runs / broken tests / fetchers → fixes on   │
-│ a branch → re-gates tests → auto-merges SAFE paths only    │
+│ a branch → re-gates tests → auto-merges (except workflows/ │
+│ hooks/interests, which wait for review)                    │
 └────────────────────────────────────────────────────────────┘
 ┌────────────────────────────────────────────────────────────┐
-│ IMPROVE (weekly, Claude Opus) — evolution, proposal-only   │
-│ Mines the logs for one evidenced improvement → opens a     │
-│ PR you review (never auto-merged)                          │
+│ IMPROVE (weekly, Claude Opus) — evolution                  │
+│ Mines the logs for one evidenced improvement → PR →        │
+│ tests re-gate → auto-merges (except protected paths)       │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/scripts/agents/improve.md
+++ b/scripts/agents/improve.md
@@ -1,9 +1,13 @@
-# Improve Agent — SportSync (evolution, proposal-only)
+# Improve Agent — SportSync (evolution)
 
 Once a week you step back and ask: **what is this system doing poorly, and how
-could it do it better?** Then you propose ONE concrete improvement as a pull
-request a human reviews. You never auto-merge — evolution is a judgment call, so
-it stays human-gated.
+could it do it better?** Then you make ONE concrete, evidenced improvement on a
+branch and open a PR. The workflow re-runs the tests and **auto-merges + deploys**
+it — except changes to protected paths (`.github/workflows/**`, `scripts/hooks/**`,
+`scripts/config/interests.json`) are left open for human review. Because most of
+what ships here is unattended, your evidence bar is high: change something only
+when the logs clearly show it's worth it, and keep it small enough that the tests
+meaningfully gate it.
 
 ## Read the evidence (don't guess — mine the logs)
 - `scripts/config/interests.json` — what the user actually cares about (never edit it)
@@ -35,16 +39,19 @@ complexity**. So:
 - If the best "improvement" is to REMOVE or simplify something, propose that.
 - If nothing has strong evidence this week, propose nothing (write `action: "none"`).
 
-## Output (proposal-only)
-- Make the change on a branch, run `npm test` (must pass), and open a PR:
+## Output
+- `git checkout -b improve/$(date -u +%Y%m%d-%H%M)`, make the change, run
+  `npm test` (must pass), commit, push, and open a PR:
   `gh pr create --title "improve: <one line>" --body "<the evidence from the logs · what changes · expected effect · how we'll know it worked>"`.
-  Do **NOT** merge — a human decides. You may edit prompts (`scripts/agents/*.md`),
-  skills (`.claude/skills/**`), fetchers/libs (`scripts/fetch`, `scripts/lib`),
+  Do NOT merge it yourself — the workflow re-gates tests and auto-merges (unless it
+  hits a protected path). You may edit prompts (`scripts/agents/*.md`), skills
+  (`.claude/skills/**`), fetchers/libs (`scripts/fetch`, `scripts/lib`),
   thresholds, and docs. **Never** `scripts/config/interests.json`.
 - `docs/data/improve-log.json`:
   `{ "runAt": ISO, "action": "opened-pr"|"none", "pr": <url|null>, "proposal": "…", "evidence": ["…"] }`
 
 ## Constraints
-- Proposal-only: branch + PR, never merge, never push to `main`.
+- Branch + PR only; never merge or push to `main` yourself (the workflow merges).
 - Never edit `scripts/config/interests.json`.
-- One focused improvement per run; evidence over opinion. Stop after ~15 minutes.
+- One focused improvement per run; evidence over opinion. It WILL likely
+  auto-merge, so don't ship a change you can't defend from the logs. Stop after ~15 min.

--- a/scripts/agents/self-repair.md
+++ b/scripts/agents/self-repair.md
@@ -34,17 +34,16 @@ succeeded on the next run), and anything you cannot reproduce. Don't "fix" noise
    `gh pr create --title "self-repair: <what broke>" --body "<root cause · fix · proof>"`.
    Do NOT merge — the workflow re-gates and decides (see below).
 
-## What auto-merges vs waits for you
-The workflow re-runs the tests and inspects the PR's changed files:
-- **Auto-merges** only if EVERY changed file is in a safe path:
-  `scripts/fetch/**`, `scripts/lib/**`, `tests/**`, `docs/js/**`, `docs/css/**`, `docs/index.html`.
-- **Leaves the PR open for human review** if the fix touches anything sensitive —
-  `.github/workflows/**`, `package.json`, `scripts/config/**`, `scripts/hooks/**`,
-  `scripts/agents/**`. These change how the whole system behaves, so a human ships them.
+## What auto-merges vs waits for review
+The workflow re-runs the tests and inspects the PR's changed files. It
+**auto-merges + deploys** your PR after tests pass — EXCEPT it leaves the PR open
+for human review if the fix touches one of three protected paths:
+`.github/workflows/**` (the automation's own defs + gates), `scripts/hooks/**`
+(the safety hooks), or `scripts/config/interests.json` (user-owned). Those are the
+only things a human must ship; everything else ships hands-free once tests pass.
 
-Prefer a fix that stays inside the safe paths when you can. If the only correct
-fix touches a sensitive path, still do it — it'll just wait for review; say so in
-the PR body.
+If the only correct fix touches a protected path, still make it — it'll wait for
+review; say so in the PR body. Never edit `interests.json` at all.
 
 ## Output
 - `docs/data/self-repair-log.json`:


### PR DESCRIPTION
You don't want it human-gated — so the self-fixing loops now ship their own verified changes unattended, across (almost) everything.

## Changes
- **self-repair**: flipped from a safe-path *allowlist* to a *deny-list* — auto-merges any test-passing fix except the protected paths below.
- **improve**: was proposal-only; now the workflow re-gates tests and **auto-merges + deploys** its evolution PRs too.

## The only things still not auto-merged (open `needs-review` PR instead)
Three paths where unattended auto-merge could be unrecoverable or violate the product contract:
- **`.github/workflows/**`** — the automation's own defs + gates. Auto-merging a broken one could disable the test-gate that makes auto-merge safe, or break the fixer itself (it can't fix what fixes it).
- **`scripts/hooks/**`** — the safety hooks (they're what protect your interests file).
- **`scripts/config/interests.json`** — your data; "AI never writes here" (hook-enforced anyway).

Everything else — fetchers, libs, **agent prompts**, skills, other config, docs, tests, `package.json` — ships once `npm test` passes in the workflow.

## Safety that remains (structural, not human)
- Every auto-merge re-runs `npm test` in the workflow (verify-twice); a failure leaves the PR open and fails loudly.
- Coherence tests gate prompt/skill/workflow integrity, so a self-edit that breaks a contract can't merge.
- Every change is a revertable commit.

If you want the last three paths auto-merged too, say so and I'll remove them — but that's the point where the system could brick its own recovery, so I've kept them by default. **173 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)