### PR TITLE
Stop live matches from vanishing off the board mid-play

### DIFF
--- a/docs/data/events.json
+++ b/docs/data/events.json
@@ -269,6 +269,39 @@
   {
     "sport": "football",
     "tournament": "FIFA World Cup",
+    "title": "Egypt at Argentina",
+    "time": "2026-07-07T16:00:00.000Z",
+    "endTime": null,
+    "venue": "Mercedes-Benz Stadium",
+    "meta": "FIFA World Cup",
+    "norwegian": false,
+    "streaming": [
+      {
+        "platform": "TV 2 Play",
+        "url": "https://play.tv2.no"
+      }
+    ],
+    "participants": [],
+    "norwegianPlayers": [],
+    "totalPlayers": null,
+    "link": null,
+    "status": null,
+    "featuredGroups": [],
+    "homeTeam": "Argentina",
+    "awayTeam": "Egypt",
+    "isFavorite": false,
+    "round": "Åttedelsfinale",
+    "verifiedAt": "2026-07-05T08:27:09.000Z",
+    "verificationStatus": "amended",
+    "verificationSources": [
+      "https://kommunikasjon.ntb.no/pressemelding/18977115/slik-sendes-attedelsfinalene-i-fotball-vm",
+      "https://www.nrk.no/fotballvm2026/program-og-tv-guide-for-fotball-vm_-slik-ser-du-norges-kamper-pa-tv-1.17694535"
+    ],
+    "mustWatch": false
+  },
+  {
+    "sport": "football",
+    "tournament": "FIFA World Cup",
     "title": "Colombia at Switzerland",
     "time": "2026-07-07T20:00:00.000Z",
     "endTime": null,

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -105,8 +105,14 @@ const CARRY_FORWARD_FIELDS = [
 const previousEvents = readJsonIfExists(path.join(dataDir, "events.json"));
 if (Array.isArray(previousEvents)) {
 	const byKey = new Map(all.map((e) => [`${e.sport}|${e.title}|${e.time}`, e]));
+	// A live match can drop out of the ESPN fetch the moment it kicks off; if we
+	// rebuild purely from the fetch, a verified in-progress event vanishes from
+	// the board mid-play (see (c) below for the rescue).
+	const now = Date.now();
+	const LIVE_GRACE_MS = 3 * 60 * 60 * 1000; // match length + buffer, for events with no endTime
 	let preserved = 0;
 	let carried = 0;
+	let rescuedLive = 0;
 	for (const prev of previousEvents) {
 		const key = `${prev.sport}|${prev.title}|${prev.time}`;
 		const current = byKey.get(key);
@@ -126,13 +132,31 @@ if (Array.isArray(previousEvents)) {
 			}
 			continue;
 		}
-		if (prev.source !== "ai-research") continue;
-		byKey.set(key, prev);
-		all.push(prev);
-		preserved++;
+		// (a) AI-research events no static fetcher knows about must survive rebuilds.
+		if (prev.source === "ai-research") {
+			byKey.set(key, prev);
+			all.push(prev);
+			preserved++;
+			continue;
+		}
+		// (c) A STATIC event that is happening RIGHT NOW but fell out of the latest
+		//     fetch (ESPN stops returning a match once it goes live) must not
+		//     disappear from the board mid-play. Rescue ONLY currently-live events —
+		//     a *future* static event missing from the fetch may be genuinely
+		//     cancelled or rescheduled, so those are still dropped as before.
+		const start = Date.parse(prev.time);
+		const end = prev.endTime ? Date.parse(prev.endTime) : start + LIVE_GRACE_MS;
+		if (Number.isFinite(start) && start <= now && now <= end) {
+			byKey.set(key, prev);
+			all.push(prev);
+			rescuedLive++;
+		}
 	}
 	if (preserved > 0) {
 		console.log(`Preserved ${preserved} AI-research event(s) from previous build.`);
+	}
+	if (rescuedLive > 0) {
+		console.log(`Rescued ${rescuedLive} in-progress static event(s) missing from the latest fetch.`);
 	}
 	if (carried > 0) {
 		console.log(`Carried forward ${carried} agent amendment(s) onto re-fetched static events.`);

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -68,6 +68,33 @@ describe("build-events", () => {
 		expect(events.find((e) => e.title === "Old static event")).toBeUndefined();
 	});
 
+	it("rescues an in-progress static event that dropped out of the latest fetch", () => {
+		const startedAgo = new Date(Date.now() - 60 * 60000).toISOString(); // kicked off 1h ago → live
+		// The live match is NOT in the current fetch (ESPN stops returning it once
+		// it goes live) — only the later, not-yet-started match is.
+		fs.writeFileSync(
+			path.join(dataDir, "football.json"),
+			JSON.stringify({ tournaments: [{ name: "FIFA World Cup", events: [
+				{ title: "Later match", time: future(1), homeTeam: "A", awayTeam: "B" },
+			] }] })
+		);
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "football", tournament: "FIFA World Cup", title: "Egypt at Argentina", time: startedAgo,
+				  homeTeam: "Argentina", awayTeam: "Egypt", streaming: [{ platform: "TV 2 Play" }],
+				  verifiedAt: "2026-07-05T08:27:09Z", verificationStatus: "amended" },
+				// A FUTURE static event missing from the fetch stays dropped (may be cancelled/moved).
+				{ sport: "football", tournament: "FIFA World Cup", title: "Cancelled future", time: future(3), homeTeam: "C", awayTeam: "D" },
+			])
+		);
+		const events = runBuild();
+		const live = events.find((e) => e.title === "Egypt at Argentina");
+		expect(live).toBeDefined();                       // the live match survived the rebuild
+		expect(live.streaming).toEqual([{ platform: "TV 2 Play" }]); // with its verified channel
+		expect(events.find((e) => e.title === "Cancelled future")).toBeUndefined(); // future drop stays dropped
+	});
+
 	it("carries agent amendments (streaming, verification) onto re-fetched static events", () => {
 		const time = future(2);
 		fs.writeFileSync(


### PR DESCRIPTION
## Problem

En verifisert VM-sluttspillkamp (Egypt–Argentina) forsvant fra dashboardet **i det den startet**. Årsak: ESPN slutter å returnere en kamp når den går live, og `build-events` bygger statiske eventer helt på nytt fra hentingen — så en live, allerede verifisert kamp ble slettet på verst tenkelige tidspunkt. Den senere kampen (ikke startet) overlevde kun fordi den fortsatt lå i hentingen.

## Fiks

`build-events` bevarer nå — i tillegg til `ai-research`-eventer — en **statisk kamp fra forrige bygg som pågår akkurat nå** (startet, innenfor `endTime` eller et 3t-vindu) men mangler i siste henting. Kun **pågående** eventer reddes; en *framtidig* statisk kamp som mangler kan være reelt avlyst/flyttet, så de droppes fortsatt som før.

Legger også den pågående Egypt–Argentina-kampen tilbake på tavla for resten av kampen; redningslogikken holder den der til den er ferdig.

## Test
`tests/build-events.test.js` dekker live-redningen + at framtidige drop fortsatt droppes. Hele pakken: 233 grønne. `validate-events`: 0 feil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)