### PR TITLE
Fix duplicate golf tournaments; show players, tee times & featured groups

### DIFF
--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -418,6 +418,37 @@ class Dashboard {
 
 	// ── Progressive disclosure: extra context on tap (calm — hidden by default) ──
 
+	/** Golf detail: each Norwegian in the field on its own line — tee time (Oslo)
+	 *  + who they're out with (the marquee/featured group), plus the field size. */
+	addGolfField(e, add) {
+		const players = e.norwegianPlayers || [];
+		const groups = e.featuredGroups || [];
+		const groupFor = (name) => groups.find((g) => String(g.player || '').toLowerCase() === String(name || '').toLowerCase());
+		let listed = false;
+		for (const p of players) {
+			const name = p.name || p;
+			const g = groupFor(name);
+			const tee = p.teeTime || g?.teeTime;
+			const mates = (g?.groupmates || []).map((m) => escapeHtml(m.name || m)).join(', ');
+			const parts = [];
+			if (tee) parts.push(`<span class="tbd">${escapeHtml(tee)}</span>`);
+			if (mates) parts.push(`med ${mates}`);
+			add(escapeHtml(name), parts.length ? parts.join(' · ') : 'i feltet');
+			listed = true;
+		}
+		// A featured group whose Norwegian isn't in norwegianPlayers (defensive).
+		for (const g of groups) {
+			if (players.some((p) => String(p.name || p).toLowerCase() === String(g.player || '').toLowerCase())) continue;
+			const mates = (g.groupmates || []).map((m) => escapeHtml(m.name || m)).join(', ');
+			const parts = [];
+			if (g.teeTime) parts.push(`<span class="tbd">${escapeHtml(g.teeTime)}</span>`);
+			if (mates) parts.push(`med ${mates}`);
+			if (parts.length) { add(escapeHtml(g.player), parts.join(' · ')); listed = true; }
+		}
+		if (!listed && players.length) add('Norske', escapeHtml(players.map((p) => p.name || p).join(', ')));
+		if (e.totalPlayers) add('Felt', `${e.totalPlayers} i feltet`);
+	}
+
 	/** True only when there's genuinely more to show — flat rows stay non-interactive. */
 	hasDetail(e) {
 		if (e.isSeries) return true;
@@ -428,6 +459,7 @@ class Dashboard {
 			(e.venue && e.venue !== 'TBD') ||
 			e.summary ||
 			e.norwegianPlayers?.length ||
+			e.featuredGroups?.length ||
 			(Array.isArray(e.streaming) && e.streaming.length > 1) ||
 			(e.source === 'ai-research' && e.evidence?.length)
 		);
@@ -444,7 +476,11 @@ class Dashboard {
 		add('Tabell', this.footballStanding(e));
 		add('Ledende', this.golfContext(e));
 		if (e.venue && e.venue !== 'TBD') add('Arena', escapeHtml(e.venue));
-		if (e.norwegianPlayers?.length) add('Norske', escapeHtml(e.norwegianPlayers.map((p) => p.name || p).join(', ')));
+		if (e.sport === 'golf' && (e.norwegianPlayers?.length || e.featuredGroups?.length)) {
+			this.addGolfField(e, add);
+		} else if (e.norwegianPlayers?.length) {
+			add('Norske', escapeHtml(e.norwegianPlayers.map((p) => p.name || p).join(', ')));
+		}
 		if (e.summary) add('Om', escapeHtml(e.summary));
 
 		const streams = Array.isArray(e.streaming) ? e.streaming : [];

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -103,6 +103,28 @@ const CARRY_FORWARD_FIELDS = [
 	"verificationStatus",
 	"verificationSources",
 ];
+// Fuzzy "same event" check, to de-dupe an ai-research event against a static one
+// when their exact start times disagree — common for multi-day golf/stage events
+// (ESPN says 04:00, the research agent wrote 06:00, so a sport|title|time key
+// misses it and both survive). Same sport + ≥2 shared title words (or one title's
+// words ⊆ the other) + overlapping date range ⇒ the same event.
+const TITLE_STOP = new Set(["the", "at", "in", "of", "and", "a", "vs", "v"]);
+function titleTokens(s) {
+	return String(s || "").toLowerCase().replace(/[^a-z0-9 ]/g, " ").split(/\s+/)
+		.filter((w) => w.length > 1 && !TITLE_STOP.has(w) && !/^\d+(st|nd|rd|th)?$/.test(w));
+}
+function sameFuzzyEvent(a, b) {
+	if (!a || !b || a.sport !== b.sport) return false;
+	const at = titleTokens(a.title), bset = new Set(titleTokens(b.title));
+	const shared = at.filter((w) => bset.has(w));
+	const subset = at.length > 0 && at.every((w) => bset.has(w));
+	if (shared.length < 2 && !subset) return false;
+	const s1 = Date.parse(a.time), e1 = a.endTime ? Date.parse(a.endTime) : s1;
+	const s2 = Date.parse(b.time), e2 = b.endTime ? Date.parse(b.endTime) : s2;
+	if (!Number.isFinite(s1) || !Number.isFinite(s2)) return false;
+	return s1 <= e2 && s2 <= e1; // date ranges overlap
+}
+
 const previousEvents = readJsonIfExists(path.join(dataDir, "events.json"));
 if (Array.isArray(previousEvents)) {
 	const byKey = new Map(all.map((e) => [`${e.sport}|${e.title}|${e.time}`, e]));
@@ -133,8 +155,15 @@ if (Array.isArray(previousEvents)) {
 			}
 			continue;
 		}
-		// (a) AI-research events no static fetcher knows about must survive rebuilds.
+		// (a) AI-research events no static fetcher knows about must survive rebuilds
+		//     — UNLESS a static fetcher already covers the same multi-day event under
+		//     a slightly different start time (e.g. the Genesis Scottish Open, which
+		//     ESPN lists at 04:00 and the agent re-added at 06:00). Prefer the static
+		//     one (it carries the ESPN field + tee times) and drop the AI duplicate.
 		if (prev.source === "ai-research") {
+			if (all.some((cur) => cur.source !== "ai-research" && sameFuzzyEvent(cur, prev))) {
+				continue;
+			}
 			byKey.set(key, prev);
 			all.push(prev);
 			preserved++;

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -176,6 +176,30 @@ describe("build-events", () => {
 		expect(events[0].source).toBeUndefined();
 	});
 
+	it("de-dupes an ai-research event a static fetcher already covers under a different start time", () => {
+		const base = new Date(Date.now() + 2 * 86400000);
+		const at = (h) => { const d = new Date(base); d.setUTCHours(h, 0, 0, 0); return d.toISOString(); };
+		const end = () => { const d = new Date(base.getTime() + 3 * 86400000); d.setUTCHours(20, 0, 0, 0); return d.toISOString(); };
+		// Static ESPN event at 04:00 with the field data.
+		fs.writeFileSync(
+			path.join(dataDir, "golf.json"),
+			JSON.stringify({ tournaments: [{ name: "PGA Tour", events: [
+				{ title: "Genesis Scottish Open", time: at(4), endTime: end(), norwegian: true, norwegianPlayers: [{ name: "Viktor Hovland", teeTime: "09:39" }] },
+			] }] })
+		);
+		// Previous build: the research agent re-added the SAME tournament at 06:00.
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "golf", tournament: "DP World Tour / PGA Tour", title: "Genesis Scottish Open", time: at(6), endTime: end(), source: "ai-research", confidence: "high", evidence: ["a", "b"] },
+			])
+		);
+		const events = runBuild();
+		const scottish = events.filter((e) => e.title === "Genesis Scottish Open");
+		expect(scottish).toHaveLength(1);            // not two rows for the same tournament
+		expect(scottish[0].source).toBeUndefined();  // kept the static one (carries the field/tee times)
+	});
+
 	it("filters out events older than 14 days", () => {
 		fs.writeFileSync(
 			path.join(dataDir, "football.json"),

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -130,6 +130,31 @@ describe("progressive disclosure detail", () => {
 	});
 });
 
+describe("golf detail: who plays, tee times, featured group", () => {
+	it("lists each Norwegian with tee time and their marquee groupmates", () => {
+		const html = dash.eventDetail({
+			sport: "golf", title: "Genesis Scottish Open", time: soon(),
+			norwegianPlayers: [{ name: "Viktor Hovland", teeTime: "09:39" }, { name: "Kristoffer Reitan", teeTime: "09:06" }],
+			featuredGroups: [
+				{ player: "Viktor Hovland", teeTime: "09:39", groupmates: [{ name: "Wyndham Clark" }, { name: "Eugenio Chacarra" }] },
+				{ player: "Kristoffer Reitan", teeTime: "09:06", groupmates: [{ name: "Xander Schauffele" }, { name: "Adam Scott" }] },
+			],
+			totalPlayers: 156,
+		});
+		expect(html).toContain("Viktor Hovland");
+		expect(html).toContain("09:39");                 // tee time
+		expect(html).toContain("Wyndham Clark");          // groupmate
+		expect(html).toContain("Eugenio Chacarra");
+		expect(html).toContain("Kristoffer Reitan");
+		expect(html).toContain("156");                    // field size
+	});
+	it("shows a Norwegian without tee data as simply in the field", () => {
+		const html = dash.eventDetail({ sport: "golf", title: "US Open", time: soon(), norwegianPlayers: [{ name: "Kristoffer Ventura" }] });
+		expect(html).toContain("Kristoffer Ventura");
+		expect(html).toContain("i feltet");
+	});
+});
+
 describe("whereToWatch — the core 'hvor kan jeg se det'", () => {
 	it("links a channel when a url is present", () => {
 		const html = dash.whereToWatch({ streaming: [{ platform: "NRK 1", url: "https://tv.nrk.no" }] });


### PR DESCRIPTION
## To golf-problemer

**1) Samme turnering to ganger samme dag** (f.eks. Genesis Scottish Open 06:00 OG 08:00). Årsak: research-agenten la inn en turnering ESPN allerede dekker, med litt annen starttid, så `sport|title|time`-dedupe bommet. **Fiks:** dedupe et `ai-research`-event mot et statisk via fuzzy tittel (≥2 felles ord / delmengde) + overlappende datoer — fleredagers-eventer trenger ikke lenger identisk starttid. Beholder det statiske (det har ESPN-feltet + tee-tider); dropper AI-duplikatet.

**2) Golf-rader viste ikke hvem som spiller.** Fetcheren fanger allerede norske spillere med tee-tider + featured/marquee-grupper + feltstørrelse — klienten rendret det bare aldri. `eventDetail` viser nå hver nordmann på egen linje: tee-tid (Oslo) + hvem de spiller med, pluss «N i feltet».

## Verifisert
- `npm test`: 246 grønne (+3). `validate-events`: 0 feil.
- Rebuild bekreftet: Genesis Scottish Open står nå én gang; den ekte majoren «The 154th Open Championship» beholdes (annen turnering).
- Skjermdump av utvidet golf-detalj: Reitan 09:06 (m/ Schauffele, Scott), Hovland 09:39 (m/ Wyndham Clark, Chacarra), 156 i feltet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)