### PR TITLE
Answer "when's X next?" — followed list becomes a next-event index

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -267,6 +267,32 @@
 .followed-item .until { margin-left: 8px; }
 .followed-item .why { display: block; margin-top: 2px; line-height: 1.45; }
 .chip-bell { font-size: 9px; margin-left: 4px; opacity: 0.8; vertical-align: 1px; }
+
+/* ── "Neste" index: one quiet row per followed athlete/team ────────────────
+   Answers "when's X next?" at a glance. A muted right-aligned relative day,
+   tap to expand when·what·where; an honest "ikke satt opp ennå" when empty. */
+.follow-next { list-style: none; margin: 0; padding: 0; }
+.fn-item { border-top: 1px solid var(--line); }
+.fn-item:first-child { border-top: none; }
+.fn-row { display: grid; grid-template-columns: 24px 1fr auto; gap: 10px; align-items: center; padding: 8px 4px; margin: 0 -4px; border-radius: 6px; }
+.fn-item.has-event .fn-row { cursor: pointer; transition: background 0.12s; }
+.fn-item.has-event .fn-row:hover { background: color-mix(in srgb, var(--fg) 6%, transparent); }
+.fn-item.has-event .fn-row:hover .fn-name { color: var(--accent); }
+.fn-row .ev-badge { width: 24px; height: 24px; font-size: 12px; }
+.fn-logo { width: 22px; height: 22px; object-fit: contain; }
+.fn-name { font-size: 14px; color: var(--fg); min-width: 0; overflow-wrap: break-word; }
+/* Honest gap, calm: sits under the name so it never crowds or clips the row. */
+.fn-sub { display: block; font-size: 11.5px; color: var(--fg-3); font-style: italic; margin-top: 1px; }
+.fn-when { font-size: 12.5px; color: var(--fg-2); text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; display: inline-flex; align-items: center; gap: 4px; }
+.fn-caret { color: var(--fg-3); font-size: 14px; opacity: 0.5; transition: transform 0.15s; }
+.fn-item.has-event .fn-row[aria-expanded="true"] .fn-caret { transform: rotate(90deg); }
+.fn-detail { padding: 2px 4px 12px 34px; display: grid; gap: 6px; font-size: 13px; }
+.fn-detail .d-row { display: flex; gap: 10px; align-items: baseline; }
+.fn-detail .d-k { color: var(--fg-3); min-width: 44px; flex-shrink: 0; }
+.fn-detail .d-v { color: var(--fg-2); }
+.fn-detail .tbd { color: var(--fg-3); font-style: italic; }
+.fn-detail a { color: var(--accent); border-bottom: 1px solid transparent; }
+.fn-detail a:hover { border-bottom-color: var(--accent); }
 .followed-note { font-size: 12.5px; color: var(--fg-3); line-height: 1.5; margin-top: 4px; }
 .followed-hint { font-size: 12.5px; color: var(--fg-3); font-style: italic; margin-top: 10px; }
 .followed-group { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-3); margin: 12px 0 5px; }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -23,6 +23,7 @@ class Dashboard {
 		this.render();
 		this.startLivePolling();
 		this.bindAgendaExpand();
+		this.bindFollowed();
 		this.maybeShowInstallHint();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
@@ -588,6 +589,10 @@ class Dashboard {
 	}
 
 	// ── "Hva vi følger" — one quiet disclosure at the bottom ──────────────────
+	// It answers the recurring "when's X next?" question, entity-first: for each
+	// athlete/team you follow, the next known event — UNWINDOWED (ignores the
+	// agenda's 14-day cap) so a match months out still shows, and honestly says
+	// "ikke satt opp ennå" when there's nothing scheduled. Tournaments stay chips.
 	renderFollowed() {
 		const wrap = document.getElementById('followed');
 		const body = document.getElementById('followed-body');
@@ -595,9 +600,6 @@ class Dashboard {
 		const at = this.interests && this.interests.alwaysTrack;
 		if (!at) { wrap.hidden = true; return; }
 
-		// Calm teaser only: chips of what you follow (🔔 = it reminds you). The full
-		// picture (broad interests, AI discoveries) and ALL editing live on the hub
-		// page (rediger.html) — keeps the dashboard an agenda, not a console.
 		const chip = (x, notifyDefault) => {
 			const notify = (x && typeof x === 'object' && x.notify != null) ? x.notify : notifyDefault;
 			return `<span class="chip-follow">${escapeHtml(ssEntityName(x))}${notify ? '<span class="chip-bell" title="Gir deg påminnelse">🔔</span>' : ''}</span>`;
@@ -605,13 +607,121 @@ class Dashboard {
 		const chipGroup = (label, items, notifyDefault) => (items || []).length
 			? `<div class="chip-group"><div class="chip-group-label">${label}</div><div class="chips-row">${items.map((x) => chip(x, notifyDefault)).join('')}</div></div>`
 			: '';
+		const nextGroup = (label, items, notifyDefault) => (items || []).length
+			? `<div class="chip-group"><div class="chip-group-label">${label}</div><ul class="follow-next">${items.map((x) => this.followRow(x, notifyDefault)).join('')}</ul></div>`
+			: '';
 		body.innerHTML = '<div class="followed-layer">'
-			+ chipGroup('Utøvere', at.athletes, true)
-			+ chipGroup('Lag', at.teams, true)
+			+ nextGroup('Utøvere', at.athletes, true)
+			+ nextGroup('Lag', at.teams, true)
 			+ chipGroup('Turneringer', at.tournaments, false)
-			+ `<div class="followed-hint">🔔 = kalendervarsel ${this.notifyLead()} min før start. <a class="followed-edit" href="rediger.html">Se og rediger alt du følger →</a></div>`
+			+ `<div class="followed-hint">🔔 = kalendervarsel ${this.notifyLead()} min før start · trykk en rad for detaljer. <a class="followed-edit" href="rediger.html">Se og rediger alt du følger →</a></div>`
 			+ '</div>';
 		wrap.hidden = false;
+	}
+
+	/** The next upcoming event for a followed entity, searched across ALL events
+	 *  (not the agenda window). Sport-scoped so "Barcelona" (football) never
+	 *  matches a Tour stage through the city. Returns the event or null. */
+	nextEventForEntity(entry) {
+		const terms = trackedTerms([entry]).map((t) => t.toLowerCase()).filter(Boolean);
+		if (!terms.length) return null;
+		const sport = (entry && typeof entry === 'object') ? entry.sport : null;
+		const floor = Date.now() - 3 * SS_CONSTANTS.MS_PER_HOUR;
+		let best = null, bestStart = Infinity;
+		for (const e of this.allEvents) {
+			if (sport && e.sport && e.sport !== sport) continue;
+			const start = new Date(e.time).getTime();
+			const end = e.endTime ? new Date(e.endTime).getTime() : start;
+			if (!(end >= floor)) continue; // already over
+			const hay = [e.title, e.tournament, e.homeTeam, e.awayTeam,
+				...(e.norwegianPlayers || []).map((p) => p.name || p),
+				...(e.participants || [])].filter(Boolean).join(' ');
+			if (!terms.some((t) => ssContainsTerm(hay, t))) continue;
+			if (start < bestStart) { best = e; bestStart = start; }
+		}
+		return best;
+	}
+
+	/** Calm relative-day label in Oslo terms. */
+	relDay(e) {
+		const now = Date.now();
+		const start = new Date(e.time).getTime();
+		const end = e.endTime ? new Date(e.endTime).getTime() : start;
+		if (start <= now && end >= now) return 'pågår nå';
+		const days = Math.round((Date.parse(this.osloDayKey(new Date(e.time))) - Date.parse(this.osloDayKey(new Date(now)))) / SS_CONSTANTS.MS_PER_DAY);
+		if (days <= 0) return 'i dag';
+		if (days === 1) return 'i morgen';
+		return `om ${days} dager`;
+	}
+
+	/** Leading mark for an entity: club crest if we have one, else the sport badge. */
+	entityMark(entry) {
+		const name = ssEntityName(entry);
+		const url = typeof getTeamLogo === 'function' ? getTeamLogo(name) : null;
+		if (url) return `<img class="fn-logo" src="${url}" alt="" loading="lazy" onerror="this.remove()">`;
+		return this.sportBadge({ sport: (entry && typeof entry === 'object') ? entry.sport : '' });
+	}
+
+	/** One row in the "neste" index: name + next event (or an honest gap). */
+	followRow(entry, notifyDefault) {
+		const name = escapeHtml(ssEntityName(entry));
+		const notify = (entry && typeof entry === 'object' && entry.notify != null) ? entry.notify : notifyDefault;
+		const bell = notify ? '<span class="chip-bell" title="Gir deg påminnelse">🔔</span>' : '';
+		const mark = this.entityMark(entry);
+		const next = this.nextEventForEntity(entry);
+		if (!next) {
+			return `<li class="fn-item no-event"><div class="fn-row">${mark}<span class="fn-name">${name}${bell}<span class="fn-sub">ikke satt opp ennå</span></span></div></li>`;
+		}
+		return `<li class="fn-item has-event"><div class="fn-row" role="button" tabindex="0" aria-expanded="false">
+			${mark}<span class="fn-name">${name}${bell}</span>
+			<span class="fn-when">${escapeHtml(this.relDay(next))}<span class="fn-caret" aria-hidden="true">›</span></span>
+		</div><div class="fn-detail" hidden>${this.followDetail(next)}</div></li>`;
+	}
+
+	/** The expanded when·what·where for a followed entity's next event. */
+	followDetail(e) {
+		const d = new Date(e.time);
+		const when = `${d.toLocaleDateString('nb-NO', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'Europe/Oslo' })} ${this.osloTime(d)}`;
+		const what = (e.homeTeam && e.awayTeam) ? `${ssShortName(e.homeTeam)} – ${ssShortName(e.awayTeam)}` : (e.title || '');
+		const streams = Array.isArray(e.streaming) ? e.streaming : [];
+		const chans = streams.length
+			? streams.map((s) => {
+				const p = escapeHtml(String(s.platform || s));
+				const label = s.tentative ? `${p} <span class="tbd">(bekreftes)</span>` : p;
+				return (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
+			}).join(' · ')
+			: '<span class="tbd">–</span>';
+		const rows = [
+			`<div class="d-row"><span class="d-k">Når</span><span class="d-v">${escapeHtml(when)}</span></div>`,
+			`<div class="d-row"><span class="d-k">Hva</span><span class="d-v">${escapeHtml(what)}</span></div>`,
+		];
+		if (e.tournament && e.tournament !== what) rows.push(`<div class="d-row"><span class="d-k">Turnering</span><span class="d-v">${escapeHtml(e.tournament)}</span></div>`);
+		rows.push(`<div class="d-row"><span class="d-k">Se på</span><span class="d-v">${chans}</span></div>`);
+		return rows.join('');
+	}
+
+	/** Tap/keyboard expand for the "neste" index rows (delegated, survives re-render). */
+	bindFollowed() {
+		const body = document.getElementById('followed-body');
+		if (!body || this._followedBound) return;
+		this._followedBound = true;
+		const toggle = (row) => {
+			const detail = row.parentElement.querySelector('.fn-detail');
+			if (!detail) return;
+			const open = row.getAttribute('aria-expanded') === 'true';
+			row.setAttribute('aria-expanded', String(!open));
+			detail.hidden = open;
+		};
+		body.addEventListener('click', (evt) => {
+			if (evt.target.closest('a')) return; // let channel/source links work
+			const row = evt.target.closest('.fn-item.has-event .fn-row');
+			if (row) toggle(row);
+		});
+		body.addEventListener('keydown', (evt) => {
+			if (evt.key !== 'Enter' && evt.key !== ' ') return;
+			const row = evt.target.closest('.fn-item.has-event .fn-row');
+			if (row) { evt.preventDefault(); toggle(row); }
+		});
 	}
 
 	// ── Live polling (ESPN, client-side) ─────────────────────────────────────

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -59,6 +59,19 @@ Static fetchers (ESPN-driven) miss:
 - Olympic / multi-sport events when active games run
 - Cross-sport notable moments
 
+**Next-fixture coverage per followed entity.** The dashboard answers "when is X
+next?" for every `alwaysTrack` athlete/team — UNWINDOWED (even months out). So for
+each one, make sure `events.json` holds at least their **next known dated fixture**;
+it need not fall inside any horizon. A followed entity with nothing upcoming shows
+the user an honest "ikke satt opp ennå" — treat that as a gap to investigate (e.g.
+Barcelona pre-season friendlies, Uno-X's next stage race, Ruud's next tournament,
+100 Thieves' next match). If after real searching there is genuinely no scheduled
+fixture, leave it — never invent one to fill the blank. So a per-entity row actually
+resolves, **name the relevant people/teams on the event**: put athletes in
+`norwegianPlayers` (or `participants`) and set `homeTeam`/`awayTeam` for matches —
+e.g. list Håvard Nygaard on a 100 Thieves match so his row resolves too, not just
+the club's.
+
 Use the **web-search** and **web-fetch** capabilities provided by your runtime. Source priority:
 - Norwegian: nrk.no/sport, tv2.no/sport, vg.no/sport, dagbladet.no/sport
 - Official: fis-ski.com, biathlonworld.com, uci.org, atptour.com, pgatour.com, espn.com

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -105,6 +105,47 @@ describe("whereToWatch — the core 'hvor kan jeg se det'", () => {
 	});
 });
 
+describe("followed 'neste' index — answers 'when's X next?'", () => {
+	const inDays = (n) => new Date(Date.now() + n * 86400000).toISOString();
+
+	it("finds the next upcoming event for a followed entity, ignoring the agenda window", () => {
+		dash.allEvents = [
+			{ sport: "tennis", title: "Wimbledon final (Casper Ruud)", time: inDays(40) },
+			{ sport: "tennis", title: "Swiss Open Gstaad (Casper Ruud)", time: inDays(6) },
+		];
+		const next = dash.nextEventForEntity({ name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis" });
+		expect(next.title).toContain("Swiss Open"); // the nearer one, though both are far out
+	});
+
+	it("is sport-scoped so a name collision in another sport doesn't match", () => {
+		dash.allEvents = [{ sport: "cycling", title: "Etappe 5: Barcelona – Girona", time: inDays(1) }];
+		expect(dash.nextEventForEntity({ name: "Barcelona", sport: "football" })).toBe(null);
+	});
+
+	it("renders an honest 'ikke satt opp ennå' when nothing is scheduled", () => {
+		dash.allEvents = [];
+		const html = dash.followRow({ name: "Aryan Tari", aliases: ["Tari"], sport: "chess" }, true);
+		expect(html).toContain("no-event");
+		expect(html).toContain("ikke satt opp ennå");
+		expect(html).not.toContain("fn-detail");
+	});
+
+	it("renders a tappable row with a relative 'neste' + expandable detail when scheduled", () => {
+		dash.allEvents = [{ sport: "esports", title: "BLAST Bounty – 100 Thieves", time: inDays(13), streaming: [{ platform: "Twitch" }] }];
+		const html = dash.followRow({ name: "100 Thieves", aliases: ["100T"], sport: "esports" }, true);
+		expect(html).toContain("has-event");
+		expect(html).toMatch(/om \d+ dager/);
+		expect(html).toContain("fn-detail");
+		expect(html).toContain("Twitch");
+	});
+
+	it("escapes HTML in entity names", () => {
+		dash.allEvents = [];
+		const html = dash.followRow({ name: "<script>x</script>", sport: "chess" }, false);
+		expect(html).not.toContain("<script>x");
+	});
+});
+
 describe("must-see selection follows the goal's priorities", () => {
 	it("favorite, importance>=4, or Norwegian participation", () => {
 		expect(dash.isMustSee({ isFavorite: true })).toBe(true);


### PR DESCRIPTION
## Hva

Dashboardet var tidssentrert (hva skjer de neste 14 dagene), men et tilbakevendende spørsmål er entitetssentrert: *når spiller Casper Ruud neste gang? når er 100 Thieves' neste CS2-kamp?* De faller ofte utenfor agendavinduet (Carlsen 35d, Lyn 18d) eller er ikke satt opp ennå — og var derfor usynlige.

«Hva vi følger»-disclosure-en nederst er gjort om til en **entitetssentrert «neste»-indeks**, uten å røre den rolige agendaen:

- Søker i **alle** events (avindusert) → neste kamp vises selv måneder fram
- Én rolig rad per utøver/lag: navn + «om N dager», trykk for **når · hva · turnering · se på**
- Ærlig **«ikke satt opp ennå»** (dempet undertittel) når ingenting er planlagt — både et svar til brukeren og et synlig dekningssignal
- Sport-scopet matching (så «Barcelona»/fotball aldri matcher en Tour-etappe)
- Turneringer forblir rolige chips

Research-agenten er også nudget til å holde neste kjente kamp per ting du følger i `events.json`, og tagge spillernavn på events (så Håvard Nygaard løses via 100 Thieves-kamper).

## Verifisert
- `npm test` — 230/230 grønne (5 nye tester for indeksen)
- Visuelt skjermdumpet i mørkt + lyst tema på 375px: ingen klipping, Tekst-TV-konsistent

## Filer
- `docs/js/dashboard.js` — `renderFollowed` omskrevet + `nextEventForEntity`/`relDay`/`entityMark`/`followRow`/`followDetail`/`bindFollowed`
- `docs/css/cards.css` — `.follow-next`-stiler
- `tests/dashboard-cards.test.js` — 5 nye tester
- `scripts/agents/research.md` — next-fixture-dekning + spiller-tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)