### PR TITLE
Football: link to the tvkampen per-match page, not just /sport

### DIFF
--- a/.claude/skills/norwegian-rights/SKILL.md
+++ b/.claude/skills/norwegian-rights/SKILL.md
@@ -21,10 +21,12 @@ specific *safe* URL — one you actually reached, never an invented path:
   use the real `https://tv.nrk.no/serie/…`, `/program/…`, or `/direkte/…` page for
   THIS broadcast when you find it. This is the gold standard.
 - **Football:** `docs/data/tv-listings.json` carries a per-match `url` (the tvkampen
-  match page listing every Norwegian broadcaster for THAT match). When an event
-  matches a listing (by team names), set `streaming[].url` to that match `url`.
-  It's the best link for football — and the ONLY good link for **shared/tentative**
-  rights (e.g. WC "NRK / TV 2"), where pointing at one broadcaster would mislead.
+  match page listing every Norwegian broadcaster for THAT match). `build-events` now
+  applies this automatically — it points TV 2 / Viaplay football options at the
+  tvkampen match page (their per-match app URLs 404), keeps NRK football on its own
+  `tv.nrk.no` URL (opens the app), and makes the shared/tentative "NRK / TV 2" chip
+  link to the tvkampen guide (the ONLY safe link when the broadcaster is unresolved).
+  You don't need to set football URLs by hand — but do deep-link NRK per the point above.
 - **TV 2 Play / Viaplay & the rest:** do NOT invent per-match paths
   (`play.tv2.no/…/<match>`) — they 404 (auth-gated). Use the service's **sport-section
   landing** (the map's fallback: `play.tv2.no/sport`, `tv.nrk.no/direkte`, `viaplay.no`),

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -200,6 +200,13 @@ class Dashboard {
 		return escapeHtml(e.title);
 	}
 
+	/** A channel is tappable when it has a URL — but a TENTATIVE (shared-rights)
+	 *  entry only links to a tvkampen match GUIDE, never to one broadcaster (which
+	 *  would mislead when it might be the other). */
+	streamLink(s) {
+		return !!(s && s.url && (!s.tentative || /tvkampen\.com/.test(s.url)));
+	}
+
 	/** Where to watch — quiet, honest. First 1–2 Norwegian channels; faint dash if unknown. */
 	whereToWatch(e) {
 		const streams = Array.isArray(e.streaming) ? e.streaming : [];
@@ -209,7 +216,7 @@ class Dashboard {
 		const extra = streams.length > 1 ? `<span class="ev-where-more">+${streams.length - 1}</span>` : '';
 		// Tentative (shared rights, exact channel not yet confirmed) → plain text,
 		// no link — linking to one broadcaster when it may be the other misleads.
-		const inner = (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
+		const inner = this.streamLink(s) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
 		const cls = s.tentative ? 'ev-where tentative' : 'ev-where';
 		return `<span class="${cls}">${inner}${extra}</span>`;
 	}
@@ -488,7 +495,7 @@ class Dashboard {
 			const chans = streams.map((s) => {
 				const p = escapeHtml(String(s.platform || s));
 				const label = s.tentative ? `${p} <span class="tbd">(bekreftes)</span>` : p;
-				return (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
+				return this.streamLink(s) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
 			}).join(' · ');
 			add('Se på', chans);
 		}
@@ -801,7 +808,7 @@ class Dashboard {
 			? streams.map((s) => {
 				const p = escapeHtml(String(s.platform || s));
 				const label = s.tentative ? `${p} <span class="tbd">(bekreftes)</span>` : p;
-				return (s.url && !s.tentative) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
+				return this.streamLink(s) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
 			}).join(' · ')
 			: '<span class="tbd">–</span>';
 		const rows = [

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -213,7 +213,22 @@ export function resolveStreaming(ev, tvListings) {
 			let s = listingStreaming(listing);
 			// WC: trust the real listing to say WHICH of NRK/TV 2, drop aggregator noise.
 			if (isWorldCup(ev)) s = worldCupChannels(s);
-			if (s.length) return s;
+			if (s.length) {
+				// Point TV 2 / Viaplay at the tvkampen MATCH page — a per-match
+				// "when & where" guide — since they don't expose linkable per-match
+				// app URLs. Keep NRK's own URL (tv.nrk.no), which opens the NRK app.
+				if (listing.url) {
+					s = s.map((c) => {
+						const isNrk = /nrk/i.test(c.platform || "") || /tv\.nrk\.no/.test(c.url || "");
+						return isNrk ? c : { ...c, url: listing.url };
+					});
+				}
+				return s;
+			}
+			// Listing exists but no confirmable Norwegian rights holder (e.g. only
+			// SVT): still offer the match's tvkampen page as a linkable guide so the
+			// user can at least see when & on which channel it airs.
+			if (isWorldCup(ev) && listing.url) return [{ ...WC_SHARED, url: listing.url }];
 		}
 	}
 	return normalizeStreaming(ev);

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -161,6 +161,16 @@ describe("whereToWatch — the core 'hvor kan jeg se det'", () => {
 		expect(html).toContain("NRK 1");
 		expect(html).toContain("tv.nrk.no");
 	});
+	it("only links a tentative (shared-rights) channel to a tvkampen guide, never to one broadcaster", () => {
+		expect(dash.streamLink({ platform: "TV 2 Play", url: "https://play.tv2.no/sport" })).toBe(true);           // confirmed → link
+		expect(dash.streamLink({ platform: "NRK / TV 2", url: "https://tv.nrk.no", tentative: true })).toBe(false); // tentative broadcaster → don't link (misleads)
+		expect(dash.streamLink({ platform: "NRK / TV 2", url: "https://www.tvkampen.com/kamp/x-1", tentative: true })).toBe(true); // tentative guide → link
+	});
+	it("renders a tentative WC chip as a tappable tvkampen guide link", () => {
+		const html = dash.whereToWatch({ streaming: [{ platform: "NRK / TV 2", url: "https://www.tvkampen.com/kamp/x-1", tentative: true }] });
+		expect(html).toContain("tvkampen.com/kamp/x-1");
+		expect(html).toContain("<a ");
+	});
 	it("shows a faint dash when the channel is unknown (honest, not noisy)", () => {
 		const html = dash.whereToWatch({ streaming: [] });
 		expect(html).toContain("ev-where unknown");

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -70,6 +70,31 @@ describe("tvkampen real-listing integration", () => {
 	});
 });
 
+describe("tvkampen per-match link (per-match 'when & where')", () => {
+	const withUrl = [
+		{ homeTeam: "Liverpool", awayTeam: "Arsenal", broadcasters: ["TV 2 Play"], url: "https://www.tvkampen.com/kamp/liverpool-arsenal-1" },
+		{ homeTeam: "Canada", awayTeam: "Marokko", broadcasters: ["NRK1", "NRK TV"], url: "https://www.tvkampen.com/kamp/canada-marokko-2" },
+		{ homeTeam: "Paraguay", awayTeam: "Frankrike", broadcasters: ["Svt"], url: "https://www.tvkampen.com/kamp/paraguay-frankrike-3" },
+	];
+	it("points TV 2 at the tvkampen match page (no linkable per-match app URL)", () => {
+		const s = resolveStreaming({ sport: "football", homeTeam: "Liverpool", awayTeam: "Arsenal", tournament: "Premier League" }, withUrl);
+		expect(s[0].platform).toBe("TV 2 Play");
+		expect(s[0].url).toBe("https://www.tvkampen.com/kamp/liverpool-arsenal-1");
+	});
+	it("keeps NRK's own URL (opens the NRK app), not the tvkampen page", () => {
+		const s = resolveStreaming({ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Canada", awayTeam: "Morocco" }, withUrl);
+		expect(s[0].platform).toBe("NRK");
+		expect(s[0].url).toContain("tv.nrk.no");
+		expect(s[0].url).not.toContain("tvkampen");
+	});
+	it("offers the tvkampen guide when no Norwegian rights holder is confirmable (SVT only)", () => {
+		const s = resolveStreaming({ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Paraguay", awayTeam: "France" }, withUrl);
+		expect(s[0].platform).toBe("NRK / TV 2");
+		expect(s[0].tentative).toBe(true);
+		expect(s[0].url).toBe("https://www.tvkampen.com/kamp/paraguay-frankrike-3");
+	});
+});
+
 describe("World Cup per-match channel resolution (English↔Norwegian nations)", () => {
 	// tvkampen lists nations in Norwegian and pads with aggregators; ESPN emits
 	// English nation names. Both bugs together made every WC match show NRK + TV 2.


### PR DESCRIPTION
## Hva

tvkampen-scraperen fanger allerede hver kamps side-URL (når + hvilken norsk kanal); `resolveStreaming` brukte den bare ikke. Nå får fotball per-kamp-lenker:

- **TV 2 / Viaplay** → tvkampen-kampsiden (deres per-kamp app-URLer 404-er / er innloggingsstyrte, så dette er den beste per-kamp «når & hvor»-lenken).
- **NRK** beholder sin egen `tv.nrk.no`-URL — den åpner NRK-appen, bedre enn en guide-side.
- **Delt/tentativ «NRK / TV 2»** (kringkaster uavklart) lenker nå også til tvkampen-guiden — før hadde den ingen lenke. Klienten gjør en tentativ chip tappbar **kun** når URL-en er en tvkampen-guide (aldri én kringkaster, som ville villedet).

## Ærlig
tvkampen-kampsiden er en per-kamp TV-*guide* (viser tid + kanal), ikke en app-deeplink — den er den beste tilgjengelige per-kamp-lenken for TV 2/Viaplay. Ekte app-deeplink skjer via NRK.

`npm test`: 249 grønne (+5). Skill oppdatert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)