### PR TITLE
Promote "Dine neste" to a central top section above the agenda

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -293,6 +293,24 @@
 .fn-detail .tbd { color: var(--fg-3); font-style: italic; }
 .fn-detail a { color: var(--accent); border-bottom: 1px solid transparent; }
 .fn-detail a:hover { border-bottom-color: var(--accent); }
+
+/* ── "Dine neste": the compact top glance ─────────────────────────────────
+   A teletext peer of the day groups (amber label + boxed table), but tighter
+   rows and upcoming-only so it tops the agenda without burying it. */
+.next-up { margin: 18px 0 4px; }
+.nu-label {
+	font-size: 12px; font-weight: 600; color: var(--accent);
+	letter-spacing: 0.10em; text-transform: uppercase;
+	margin: 0 0 7px 0; display: flex; align-items: center; gap: 8px;
+}
+.nu-label::before { content: ""; width: 9px; height: 13px; background: var(--accent); }
+.next-up .follow-next { border: 1px solid var(--line); border-radius: 8px; background: var(--surface); padding: 2px 13px; overflow: hidden; }
+.next-up .fn-row { padding: 7px 4px; grid-template-columns: 22px 1fr auto; gap: 9px; }
+.next-up .fn-row .ev-badge { width: 22px; height: 22px; font-size: 11px; }
+.next-up .fn-logo { width: 20px; height: 20px; }
+.next-up .fn-when { font-size: 12.5px; }
+.nu-more { display: inline-block; margin-top: 8px; font-size: 12px; color: var(--fg-2); background: none; border: none; padding: 2px; cursor: pointer; }
+.nu-more:hover { color: var(--accent); }
 .followed-note { font-size: 12.5px; color: var(--fg-3); line-height: 1.5; margin-top: 4px; }
 .followed-hint { font-size: 12.5px; color: var(--fg-3); font-style: italic; margin-top: 10px; }
 .followed-group { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-3); margin: 12px 0 5px; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,7 @@
 		</section>
 		<p class="install-hint" id="install-hint" hidden></p>
 		<div class="live-now" id="live-now" hidden></div>
+		<section class="next-up" id="next-up" hidden></section>
 		<div id="agenda"></div>
 		<details class="followed" id="followed" hidden>
 			<summary id="followed-summary"><span>Hva vi følger</span><a class="followed-edit-top" href="rediger.html" onclick="event.stopPropagation()">✎ Rediger</a></summary>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -50,6 +50,7 @@ class Dashboard {
 	render() {
 		this.renderTodayLine();
 		this.renderLive();
+		this.renderNextUp();
 		this.renderAgenda();
 		this.renderFollowed();
 		this.renderFooter();
@@ -588,6 +589,36 @@ class Dashboard {
 		});
 	}
 
+	// ── "Dine neste" — the compact, central answer to "when's X next?" ────────
+	// A capped, nearest-first glance across the athletes/teams you follow,
+	// upcoming-only. Kept deliberately small so it tops the agenda without
+	// burying it; the full list (incl. "ikke satt opp ennå" + tournaments +
+	// editing) stays in the "Hva vi følger" disclosure at the bottom.
+	/** Followed athletes/teams that have an upcoming event, nearest first. The
+	 *  pure selection behind "Dine neste" (upcoming-only; gaps live at the bottom). */
+	nextUpEntries() {
+		const at = this.interests && this.interests.alwaysTrack;
+		if (!at) return [];
+		return [...(at.athletes || []), ...(at.teams || [])]
+			.map((entry) => ({ entry, next: this.nextEventForEntity(entry) }))
+			.filter((x) => x.next)
+			.sort((a, b) => new Date(a.next.time) - new Date(b.next.time));
+	}
+
+	renderNextUp() {
+		const el = document.getElementById('next-up');
+		if (!el) return;
+		const all = this.nextUpEntries();
+		if (!all.length) { el.hidden = true; return; }
+		const MAX = 5;
+		const shown = all.slice(0, MAX);
+		const more = all.length - shown.length;
+		el.innerHTML = '<div class="nu-label">Dine neste</div>'
+			+ `<ul class="follow-next">${shown.map((x) => this.followRow(x.entry, true)).join('')}</ul>`
+			+ (more > 0 ? `<button type="button" class="nu-more">+ ${more} til i «Hva vi følger»</button>` : '');
+		el.hidden = false;
+	}
+
 	// ── "Hva vi følger" — one quiet disclosure at the bottom ──────────────────
 	// It answers the recurring "when's X next?" question, entity-first: for each
 	// athlete/team you follow, the next known event — UNWINDOWED (ignores the
@@ -700,10 +731,10 @@ class Dashboard {
 		return rows.join('');
 	}
 
