### PR TITLE
Show the Tour de France on TV 2 Play only (owner watches there)

### DIFF
--- a/.claude/skills/norwegian-rights/SKILL.md
+++ b/.claude/skills/norwegian-rights/SKILL.md
@@ -62,7 +62,7 @@ known URL per broadcaster and won't clobber it with the generic landing.
 - Alpine (FIS World Cup) → **Viaplay** [verify]
 
 ## Cycling
-- Tour de France → **TV 2 Play** [solid] (TV 2 deal covers 2026–2030 per NTB press release; hjelp.tv2.no confirms TV 2 Direkte + TV 2 Play; Eurosport Norge reportedly shares 2026 rights per cyclingweekly.com [verify]; confirmed 2026-07-03)
+- Tour de France → **TV 2 Play** [solid] (TV 2 deal covers 2026–2030 per NTB press release; hjelp.tv2.no confirms TV 2 Direkte + TV 2 Play; Eurosport Norge reportedly shares 2026 rights per cyclingweekly.com [verify]; confirmed 2026-07-03). **Owner preference: show TV 2 Play only** for the Tour — don't re-add Max/Eurosport as a "+1" even though WBD carries the opening hour (they follow it on TV 2 Play).
 - Other UCI races → [verify per event]
 
 ## Chess

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -86,9 +86,11 @@ export function norwegianRights(ev) {
 	}
 	if (sport === "golf") return /masters/.test(hay) ? [CH.discovery] : [CH.viaplay];
 	if (sport === "f1" || sport === "formula1") return [CH.viaplay];
-	// Tour de France 2026 rights are SHARED: TV 2 (Play/Direkte) + WBD (Max/Eurosport,
-	// which alone carries the first hour of each stage). Both are valid "where to watch".
-	if (sport === "cycling") return /tour de france/.test(hay) ? [CH.tv2, CH.max] : [];
+	// Tour de France 2026 rights are shared: TV 2 (Play/Direkte) + WBD (Max/Eurosport
+	// carries the first hour of each stage). The owner follows the Tour on TV 2 Play,
+	// so we show that single channel rather than a "+1" — a viewing preference, not a
+	// rights claim (Max still carries the opening hour).
+	if (sport === "cycling") return /tour de france/.test(hay) ? [CH.tv2] : [];
 	if (sport === "tennis") {
 		// Wimbledon (like all Grand Slams) is Warner Bros. Discovery in Norway —
 		// HBO Max + Eurosport, NOT TV 2. Finals are also free on WBD's REX channel.

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -50,6 +50,14 @@ describe("Viaplay sports (golf, F1) link to the sport section, not the homepage"
 	});
 });
 
+describe("cycling: the Tour is shown on TV 2 Play only (owner preference)", () => {
+	it("Tour de France → TV 2 Play, no Max '+1'", () => {
+		const s = normalizeStreaming({ sport: "cycling", tournament: "Tour de France", title: "Etappe 5" });
+		expect(s.map((c) => c.platform)).toEqual(["TV 2 Play"]);
+		expect(s[0].url).toContain("play.tv2.no");
+	});
+});
+
 describe("tvkampen real-listing integration", () => {
 	const listings = [
 		{ homeTeam: "Liverpool", awayTeam: "Arsenal", time: "18:30", broadcasters: ["TV 2 Play", "TV 2 Sport 1", "Coolbet"] },


### PR DESCRIPTION
Du følger Touren på **TV 2 Play**, så jeg dropper Max-«+1» for sykkel/TdF — en visningspreferanse, ikke en rettighetsendring (WBD har fortsatt første time). Renere «hvor ser jeg det» og matcher hvordan du faktisk ser det. Notert i skillet så verify-agenten ikke re-legger Max.

**WBD-familien** (Discovery+/Max/Eurosport for Masters + tennis) sjekket, men latt stå på forside-nivå: Discovery+ `/sport` er bare SPA-skallet, Eurosport blokkerer bots, og ingen verifiserbar dypere Max-landing — å utdype ville risikert en død lenke.

`npm test`: 253 grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)