### PR TITLE
Golf & F1: link Viaplay to its sport section, not the homepage

### DIFF
--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -250,6 +250,7 @@ function withDeepUrls(streaming, prevStreaming) {
 const LANDING_UPGRADE = {
 	"https://tv.nrk.no": "https://tv.nrk.no/direkte",
 	"https://play.tv2.no": "https://play.tv2.no/sport",
+	"https://viaplay.no": "https://viaplay.no/no-no/sport",
 };
 function upgradeLanding(streaming) {
 	if (!Array.isArray(streaming)) return streaming;

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -7,7 +7,7 @@
 // lands closer to the broadcast and is likelier to be claimed by the app's
 // universal links (deep per-event URLs from the verify agent override these).
 const CH = {
-	viaplay: { platform: "Viaplay", url: "https://viaplay.no" },
+	viaplay: { platform: "Viaplay", url: "https://viaplay.no/no-no/sport" },
 	tv2: { platform: "TV 2 Play", url: "https://play.tv2.no/sport" },
 	nrk: { platform: "NRK", url: "https://tv.nrk.no/direkte" },
 	discovery: { platform: "Discovery+", url: "https://www.discoveryplus.no" },
@@ -125,7 +125,7 @@ export function normalizeStreaming(ev) {
 const CHANNEL_URLS = [
 	["tv 2 play", "https://play.tv2.no/sport"], ["tv2 play", "https://play.tv2.no/sport"],
 	["tv 2 sport", "https://play.tv2.no/sport"], ["tv 2", "https://play.tv2.no/sport"],
-	["viaplay", "https://viaplay.no"], ["v sport", "https://viaplay.no"],
+	["viaplay", "https://viaplay.no/no-no/sport"], ["v sport", "https://viaplay.no/no-no/sport"],
 	["nrk", "https://tv.nrk.no/direkte"],
 	["discovery", "https://www.discoveryplus.no"], ["eurosport", "https://www.eurosport.no"],
 	["max", "https://www.max.com"], ["vg", "https://www.vg.no/sport"],

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -38,6 +38,18 @@ describe("normalizeStreaming", () => {
 
 import { resolveStreaming, matchTvListing } from "../scripts/lib/norwegian-rights.js";
 
+describe("Viaplay sports (golf, F1) link to the sport section, not the homepage", () => {
+	it("F1 resolves to Viaplay's sport section", () => {
+		const s = normalizeStreaming({ sport: "f1", tournament: "Belgian Grand Prix" });
+		expect(s[0].platform).toBe("Viaplay");
+		expect(s[0].url).toBe("https://viaplay.no/no-no/sport");
+	});
+	it("golf resolves to Viaplay's sport section", () => {
+		const s = normalizeStreaming({ sport: "golf", tournament: "PGA Tour" });
+		expect(s[0].url).toBe("https://viaplay.no/no-no/sport");
+	});
+});
+
 describe("tvkampen real-listing integration", () => {
 	const listings = [
 		{ homeTeam: "Liverpool", awayTeam: "Arsenal", time: "18:30", broadcasters: ["TV 2 Play", "TV 2 Sport 1", "Coolbet"] },


### PR DESCRIPTION
Golf og F1 (og Viaplay-alpint) pekte fortsatt på bar `viaplay.no` — de fikk ikke landings-oppgraderingen som bare dekket NRK/TV 2. Peker nå Viaplay på den verifiserte sport-seksjonen (`viaplay.no/no-no/sport` — en ekte side, tittel «Følg live sport online», forskjellig fra forsiden), både i rights-kartet og i forside-normaliseringen.

Viaplay er en innloggings-SPA uten pålitelige per-event/per-sport dype URLer (`/golf`, `/formel-1` faller tilbake til det generiske sport-skallet), så sport-seksjonen er den tryggeste, nærmeste landingen som åpner appen.

`npm test`: 252 grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)