-	/** Tap/keyboard expand for the "neste" index rows (delegated, survives re-render). */
+	/** Tap/keyboard expand for the "neste" index rows in BOTH the top "Dine
+	 *  neste" section and the bottom disclosure (delegated, survives re-render). */
 	bindFollowed() {
-		const body = document.getElementById('followed-body');
-		if (!body || this._followedBound) return;
+		if (this._followedBound) return;
 		this._followedBound = true;
 		const toggle = (row) => {
 			const detail = row.parentElement.querySelector('.fn-detail');
@@ -712,16 +743,27 @@ class Dashboard {
 			row.setAttribute('aria-expanded', String(!open));
 			detail.hidden = open;
 		};
-		body.addEventListener('click', (evt) => {
+		const onClick = (evt) => {
 			if (evt.target.closest('a')) return; // let channel/source links work
+			if (evt.target.closest('.nu-more')) {
+				const d = document.getElementById('followed');
+				if (d) { d.open = true; d.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+				return;
+			}
 			const row = evt.target.closest('.fn-item.has-event .fn-row');
 			if (row) toggle(row);
-		});
-		body.addEventListener('keydown', (evt) => {
+		};
+		const onKey = (evt) => {
 			if (evt.key !== 'Enter' && evt.key !== ' ') return;
 			const row = evt.target.closest('.fn-item.has-event .fn-row');
 			if (row) { evt.preventDefault(); toggle(row); }
-		});
+		};
+		for (const id of ['next-up', 'followed-body']) {
+			const c = document.getElementById(id);
+			if (!c) continue;
+			c.addEventListener('click', onClick);
+			c.addEventListener('keydown', onKey);
+		}
 	}
 
 	// ── Live polling (ESPN, client-side) ─────────────────────────────────────

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -146,6 +146,32 @@ describe("followed 'neste' index — answers 'when's X next?'", () => {
 	});
 });
 
+describe("'Dine neste' top glance — upcoming-only, nearest first", () => {
+	const inDays = (n) => new Date(Date.now() + n * 86400000).toISOString();
+
+	it("keeps only followed entities with an upcoming event, sorted soonest-first", () => {
+		dash.interests = { alwaysTrack: {
+			athletes: [
+				{ name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis" },
+				{ name: "Aryan Tari", aliases: ["Tari"], sport: "chess" }, // no event → excluded
+			],
+			teams: [{ name: "Lyn", sport: "football" }],
+		} };
+		dash.allEvents = [
+			{ sport: "football", title: "Strømsgodset – Lyn", homeTeam: "Strømsgodset", awayTeam: "Lyn", time: inDays(18) },
+			{ sport: "tennis", title: "Swiss Open (Casper Ruud)", time: inDays(6) },
+		];
+		const rows = dash.nextUpEntries();
+		expect(rows.map((r) => r.entry.name)).toEqual(["Casper Ruud", "Lyn"]); // Tari dropped, Ruud (6d) before Lyn (18d)
+	});
+
+	it("returns nothing when no followed entity has an upcoming event (section stays hidden)", () => {
+		dash.interests = { alwaysTrack: { athletes: [{ name: "Aryan Tari", sport: "chess" }], teams: [] } };
+		dash.allEvents = [];
+		expect(dash.nextUpEntries()).toEqual([]);
+	});
+});
+
 describe("must-see selection follows the goal's priorities", () => {
 	it("favorite, importance>=4, or Norwegian participation", () => {
 		expect(dash.isMustSee({ isFavorite: true })).toBe(true);


### PR DESCRIPTION
## Hva

Neste-event-indeksen (fra #211) var godt likt, men lå i den kollapsede seksjonen nederst. Denne løfter en **kompakt utgave opp til toppen av hovedvisningen**, rett over den dag-grupperte agendaen — så «når spiller X neste gang?» besvares ved første blikk.

- Ny **«Dine neste»**-seksjon: kun kommende, nærmest først, på tvers av utøvere/lag du følger (inkl. de utenfor 14-dagersvinduet)
- **Balansert** så den ikke begraver agendaen: teletext-jevnbyrdig med dag-gruppene (amber-etikett + boks), men tettere rader, ingen tidskolonne, tak på 5 med «+ N til» som åpner den fulle lista nederst
- Full indeks (inkl. «ikke satt opp ennå», turneringer, rediger) blir værende i «Hva vi følger»-disclosuren nederst
- Utvid-på-tapp dekker nå både topp-seksjonen og bunn-lista
- Utvelgingslogikk trukket ut i `nextUpEntries()` for enhetstest

## Verifisert
- `npm test` — 232/232 grønne (2 nye tester)
- Skjermdumpet 375px i mørkt + lyst tema: «I DAG» ligger fortsatt over folden

## Filer
`docs/index.html`, `docs/js/dashboard.js`, `docs/css/cards.css`, `tests/dashboard-cards.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)