### PR TITLE
Redesign: Tekst-TV — original teletext-inspired identity

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -4,42 +4,54 @@
    restrained accent used only where it earns attention (live, must-see). */
 
 :root {
-	/* Dark — quiet, near-black */
-	--bg: #0c0e11;
-	--surface: #14171b;
-	--fg: #eceef1;
-	--fg-2: #9298a1;
-	--fg-3: #5f656e;
-	--line: #21252b;
-	--accent: #e8825a;   /* warm, low-saturation — a whisper, not a shout */
-	--live: #f0564b;
+	/* Tekst-TV, reborn — a premium modern take on NRK teletext sport pages:
+	   near-black "page", monospace, the teletext colour language led by amber. */
+	/* Dark (default) — the page */
+	--bg: #08090c;
+	--surface: #111318;
+	--fg: #e9ecef;
+	--fg-2: #949aa3;
+	--fg-3: #5b616b;
+	--line: rgba(255, 255, 255, 0.09);
+	--accent: #ffb454;        /* teletext amber — leads the palette */
+	--accent-ink: #08090c;    /* dark text on an amber block */
+	--accent-wash: rgba(255, 180, 84, 0.13);
+	--cyan: #66d0ff;          /* teletext cyan — secondary / links */
+	--live: #ff5b54;          /* teletext red — live */
 
-	--font: "Schibsted Grotesk", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-	--max-w: 640px;
+	--font: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, "Cascadia Mono", monospace;
+	--display: var(--font);
+	--max-w: 680px;
 }
 
 :root[data-theme="light"] {
-	--bg: #f6f3 ec;
-	--bg: #f6f3ec;
-	--surface: #fffdf9;
-	--fg: #1c1915;
-	--fg-2: #6e6960;
-	--fg-3: #a29c90;
-	--line: #e7e2d7;
-	--accent: #c25a34;
-	--live: #cf3b30;
+	/* A clean "paper" sibling — same mono + structure carries the identity */
+	--bg: #f4f4f1;
+	--surface: #ffffff;
+	--fg: #14161a;
+	--fg-2: #5a616b;
+	--fg-3: #9aa0a8;
+	--line: rgba(20, 24, 34, 0.12);
+	--accent: #b26a12;
+	--accent-ink: #ffffff;
+	--accent-wash: rgba(178, 106, 18, 0.12);
+	--cyan: #0e7fb8;
+	--live: #d33a30;
 }
 
 @media (prefers-color-scheme: light) {
 	:root:not([data-theme="dark"]) {
-		--bg: #f6f3ec;
-		--surface: #fffdf9;
-		--fg: #1c1915;
-		--fg-2: #6e6960;
-		--fg-3: #a29c90;
-		--line: #e7e2d7;
-		--accent: #c25a34;
-		--live: #cf3b30;
+		--bg: #f4f4f1;
+		--surface: #ffffff;
+		--fg: #14161a;
+		--fg-2: #5a616b;
+		--fg-3: #9aa0a8;
+		--line: rgba(20, 24, 34, 0.12);
+		--accent: #b26a12;
+		--accent-ink: #ffffff;
+		--accent-wash: rgba(178, 106, 18, 0.12);
+		--cyan: #0e7fb8;
+		--live: #d33a30;
 	}
 }
 
