### PR TITLE
Lift bare broadcaster homepages to their sport/live section

### DIFF
--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -242,6 +242,24 @@ function withDeepUrls(streaming, prevStreaming) {
 	});
 }
 
+// A bare broadcaster homepage → its sport/live section (closer to the broadcast,
+// likelier to be claimed by the app's universal links). Only exact homepages are
+// rewritten, so a deeper per-event URL is never downgraded. Catches agent-set
+// URLs that bypass the rights map (e.g. a verified WC channel written as
+// "https://tv.nrk.no").
+const LANDING_UPGRADE = {
+	"https://tv.nrk.no": "https://tv.nrk.no/direkte",
+	"https://play.tv2.no": "https://play.tv2.no/sport",
+};
+function upgradeLanding(streaming) {
+	if (!Array.isArray(streaming)) return streaming;
+	return streaming.map((c) => {
+		if (!c || !c.url) return c;
+		const bare = c.url.replace(/\/+$/, "");
+		return LANDING_UPGRADE[bare] ? { ...c, url: LANDING_UPGRADE[bare] } : c;
+	});
+}
+
 // Resolve streaming to Norwegian channels — prefer REAL tvkampen.com listings
 // for football, fall back to the deterministic rights map (never FOX/ESPN).
 const tvListings = readJsonIfExists(path.join(dataDir, "tv-listings.json"))?.listings || [];
@@ -259,8 +277,9 @@ for (const e of all) {
 	} else {
 		e.streaming = resolved;
 	}
-	// Upgrade generic landing URLs to a deeper per-event URL we already knew.
-	e.streaming = withDeepUrls(e.streaming, prevStreamingByKey.get(key));
+	// Upgrade generic landing URLs to a deeper per-event URL we already knew,
+	// then lift any bare homepage to the broadcaster's sport/live section.
+	e.streaming = upgradeLanding(withDeepUrls(e.streaming, prevStreamingByKey.get(key)));
 	if (e.sport === "football" && e.streaming !== before && e.streaming.length && tvListings.length) {
 		// count football events whose channel came from a real listing match
 		fromTv++;

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -158,6 +158,27 @@ describe("build-events", () => {
 		expect(sprint.streaming[0].url).toBe("https://tv.nrk.no/serie/skiskyting/sprint-abc"); // deep URL survived, not clobbered by /direkte
 	});
 
+	it("lifts a bare broadcaster homepage to its sport/live section", () => {
+		const time = future(2);
+		fs.writeFileSync(
+			path.join(dataDir, "football.json"),
+			JSON.stringify({ tournaments: [{ name: "FIFA World Cup", events: [
+				{ title: "Norway vs Brazil", time, homeTeam: "Norway", awayTeam: "Brazil" },
+			] }] })
+		);
+		// Previous build: verify confirmed NRK but wrote the bare homepage URL.
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "football", tournament: "FIFA World Cup", title: "Norway vs Brazil", time, homeTeam: "Norway", awayTeam: "Brazil",
+				  streaming: [{ platform: "NRK", url: "https://tv.nrk.no" }] },
+			])
+		);
+		const events = runBuild();
+		const m = events.find((e) => e.title === "Norway vs Brazil");
+		expect(m.streaming[0].url).toBe("https://tv.nrk.no/direkte"); // homepage → sport/live section
+	});
+
 	it("keeps a confirmed channel instead of downgrading it to a tentative guess", () => {
 		const time = future(2);
 		// A World Cup fixture — resolveStreaming would produce the tentative NRK / TV 2 label.
@@ -177,7 +198,9 @@ describe("build-events", () => {
 		);
 		const events = runBuild();
 		const match = events.find((e) => e.title === "Brazil vs Norway");
-		expect(match.streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no" }]);
+		// Confirmed NRK is kept (not downgraded to the tentative NRK/TV 2 guess);
+		// the bare homepage is lifted to NRK's live section.
+		expect(match.streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no/direkte" }]);
 		expect(match.streaming.some((s) => s.tentative)).toBe(false);
 	});
 


### PR DESCRIPTION
Oppfølging til deeplink-arbeidet: WC-kamper med agent-bekreftet kanal beholdt bar forside-URL (`tv.nrk.no` / `play.tv2.no`), fordi den bekreftede verdien vinner over rights-kartet. `build-events` normaliserer nå enhver endelig bar forside til kringkasterens sport/direkte-seksjon (`tv.nrk.no/direkte`, `play.tv2.no/sport`) — nærmere sendingen og mer sannsynlig å åpne appen — uten å nedgradere en dypere per-event-URL.

`npm test`: 250 grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)