### PR TITLE
Show cancelled/postponed matches as such — never silently drop them

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -215,6 +215,11 @@
 .ev-where a { border-bottom: 1px dotted var(--fg-3); }
 .ev-where a:hover { border-bottom: 1px solid var(--accent); color: var(--accent); }
 .ev-where.unknown { color: var(--fg-3); }
+/* Cancelled/postponed: stays on the board but clearly faded — "not happening",
+   so it recedes rather than shouts (never the live red). */
+.ev.cancelled { opacity: 0.6; }
+.ev.cancelled .ev-title { text-decoration: line-through; text-decoration-color: var(--fg-3); }
+.ev-status { font-size: 11.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-2); text-align: right; white-space: nowrap; justify-self: end; }
 .ev-where.tentative { color: var(--fg-3); font-style: italic; }
 .ev-where-more { color: var(--fg-3); font-size: 11px; margin-left: 4px; }
 .d-v .tbd { color: var(--fg-3); font-style: italic; }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -320,23 +320,36 @@ class Dashboard {
 		return out;
 	}
 
+	/** A cancelled/postponed match stays on the board, clearly labelled — it must
+	 *  never silently vanish (the same failure as a live match dropping off).
+	 *  Returns the Norwegian label or null. */
+	statusLabel(e) {
+		const s = String(e.status || '').toLowerCase();
+		if (s === 'cancelled' || s === 'canceled') return 'Avlyst';
+		if (s === 'postponed') return 'Utsatt';
+		return null;
+	}
+
 	eventRow(e) {
 		if (e.isSeries) return this.seriesRow(e);
 		const date = new Date(e.time);
 		const live = this.liveScores[e.id];
-		const where = live && live.state === 'in'
-			? `<span class="ev-where ev-live">${live.home}–${live.away}</span>`
-			: this.whereToWatch(e);
+		const status = this.statusLabel(e);
+		const where = status
+			? `<span class="ev-status">${escapeHtml(status)}</span>`
+			: (live && live.state === 'in'
+				? `<span class="ev-where ev-live">${live.home}–${live.away}</span>`
+				: this.whereToWatch(e));
 		const expandable = this.hasDetail(e);
 		const caret = expandable ? `<span class="ev-caret" aria-hidden="true">›</span>` : `<span class="ev-caret"></span>`;
 		const attrs = expandable
 			? ` role="button" tabindex="0" aria-expanded="false" data-event-id="${escapeHtml(e.id)}"`
 			: '';
 		const round = e.round ? `<span class="ev-round">${escapeHtml(e.round)}</span>` : '';
-		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${expandable ? ' expandable' : ''}"${attrs}>
+		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${status ? ' cancelled' : ''}${expandable ? ' expandable' : ''}"${attrs}>
 			${this.sportBadge(e)}
 			<span class="ev-time">${escapeHtml(this.osloTime(date))}</span>
-			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${round}${this.notifyMark(e.mustWatch)}</span>
+			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${round}${status ? '' : this.notifyMark(e.mustWatch)}</span>
 			${where}
 			${caret}
 		</div><div class="ev-detail" hidden></div></div>`;

--- a/scripts/agents/verify.md
+++ b/scripts/agents/verify.md
@@ -45,8 +45,16 @@ source's failure mode once instead of rediscovering it every week. (Quantitative
 "how often is it wrong" stays in the calibration ledger; the skill is for the
 mechanism + the fix.)
 
-If `verificationStatus` is `removed` (the event demonstrably does not exist or
-was cancelled), drop the event from events.json entirely.
+**Cancelled / postponed ≠ removed.** If a real, scheduled event is **cancelled
+or postponed**, do NOT delete it — a match that silently vanishes is exactly as
+confusing to the user as one that disappears mid-play. Instead **keep it on the
+board** and set `status: "cancelled"` (or `"postponed"`), plus
+`verificationStatus: "amended"` and the source URL. The dashboard then shows it
+as «Avlyst»/«Utsatt» (faded, no channel) rather than dropping it. If it was
+merely **rescheduled**, keep it and correct `time` (don't mark it cancelled).
+Only when `verificationStatus` is `removed` — the event **demonstrably never
+existed** (a bogus/duplicate listing, not a real fixture that fell through) —
+drop it from events.json entirely.
 
 For `source: "espn"` / static-pipeline events, only verify if `time` is more
 than 14 days out (APIs are reliable near-term; long-range schedules drift).

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -98,6 +98,7 @@ if (fs.existsSync(configDir)) {
 // Dedupe key: sport|title|time.
 const CARRY_FORWARD_FIELDS = [
 	"streaming",
+	"status", // a "cancelled"/"postponed" mark from the verify agent must survive the hourly rebuild
 	"verifiedAt",
 	"verificationStatus",
 	"verificationSources",
@@ -112,7 +113,7 @@ if (Array.isArray(previousEvents)) {
 	const LIVE_GRACE_MS = 3 * 60 * 60 * 1000; // match length + buffer, for events with no endTime
 	let preserved = 0;
 	let carried = 0;
-	let rescuedLive = 0;
+	let keptOnBoard = 0;
 	for (const prev of previousEvents) {
 		const key = `${prev.sport}|${prev.title}|${prev.time}`;
 		const current = byKey.get(key);
@@ -139,24 +140,33 @@ if (Array.isArray(previousEvents)) {
 			preserved++;
 			continue;
 		}
-		// (c) A STATIC event that is happening RIGHT NOW but fell out of the latest
-		//     fetch (ESPN stops returning a match once it goes live) must not
-		//     disappear from the board mid-play. Rescue ONLY currently-live events —
-		//     a *future* static event missing from the fetch may be genuinely
-		//     cancelled or rescheduled, so those are still dropped as before.
+		// (c) A STATIC event missing from the latest fetch is normally rebuilt
+		//     from source — but keep it when dropping it would make it silently
+		//     vanish from the board at the wrong moment:
+		//       • it's happening RIGHT NOW (ESPN stops returning a match once it
+		//         goes live), or
+		//       • an agent marked it cancelled/postponed — verify keeps such a
+		//         match on the board as "Avlyst"/"Utsatt" instead of removing it,
+		//         and that annotation must survive the hourly rebuild.
+		//     A plain *future* static event missing from the fetch is still dropped
+		//     (may be genuinely cancelled/rescheduled — we only keep it once an
+		//     agent has confirmed the status, which also avoids reschedule ghosts).
 		const start = Date.parse(prev.time);
 		const end = prev.endTime ? Date.parse(prev.endTime) : start + LIVE_GRACE_MS;
-		if (Number.isFinite(start) && start <= now && now <= end) {
+		const isLiveNow = Number.isFinite(start) && start <= now && now <= end;
+		const sticky = ["cancelled", "canceled", "postponed"].includes(String(prev.status || "").toLowerCase());
+		const stickyStillRelevant = sticky && Number.isFinite(end) && now <= end + MS_PER_DAY;
+		if (isLiveNow || stickyStillRelevant) {
 			byKey.set(key, prev);
 			all.push(prev);
-			rescuedLive++;
+			keptOnBoard++;
 		}
 	}
 	if (preserved > 0) {
 		console.log(`Preserved ${preserved} AI-research event(s) from previous build.`);
 	}
-	if (rescuedLive > 0) {
-		console.log(`Rescued ${rescuedLive} in-progress static event(s) missing from the latest fetch.`);
+	if (keptOnBoard > 0) {
+		console.log(`Kept ${keptOnBoard} in-progress / cancelled static event(s) missing from the latest fetch.`);
 	}
 	if (carried > 0) {
 		console.log(`Carried forward ${carried} agent amendment(s) onto re-fetched static events.`);

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -95,6 +95,25 @@ describe("build-events", () => {
 		expect(events.find((e) => e.title === "Cancelled future")).toBeUndefined(); // future drop stays dropped
 	});
 
+	it("keeps an agent-marked cancelled event on the board instead of dropping it", () => {
+		// The cancelled match is gone from the fetch; only an unrelated match remains.
+		fs.writeFileSync(
+			path.join(dataDir, "football.json"),
+			JSON.stringify({ tournaments: [{ name: "PL", events: [{ title: "Other", time: future(2) }] }] })
+		);
+		// Previous build: verify marked a real fixture cancelled (kept, not removed).
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "football", tournament: "PL", title: "Cancelled match", time: future(1), status: "cancelled", verificationStatus: "amended" },
+			])
+		);
+		const events = runBuild();
+		const c = events.find((e) => e.title === "Cancelled match");
+		expect(c).toBeDefined();          // it stays on the board...
+		expect(c.status).toBe("cancelled"); // ...still labelled cancelled
+	});
+
 	it("carries agent amendments (streaming, verification) onto re-fetched static events", () => {
 		const time = future(2);
 		fs.writeFileSync(

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -70,6 +70,24 @@ describe("agenda event row", () => {
 	});
 });
 
+describe("cancelled / postponed matches stay on the board, labelled", () => {
+	it("shows a cancelled match faded with an 'Avlyst' label instead of a channel", () => {
+		const html = dash.eventRow({ id: "c", sport: "football", title: "Barcelona vs X", time: soon(), status: "cancelled", streaming: [{ platform: "TV3" }] });
+		expect(html).toContain("Avlyst");
+		expect(html).toContain("cancelled");   // dims the row
+		expect(html).not.toContain("TV3");      // channel is moot when cancelled
+	});
+	it("labels a postponed match 'Utsatt'", () => {
+		const html = dash.eventRow({ id: "p", sport: "football", title: "Y", time: soon(), status: "postponed" });
+		expect(html).toContain("Utsatt");
+	});
+	it("leaves a normal match unaffected", () => {
+		const html = dash.eventRow({ id: "n", sport: "football", title: "Z", time: soon(), streaming: [{ platform: "NRK" }] });
+		expect(html).not.toContain("cancelled");
+		expect(html).toContain("NRK");
+	});
+});
+
 describe("progressive disclosure detail", () => {
 	it("only marks rows expandable when there's genuinely more to show", () => {
 		const bare = { id: "b", sport: "chess", title: "Round 3", time: soon() };


### PR DESCRIPTION
## Prinsipp

En kamp som lå på tavla skal **aldri bare forsvinne**: den skal stå (kommende/live), flyttes til resultater (ferdig), eller vises som **avlyst/utsatt**. Avlyste kamper ble slettet helt — like forvirrende som live-kampen som forsvant.

## Lagdelt (riktig + uten spøkelser)

- **verify-agenten:** en ekte kamp som er avlyst/utsatt **beholdes** nå med `status: "cancelled"/"postponed"` (ikke slettet). Flyttet kamp → oppdaterer `time`. Kun beviselig falske oppføringer fjernes fortsatt.
- **build-events:** en status-merket kamp bevares gjennom den timevise ombyggingen (`status` lagt til carry-forward + beholder status-merkede kamper som mangler i hentingen). Kun *live* eller *eksplisitt merkede* beholdes — ikke alle forsvunne framtidige — så en flytting aldri gir duplikat gammel+ny tid.
- **klienten:** viser «Avlyst»/«Utsatt» — raden blir stående, men dimmes (gjennomstreket, ingen kanal), toner ned i stedet for å rope (aldri live-rødt).

## Verifisert
Visuelt 375px (mørkt + lyst). `npm test`: 237 grønne (+4 nye).

🤖 Generated with [Claude Code](https://claude.com/claude-code)