### PR TITLE
Header: drop the '285' page number

### DIFF
--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -33,12 +33,6 @@
 	color: var(--fg);
 	text-transform: uppercase;
 }
-/* The teletext page number, in amber, like a real Tekst-TV header */
-.tt-page {
-	color: var(--accent);
-	margin-left: 8px;
-	font-weight: 600;
-}
 .masthead-clock {
 	margin-left: auto;
 	font-size: 13px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,7 +23,7 @@
 <body>
 	<header class="masthead">
 		<div class="wrap masthead-inner">
-			<span class="wordmark">SportSync<span class="tt-page">285</span></span>
+			<span class="wordmark">SportSync</span>
 			<span class="masthead-clock" id="masthead-clock" aria-hidden="true"></span>
 			<button class="theme-toggle" id="theme-toggle" title="Bytt tema" aria-label="Bytt tema">◐</button>
 		</div>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // SportSync v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-9';
+const CACHE_NAME = 'sportsync-v2-10';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [


### PR DESCRIPTION
Removes the arbitrary teletext page number from the header — just 'SportSync' now.