### PR TITLE
Deep-link streaming URLs to the broadcast, not the homepage

### DIFF
--- a/.claude/skills/norwegian-rights/SKILL.md
+++ b/.claude/skills/norwegian-rights/SKILL.md
@@ -12,16 +12,26 @@ watch in Norway**. This map is the prior; `docs/data/tv-listings.json`
 Confidence key: `[solid]` = well-established, `[verify]` = check before relying on it.
 
 ## Streaming URL (the tappable deep link in `streaming[].url`)
-The dashboard makes each streaming option's `url` tappable — "open where to watch"
-(on mobile it opens the broadcaster's app). Fill it with the most specific *safe* URL:
-- **Football:** `docs/data/tv-listings.json` now carries a per-match `url` (the
-  tvkampen match page listing every Norwegian broadcaster for THAT match). When an
-  event matches a listing (by team names), set `streaming[].url` to that match `url`.
-  It's the best "where to watch this match" link — and the ONLY good link for
-  **shared/tentative** rights (e.g. WC "NRK / TV 2"), where pointing at one
-  broadcaster would mislead.
-- **Everything else:** use the service landing URL from the map below (it opens the
-  app). Do NOT invent per-match broadcaster paths (`play.tv2.no/…/<match>`) — they 404.
+The dashboard makes each streaming option's `url` tappable — "open where to watch".
+A URL on the broadcaster's own domain *may* open its app (iOS Universal Links /
+Android App Links) if installed; a deep per-event URL is both likelier to open the
+app AND lands on the actual broadcast, not the home screen. Fill it with the most
+specific *safe* URL — one you actually reached, never an invented path:
+- **NRK — go deep.** NRK's programme/live URLs are stable and reliably deep-linkable:
+  use the real `https://tv.nrk.no/serie/…`, `/program/…`, or `/direkte/…` page for
+  THIS broadcast when you find it. This is the gold standard.
+- **Football:** `docs/data/tv-listings.json` carries a per-match `url` (the tvkampen
+  match page listing every Norwegian broadcaster for THAT match). When an event
+  matches a listing (by team names), set `streaming[].url` to that match `url`.
+  It's the best link for football — and the ONLY good link for **shared/tentative**
+  rights (e.g. WC "NRK / TV 2"), where pointing at one broadcaster would mislead.
+- **TV 2 Play / Viaplay & the rest:** do NOT invent per-match paths
+  (`play.tv2.no/…/<match>`) — they 404 (auth-gated). Use the service's **sport-section
+  landing** (the map's fallback: `play.tv2.no/sport`, `tv.nrk.no/direkte`, `viaplay.no`),
+  or a real per-event page only if you genuinely land on one.
+
+A deep `url` you set **survives rebuilds** — build-events keeps the most specific
+known URL per broadcaster and won't clobber it with the generic landing.
 
 ## Football
 - Premier League → **TV 2 Play / TV 2 Sport Premium** [solid]

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -115,6 +115,10 @@ Use the `norwegian-rights` skill (`.claude/skills/norwegian-rights/SKILL.md`) as
 the prior, `docs/data/tv-listings.json` as ground truth for football, and web
 search for confirmation. If genuinely unknown after checking, write
 `"streaming": []` and mention it in research-log notes — never guess a channel.
+**Prefer a deep per-event `url`** — the specific programme/live page (esp. NRK:
+`https://tv.nrk.no/serie/…` / `/direkte/…`) that opens the app on THIS broadcast,
+not the broadcaster's homepage. Use the homepage only when you can't reach a
+deeper page; never invent a URL.
 
 Confidence:
 - `high` = 2+ authoritative sources agree on date/time/venue

--- a/scripts/agents/verify.md
+++ b/scripts/agents/verify.md
@@ -27,6 +27,16 @@ survives future rebuilds (build-events never downgrades a confirmed channel back
 to a guess). If you genuinely cannot confirm which, leave the tentative label as
 is — an honest guess beats a wrong certainty.
 
+**Deep-link the URL to the actual broadcast when you can.** Prefer the specific
+programme/live page over the broadcaster's front page — it opens the app on THIS
+event, not its home screen. NRK is the easiest and most reliable: use the real
+programme/live URL (`https://tv.nrk.no/serie/…`, `/program/…`, or `/direkte/…`)
+that you land on when you find the broadcast. TV 2 Play / Viaplay per-event pages
+too when stable. A deep URL you set for an event **survives rebuilds** (build-events
+keeps the most specific known URL per broadcaster); the rights map's generic
+sport-section landing is only the fallback. Never invent a URL — only use one you
+actually reached.
+
 **Feed the calibration ledger.** For every source you consult, append one line
 to `docs/data/calibration-ledger.jsonl` (create if missing):
 `{ "checkedAt": ISO, "sport": "...", "source": "domain.tld", "field": "time"|"streaming"|"existence", "agreed": true|false, "note": "..." }`

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -207,13 +207,39 @@ if (Array.isArray(previousEvents)) {
 // e.g. verify resolves a World Cup match's "NRK / TV 2" to the actual "NRK";
 // without this the hourly rebuild would overwrite it with the guess again.
 const prevConfirmedStreaming = new Map();
+const prevStreamingByKey = new Map();
 if (Array.isArray(previousEvents)) {
 	for (const prev of previousEvents) {
 		const s = prev.streaming;
-		if (Array.isArray(s) && s.length && !s.some((c) => c && c.tentative)) {
-			prevConfirmedStreaming.set(`${prev.sport}|${prev.title}|${prev.time}`, s);
+		if (Array.isArray(s) && s.length) {
+			prevStreamingByKey.set(`${prev.sport}|${prev.title}|${prev.time}`, s);
+			if (!s.some((c) => c && c.tentative)) {
+				prevConfirmedStreaming.set(`${prev.sport}|${prev.title}|${prev.time}`, s);
+			}
 		}
 	}
+}
+
+// Keep the most specific known viewing URL per broadcaster. A deep per-event URL
+// (e.g. a verify-found NRK program page tv.nrk.no/serie/…, which opens the app on
+// the actual broadcast) must survive the hourly rebuild — otherwise resolveStreaming
+// re-derives the generic sport-section landing from the rights map and clobbers it.
+// Match by host, prefer the deeper path.
+function hostOf(u) { try { return new URL(u).host; } catch { return ""; } }
+function pathDepth(u) { try { return new URL(u).pathname.replace(/\/+$/, "").split("/").filter(Boolean).length; } catch { return -1; } }
+function withDeepUrls(streaming, prevStreaming) {
+	if (!Array.isArray(streaming) || !Array.isArray(prevStreaming) || !prevStreaming.length) return streaming;
+	const bestByHost = new Map();
+	for (const p of prevStreaming) {
+		if (!p || !p.url || p.tentative) continue;
+		const h = hostOf(p.url);
+		if (h && (!bestByHost.has(h) || pathDepth(p.url) > pathDepth(bestByHost.get(h)))) bestByHost.set(h, p.url);
+	}
+	return streaming.map((c) => {
+		if (!c || !c.url) return c;
+		const deeper = bestByHost.get(hostOf(c.url));
+		return (deeper && pathDepth(deeper) > pathDepth(c.url)) ? { ...c, url: deeper } : c;
+	});
 }
 
 // Resolve streaming to Norwegian channels — prefer REAL tvkampen.com listings
@@ -223,15 +249,18 @@ let fromTv = 0;
 let keptConfirmed = 0;
 for (const e of all) {
 	const before = e.streaming;
+	const key = `${e.sport}|${e.title}|${e.time}`;
 	const resolved = resolveStreaming(e, tvListings);
 	const resolvedTentative = !resolved.length || resolved.some((c) => c && c.tentative);
-	const priorConfirmed = prevConfirmedStreaming.get(`${e.sport}|${e.title}|${e.time}`);
+	const priorConfirmed = prevConfirmedStreaming.get(key);
 	if (resolvedTentative && priorConfirmed) {
 		e.streaming = priorConfirmed; // keep the confirmed channel, don't re-guess
 		keptConfirmed++;
 	} else {
 		e.streaming = resolved;
 	}
+	// Upgrade generic landing URLs to a deeper per-event URL we already knew.
+	e.streaming = withDeepUrls(e.streaming, prevStreamingByKey.get(key));
 	if (e.sport === "football" && e.streaming !== before && e.streaming.length && tvListings.length) {
 		// count football events whose channel came from a real listing match
 		fromTv++;

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -3,10 +3,13 @@
 // broadcaster like FOX/ESPN. The verify agent refines per-event on top of this;
 // this guarantees a correct default. Mirrors .claude/skills/norwegian-rights.
 
+// Fallback landing URLs — the sport/live section, not the bare homepage, so a tap
+// lands closer to the broadcast and is likelier to be claimed by the app's
+// universal links (deep per-event URLs from the verify agent override these).
 const CH = {
 	viaplay: { platform: "Viaplay", url: "https://viaplay.no" },
-	tv2: { platform: "TV 2 Play", url: "https://play.tv2.no" },
-	nrk: { platform: "NRK", url: "https://tv.nrk.no" },
+	tv2: { platform: "TV 2 Play", url: "https://play.tv2.no/sport" },
+	nrk: { platform: "NRK", url: "https://tv.nrk.no/direkte" },
 	discovery: { platform: "Discovery+", url: "https://www.discoveryplus.no" },
 	eurosport: { platform: "Eurosport", url: "https://www.eurosport.no" },
 	max: { platform: "Max", url: "https://www.max.com" },
@@ -120,10 +123,10 @@ export function normalizeStreaming(ev) {
 // ── Real Norwegian TV listings (tvkampen.com) — actual data over the static map ──
 
 const CHANNEL_URLS = [
-	["tv 2 play", "https://play.tv2.no"], ["tv2 play", "https://play.tv2.no"],
-	["tv 2 sport", "https://play.tv2.no"], ["tv 2", "https://play.tv2.no"],
+	["tv 2 play", "https://play.tv2.no/sport"], ["tv2 play", "https://play.tv2.no/sport"],
+	["tv 2 sport", "https://play.tv2.no/sport"], ["tv 2", "https://play.tv2.no/sport"],
 	["viaplay", "https://viaplay.no"], ["v sport", "https://viaplay.no"],
-	["nrk", "https://tv.nrk.no"],
+	["nrk", "https://tv.nrk.no/direkte"],
 	["discovery", "https://www.discoveryplus.no"], ["eurosport", "https://www.eurosport.no"],
 	["max", "https://www.max.com"], ["vg", "https://www.vg.no/sport"],
 ];

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -138,6 +138,26 @@ describe("build-events", () => {
 		expect(derby.verificationStatus).toBe("confirmed");
 	});
 
+	it("upgrades a generic landing URL to a deeper per-event URL from the previous build", () => {
+		const time = future(2);
+		// biathlon → rights map returns the NRK sport-section landing (tv.nrk.no/direkte, depth 1).
+		fs.writeFileSync(
+			path.join(configDir, "biathlon.json"),
+			JSON.stringify({ sport: "biathlon", name: "IBU World Cup", events: [{ title: "Sprint", time }] })
+		);
+		// Previous build: verify found the real NRK programme page (deeper).
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "biathlon", tournament: "IBU World Cup", title: "Sprint", time,
+				  streaming: [{ platform: "NRK", url: "https://tv.nrk.no/serie/skiskyting/sprint-abc" }] },
+			])
+		);
+		const events = runBuild();
+		const sprint = events.find((e) => e.title === "Sprint");
+		expect(sprint.streaming[0].url).toBe("https://tv.nrk.no/serie/skiskyting/sprint-abc"); // deep URL survived, not clobbered by /direkte
+	});
+
 	it("keeps a confirmed channel instead of downgrading it to a tentative guess", () => {
 		const time = future(2);
 		// A World Cup fixture — resolveStreaming would produce the tentative NRK / TV 2 label.


### PR DESCRIPTION
## Spørsmålet: åpner et trykk appen / selve sendingen?

Før: **ikke pålitelig.** Vi lagret generiske forside-URLer (viaplay.no, play.tv2.no, tv.nrk.no), så et trykk landet på forsiden — og ofte bare i nettleseren.

## Endringer

- **Rights-kartets fallback** peker nå på sport/direkte-seksjonen, ikke bar forside (verifisert 200): NRK → `tv.nrk.no/direkte`, TV 2 → `play.tv2.no/sport`. Nærmere sendingen og mer sannsynlig fanget av appens universal links.
- **build-events beholder den mest spesifikke kjente URL-en per kringkaster** (match på host, foretrekk dypere sti) — så en dyp per-event-URL en agent finner **overlever den timevise ombyggingen** i stedet for å bli klobbet av den generiske landingen.
- **verify/research-prompter + norwegian-rights-skill:** foretrekk dyp per-event-URL — særlig NRK-programsider (`tv.nrk.no/serie|program|direkte`), som er stabile og pålitelig dyp-lenkbare — forside kun som fallback, aldri en oppdiktet sti (TV 2/Viaplay match-stier 404-er).

Klienten rendrer allerede `streaming[].url`, så dype URLer flyter gjennom automatisk.

## Ærlig forbehold
Om et trykk faktisk åpner *appen* avhenger fortsatt av kringkasterens universal-link-oppsett + brukerens enhet/installerte app — det kan vi ikke tvinge eller teste herfra. Vi sender nå den dypeste/mest spesifikke URL-en vi kjenner, som er forutsetningen.

`npm test`: 244 grønne (+1). Landings-URLer HTTP-verifisert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)