@@ -50,7 +62,7 @@ body {
 	background: var(--bg);
 	color: var(--fg);
 	font-family: var(--font);
-	font-size: 16px;
+	font-size: 15px;
 	line-height: 1.5;
 	font-weight: 400;
 	font-feature-settings: "tnum" 1;   /* tabular numerals — times line up */

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -37,19 +37,39 @@
 	@keyframes breathe { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 }
 
-/* Day groups */
+/* Day groups — a teletext section header (amber block + label) over a boxed table */
 .day {
-	margin-top: 34px;
+	margin-top: 22px;
 }
-.day:first-of-type { margin-top: 26px; }
+.day:first-of-type { margin-top: 10px; }
 .day-name {
-	font-size: 13px;
+	font-size: 12px;
 	font-weight: 600;
-	color: var(--fg-3);
-	letter-spacing: 0.02em;
-	margin-bottom: 4px;
+	color: var(--accent);
+	letter-spacing: 0.10em;
+	text-transform: uppercase;
+	margin: 0 0 7px 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+/* A teletext block glyph leading the section label */
+.day-name::before {
+	content: "";
+	width: 9px;
+	height: 13px;
+	background: var(--accent);
 }
 .day.is-today .day-name { color: var(--accent); }
+
+/* The boxed "table" holding a day's rows — flat, bordered, teletext */
+.day-card {
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	background: var(--surface);
+	padding: 2px 13px;
+	overflow: hidden;
+}
 
 .ev-wrap { border-bottom: 1px solid var(--line); }
 .ev-wrap:last-child { border-bottom: none; }
@@ -57,12 +77,16 @@
 /* Event row — icon · time · what · where. Scan by the visual anchor, not by reading. */
 .ev {
 	display: grid;
-	grid-template-columns: 30px 44px 1fr auto 12px;
+	grid-template-columns: 30px 46px 1fr auto 12px;
 	gap: 10px;
 	align-items: center;
-	padding: 11px 0;
+	padding: 11px 5px;
+	margin: 0 -5px;
+	border-radius: 6px;
+	transition: background 0.12s;
 }
 .ev.expandable { cursor: pointer; }
+.ev.expandable:hover { background: color-mix(in srgb, var(--fg) 6%, transparent); }
 .ev.expandable:hover .ev-title { color: var(--accent); }
 
 .ev-flag { font-size: 15px; margin-right: 6px; vertical-align: -1px; }
@@ -82,14 +106,15 @@
 .ev-detail a { color: var(--accent); border-bottom: 1px solid transparent; }
 .ev-detail a:hover { border-bottom-color: var(--accent); }
 
-/* Sport badge — the quick "what kind of activity" indicator */
+/* Sport badge — a small teletext cell; the emoji carries the sport */
 .ev-badge {
 	width: 30px; height: 30px;
-	border-radius: 50%;
+	border-radius: 5px;
 	display: grid; place-items: center;
 	font-size: 15px;
 	line-height: 1;
-	background: color-mix(in srgb, var(--sport-color) 15%, transparent);
+	background: color-mix(in srgb, var(--fg) 6%, transparent);
+	border: 1px solid var(--line);
 }
 
 .ev-time {
@@ -120,10 +145,29 @@
 	margin-right: 5px;
 }
 
-/* Must-see: a quiet accent ring on the badge + warm time — recognisable, not loud */
-.ev.must .ev-title { font-weight: 600; }
-.ev.must .ev-badge { box-shadow: 0 0 0 1.5px var(--accent); }
-.ev.must .ev-time { color: var(--accent); }
+/* Must-see: an amber teletext highlight — amber block, wash + amber time/title */
+.ev.must {
+	background: var(--accent-wash);
+	box-shadow: inset 3px 0 0 0 var(--accent);
+}
+.ev.must.expandable:hover { background: var(--accent-wash); }
+.ev.must .ev-title { font-weight: 600; color: var(--accent); }
+.ev.must .ev-badge { border-color: var(--accent); }
+.ev.must .ev-time { color: var(--accent); font-weight: 600; }
+
+/* Gentle staggered reveal on load — a little life, respectful of reduced-motion */
+@media (prefers-reduced-motion: no-preference) {
+	.hero { animation: ss-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both; animation-delay: 0.02s; }
+	/* Only on the first render (#agenda.reveal), never on live-poll re-renders */
+	#agenda.reveal .day { animation: ss-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+	#agenda.reveal .day:nth-of-type(1) { animation-delay: 0.09s; }
+	#agenda.reveal .day:nth-of-type(2) { animation-delay: 0.15s; }
+	#agenda.reveal .day:nth-of-type(3) { animation-delay: 0.21s; }
+	#agenda.reveal .day:nth-of-type(4) { animation-delay: 0.27s; }
+	#agenda.reveal .day:nth-of-type(5) { animation-delay: 0.33s; }
+	#agenda.reveal .day:nth-of-type(n+6) { animation-delay: 0.39s; }
+	@keyframes ss-rise { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: none; } }
+}
 
 /* Collapsed stage race (e.g. Tour de France): past stages dimmed when expanded */
 .ev-detail .d-row.stage.past { opacity: 0.45; }
@@ -131,14 +175,16 @@
 /* Quiet "show the rest of the fortnight" control */
 .agenda-more {
 	display: block;
-	width: 100%;
-	margin-top: 28px;
-	padding: 10px 0;
-	font-size: 14px;
+	margin: 22px auto 0;
+	padding: 10px 20px;
+	font-size: 13px;
+	font-weight: 500;
 	color: var(--fg-2);
-	text-align: center;
+	background: var(--surface);
+	border: 1px solid var(--line);
+	border-radius: 6px;
 }
-.agenda-more:hover { color: var(--accent); }
+.agenda-more:hover { color: var(--accent); border-color: var(--accent); }
 
 .ai-badge { font-size: 11px; color: var(--fg-3); margin-left: 4px; vertical-align: 1px; }
 .ai-badge:hover { color: var(--accent); }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -11,35 +11,76 @@
 	.wrap { padding: 0 16px; }
 }
 
