### PR TITLE
Show finished matches as "Ferdig" + result, not a watch-channel

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -220,6 +220,11 @@
 .ev.cancelled { opacity: 0.6; }
 .ev.cancelled .ev-title { text-decoration: line-through; text-decoration-color: var(--fg-3); }
 .ev-status { font-size: 11.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-2); text-align: right; white-space: nowrap; justify-self: end; }
+/* Finished: stays briefly with its result, gently dimmed (it happened — not
+   cancelled, so no strikethrough). */
+.ev.done { opacity: 0.72; }
+.ev-done { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-3); text-align: right; white-space: nowrap; justify-self: end; }
+.ev-done-score { color: var(--fg); font-weight: 600; font-variant-numeric: tabular-nums; text-transform: none; letter-spacing: 0; margin-left: 5px; }
 .ev-where.tentative { color: var(--fg-3); font-style: italic; }
 .ev-where-more { color: var(--fg-3); font-size: 11px; margin-left: 4px; }
 .d-v .tbd { color: var(--fg-3); font-style: italic; }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -330,26 +330,59 @@ class Dashboard {
 		return null;
 	}
 
+	/** Is this event over? Returns { score } ("2–1", event-oriented) or { score: null }
+	 *  (finished, score unknown), or null (not finished). A finished match stays on
+	 *  the board briefly showing its result — never a "watch here" channel. */
+	finishedInfo(e) {
+		const live = this.liveScores[e.id];
+		if (live && live.state === 'post') return { score: `${live.home}–${live.away}` };
+		const score = this.finishedScore(e);
+		if (score) return { score };
+		// Time fallback only where the end is boundable: an explicit endTime, or a
+		// football fixture (~2.5h). Never guess "finished" for open-ended entries.
+		const start = new Date(e.time).getTime();
+		if (!Number.isFinite(start)) return null;
+		let end = null;
+		if (e.endTime) end = new Date(e.endTime).getTime();
+		else if (e.sport === 'football') end = start + 2.5 * SS_CONSTANTS.MS_PER_HOUR;
+		if (end != null && Date.now() > end) return { score: null };
+		return null;
+	}
+
+	/** Event-oriented final score ("2–1") from recent-results, or null. */
+	finishedScore(e) {
+		if (!e.homeTeam || !e.awayTeam) return null;
+		const fb = this.recentResults?.football;
+		if (!Array.isArray(fb)) return null;
+		const hn = e.homeTeam.toLowerCase(), an = e.awayTeam.toLowerCase();
+		const m = fb.find((r) => {
+			const rh = (r.homeTeam || '').toLowerCase(), ra = (r.awayTeam || '').toLowerCase();
+			return (rh.includes(hn) || hn.includes(rh)) && (ra.includes(an) || an.includes(ra)) && r.homeScore != null;
+		});
+		return m ? `${m.homeScore}–${m.awayScore}` : null;
+	}
+
 	eventRow(e) {
 		if (e.isSeries) return this.seriesRow(e);
 		const date = new Date(e.time);
 		const live = this.liveScores[e.id];
 		const status = this.statusLabel(e);
-		const where = status
-			? `<span class="ev-status">${escapeHtml(status)}</span>`
-			: (live && live.state === 'in'
-				? `<span class="ev-where ev-live">${live.home}–${live.away}</span>`
-				: this.whereToWatch(e));
+		const done = (!status && !(live && live.state === 'in')) ? this.finishedInfo(e) : null;
+		let where;
+		if (status) where = `<span class="ev-status">${escapeHtml(status)}</span>`;
+		else if (live && live.state === 'in') where = `<span class="ev-where ev-live">${live.home}–${live.away}</span>`;
+		else if (done) where = `<span class="ev-done">Ferdig${done.score ? `<span class="ev-done-score">${escapeHtml(done.score)}</span>` : ''}</span>`;
+		else where = this.whereToWatch(e);
 		const expandable = this.hasDetail(e);
 		const caret = expandable ? `<span class="ev-caret" aria-hidden="true">›</span>` : `<span class="ev-caret"></span>`;
 		const attrs = expandable
 			? ` role="button" tabindex="0" aria-expanded="false" data-event-id="${escapeHtml(e.id)}"`
 			: '';
 		const round = e.round ? `<span class="ev-round">${escapeHtml(e.round)}</span>` : '';
-		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${status ? ' cancelled' : ''}${expandable ? ' expandable' : ''}"${attrs}>
+		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${status ? ' cancelled' : ''}${done ? ' done' : ''}${expandable ? ' expandable' : ''}"${attrs}>
 			${this.sportBadge(e)}
 			<span class="ev-time">${escapeHtml(this.osloTime(date))}</span>
-			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${round}${status ? '' : this.notifyMark(e.mustWatch)}</span>
+			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${round}${(status || done) ? '' : this.notifyMark(e.mustWatch)}</span>
 			${where}
 			${caret}
 		</div><div class="ev-detail" hidden></div></div>`;

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -88,6 +88,32 @@ describe("cancelled / postponed matches stay on the board, labelled", () => {
 	});
 });
 
+describe("finished matches show their result, not a channel", () => {
+	const hoursAgo = (h) => new Date(Date.now() - h * 3600000).toISOString();
+	it("shows 'Ferdig' + the score for a completed football match", () => {
+		dash.liveScores = {};
+		dash.recentResults = { football: [{ homeTeam: "Argentina", awayTeam: "Egypt", homeScore: 2, awayScore: 1 }] };
+		const html = dash.eventRow({ id: "f1", sport: "football", title: "Argentina vs Egypt", homeTeam: "Argentina", awayTeam: "Egypt", time: hoursAgo(2), streaming: [{ platform: "TV 2 Play" }] });
+		expect(html).toContain("Ferdig");
+		expect(html).toContain("2–1");
+		expect(html).toContain("done");
+		expect(html).not.toContain("TV 2 Play"); // it's over — not "watch here"
+	});
+	it("marks a clearly-ended football match finished even without a score", () => {
+		dash.liveScores = {};
+		dash.recentResults = { football: [] };
+		const html = dash.eventRow({ id: "f2", sport: "football", title: "A vs B", homeTeam: "A", awayTeam: "B", time: hoursAgo(3) });
+		expect(html).toContain("Ferdig");
+		expect(html).toContain("done");
+	});
+	it("does not guess 'finished' for an open-ended entry (non-football, no endTime)", () => {
+		dash.liveScores = {};
+		dash.recentResults = null;
+		const html = dash.eventRow({ id: "f3", sport: "tennis", title: "Some tournament", time: hoursAgo(5) });
+		expect(html).not.toContain("done");
+	});
+});
+
 describe("progressive disclosure detail", () => {
 	it("only marks rows expandable when there's genuinely more to show", () => {
 		const bare = { id: "b", sport: "chess", title: "Round 3", time: soon() };


### PR DESCRIPTION
## Hva

Fullfører livssyklusen på tavla: en ferdigspilt kamp lå igjen en stund, men viste fortsatt en «se-på»-kanal som om den var kommende. Nå viser den sin virkelige tilstand.

- `eventRow` viser «Ferdig» + sluttresultatet (event-orientert) — fra resultat-feeden (`finishedScore`) eller live-pollingens `post`-tilstand, med et tids-fallback avgrenset til fotball / eventer med `endTime` (gjetter aldri «ferdig» for åpne oppføringer).
- Dempet (den skjedde) — distinkt fra avlyst (gjennomstreket) og live (rød score). Ingen kanal, ingen bjelle.

Kun klient. `npm test`: 240 grønne (+3 nye). Verifisert 375px, mørkt + lyst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)