+/* Masthead — a teletext header row: page name + number, a ticking clock */
 .masthead {
-	padding-top: calc(env(safe-area-inset-top) + 26px);
+	position: sticky;
+	top: 0;
+	z-index: 30;
+	padding-top: calc(env(safe-area-inset-top) + 12px);
+	padding-bottom: 10px;
+	background: var(--bg);
+	border-bottom: 1px solid var(--line);
 }
 .masthead-inner {
 	display: flex;
 	align-items: baseline;
-	justify-content: space-between;
-	gap: 16px;
+	gap: 14px;
 }
 .wordmark {
-	font-size: 19px;
-	font-weight: 600;
-	letter-spacing: -0.02em;
+	font-weight: 700;
+	font-size: 18px;
+	letter-spacing: -0.01em;
 	color: var(--fg);
+	text-transform: uppercase;
 }
-.masthead-date {
-	font-size: 14px;
+/* The teletext page number, in amber, like a real Tekst-TV header */
+.tt-page {
+	color: var(--accent);
+	margin-left: 8px;
+	font-weight: 600;
+}
+.masthead-clock {
+	margin-left: auto;
+	font-size: 13px;
+	font-weight: 500;
 	color: var(--fg-2);
-	text-transform: capitalize;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 0.02em;
 }
 .theme-toggle {
 	font-size: 16px;
-	color: var(--fg-3);
-	padding: 4px;
+	color: var(--fg-2);
+	padding: 2px 4px;
 	line-height: 1;
+	transition: color 0.15s;
 }
-.theme-toggle:hover { color: var(--fg-2); }
+.theme-toggle:hover { color: var(--accent); }
 
-main { padding: 8px 0 60px; }
+main { padding: 14px 0 72px; }
+
+/* Hero — the brief, set like a teletext deck: monospace, tight, one amber word. */
+.hero {
+	padding: 20px 0 24px;
+}
+.hero-eyebrow {
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--accent);
+	margin-bottom: 12px;
+}
+.hero-headline {
+	font-weight: 600;
+	font-size: clamp(21px, 4.6vw, 29px);
+	line-height: 1.25;
+	letter-spacing: -0.01em;
+	color: var(--fg);
+	text-wrap: balance;
+	max-width: 30ch;
+}
+.hero-headline .em { color: var(--accent); }
+.hero:empty, .hero-headline:empty { display: none; }
 
 .site-footer {
 	margin-top: 48px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 	<title>SportSync</title>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Schibsted+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="css/base.css">
 	<link rel="stylesheet" href="css/layout.css">
 	<link rel="stylesheet" href="css/cards.css">
@@ -23,14 +23,17 @@
 <body>
 	<header class="masthead">
 		<div class="wrap masthead-inner">
-			<span class="wordmark">SportSync</span>
-			<span class="masthead-date" id="header-date"></span>
+			<span class="wordmark">SportSync<span class="tt-page">285</span></span>
+			<span class="masthead-clock" id="masthead-clock" aria-hidden="true"></span>
 			<button class="theme-toggle" id="theme-toggle" title="Bytt tema" aria-label="Bytt tema">◐</button>
 		</div>
 	</header>
 
 	<main class="wrap">
-		<p class="today-line" id="today-line" hidden></p>
+		<section class="hero" id="hero">
+			<p class="hero-eyebrow" id="hero-date"></p>
+			<h1 class="hero-headline" id="hero-headline"></h1>
+		</section>
 		<div class="live-now" id="live-now" hidden></div>
 		<div id="agenda"></div>
 		<details class="followed" id="followed" hidden>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -18,6 +18,7 @@ class Dashboard {
 	async init() {
 		this.initTheme();
 		this.renderDate();
+		this.startClock();
 		await this.loadData();
 		this.render();
 		this.startLivePolling();
@@ -71,20 +72,48 @@ class Dashboard {
 		el.hidden = false;
 	}
 
-	// ── Header ──────────────────────────────────────────────────────────────
+	// ── Hero (the editorial brief) ────────────────────────────────────────────
 	renderDate() {
-		const el = document.getElementById('header-date');
+		const el = document.getElementById('hero-date');
 		if (el) el.textContent = new Date().toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/Oslo' });
 	}
 
-	/** One quiet editorial line under the date — the "nice extra", never a section. */
-	renderTodayLine() {
-		const el = document.getElementById('today-line');
+	/** Teletext-style ticking clock in the header. */
+	startClock() {
+		const el = document.getElementById('masthead-clock');
 		if (!el) return;
-		const headline = this.featured?.blocks?.find((b) => b.type === 'headline')?.text;
-		if (!headline) { el.hidden = true; return; }
-		el.textContent = headline;
-		el.hidden = false;
+		const tick = () => {
+			el.textContent = new Date().toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'Europe/Oslo' });
+		};
+		tick();
+		clearInterval(this._clockInterval);
+		this._clockInterval = setInterval(tick, 1000);
+	}
+
+	/** The hero headline — the editorial brief, set large in the display serif. */
+	renderTodayLine() {
+		const el = document.getElementById('hero-headline');
+		if (!el) return;
+		const headline = this.featured?.blocks?.find((b) => b.type === 'headline')?.text || this.heroFallback();
+		el.innerHTML = this.emphasize(escapeHtml(headline));
+	}
+
+	/** Calm fallback when the editorial agent hasn't written a headline yet. */
+	heroFallback() {
+		return 'Sporten du følger — når det skjer, og hvor du ser det.';
+	}
+
+	/** Italic-accent the first Norwegian/tracked keyword — one editorial pop in the deck. */
+	emphasize(safe) {
+		const names = ['Norge', 'Norway', ...(this.interests?.alwaysTrack?.athletes || []), ...(this.interests?.alwaysTrack?.teams || [])];
+		const lower = safe.toLowerCase();
+		let best = -1, bestLen = 0;
+		for (const n of names) {
+			const i = lower.indexOf(n.toLowerCase());
+			if (i >= 0 && (best === -1 || i < best)) { best = i; bestLen = n.length; }
+		}
+		if (best === -1) return safe;
+		return safe.slice(0, best) + '<span class="em">' + safe.slice(best, best + bestLen) + '</span>' + safe.slice(best + bestLen);
 	}
 
 	renderFooter() {
@@ -232,10 +261,14 @@ class Dashboard {
 			if (key === todayKey) name = 'I dag';
 			else if (key === tomorrowKey) name = 'I morgen';
 			else name = new Date(evs[0].time).toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/Oslo' });
-			html += `<section class="day${key === todayKey ? ' is-today' : ''}"><div class="day-name">${escapeHtml(name)}</div>${evs.map((e) => this.eventRow(e)).join('')}</section>`;
+			html += `<section class="day${key === todayKey ? ' is-today' : ''}"><div class="day-name">${escapeHtml(name)}</div><div class="day-card">${evs.map((e) => this.eventRow(e)).join('')}</div></section>`;
 		}
 		if (hasMore) html += `<button type="button" class="agenda-more">Vis resten av de neste to ukene ›</button>`;
 		el.innerHTML = html;
+		// Play the entrance reveal ONCE on first load — not on every live-poll
+		// re-render (which would re-flash the whole agenda each minute).
+		if (!this._revealed) { el.classList.add('reveal'); this._revealed = true; }
+		else { el.classList.remove('reveal'); }
 	}
 
 	/** Fold same-tournament stage races (cycling "Etappe N", etc.) into one series item. */

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // SportSync v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-3';
+const CACHE_NAME = 'sportsync-v2-9';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -33,6 +33,7 @@ const positional = args.filter((a) => !a.startsWith("--"));
 const outputPath = path.resolve(positional[0] || path.join(rootDataPath(), "screenshot.png"));
 const width = parseInt(flags.find((f) => f.startsWith("--width="))?.split("=")[1] || "480", 10);
 const fullPage = flags.includes("--full-page");
+const colorScheme = flags.includes("--dark") ? "dark" : "light"; // --dark renders the OLED theme
 
 const docsDir = path.resolve(process.cwd(), "docs");
 
@@ -75,6 +76,7 @@ const { chromium } = require('playwright');
 	const page = await browser.newPage({
 		viewport: { width: ${width}, height: 900 },
 		deviceScaleFactor: 2,
+		colorScheme: ${JSON.stringify(colorScheme)},
 	});
 	await page.goto(${JSON.stringify(url)}, { waitUntil: 'domcontentloaded', timeout: 10000 }).catch(() => {});
 	await page.waitForTimeout(3000);


### PR DESCRIPTION
Ships SportSync's own visual identity: a premium modern reinterpretation of **NRK Tekst-TV** (the teletext sport pages every Norwegian fan grew up checking) — original, culturally rooted, not a template or an Apple imitation.

- Monospace throughout (IBM Plex Mono); near-black "page" (clean "paper" light variant)
- Teletext header: `SPORTSYNC 285` + a live ticking clock
- Amber-led palette (the warm accent, as classic teletext amber); section headers with the teletext block glyph; must-sees highlighted amber
- Boxed result tables per day, tabular data
- Keeps collapse-series, must-see, 7-day horizon, staleness + AI-budget features
- `screenshot.js` gains `--dark` so visual-qa can check both themes
- Reveal animation plays once on load (fixed: no longer re-flashes on live-poll)

173 tests pass; verified desktop + mobile, dark + light, and previewed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)