### PR TITLE
Refresh data + date when the PWA returns to the foreground

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,24 @@
 	<script>
 		if ('serviceWorker' in navigator) {
 			window.addEventListener('load', () => {
-				navigator.serviceWorker.register('sw.js').catch(() => {});
+				navigator.serviceWorker.register('sw.js').then((reg) => {
+					reg.update();
+					// Re-check for a new version when the app returns to the foreground
+					// (iOS home-screen PWAs resume without reloading).
+					document.addEventListener('visibilitychange', () => {
+						if (!document.hidden) reg.update();
+					});
+				}).catch(() => {});
+				// If the page was already controlled, reload once when a new worker
+				// takes over so a shipped update lands without a manual refresh.
+				if (navigator.serviceWorker.controller) {
+					let reloaded = false;
+					navigator.serviceWorker.addEventListener('controllerchange', () => {
+						if (reloaded) return;
+						reloaded = true;
+						window.location.reload();
+					});
+				}
 			});
 		}
 	</script>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -21,14 +21,32 @@ class Dashboard {
 		this.startClock();
 		await this.loadData();
 		this.render();
+		this._lastRefresh = Date.now();
 		this.startLivePolling();
 		this.bindAgendaExpand();
 		this.bindFollowed();
 		this.maybeShowInstallHint();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
-			if (this._liveVisible) this.pollLiveScores();
+			if (this._liveVisible) this.onResume();
 		});
+	}
+
+	/** Brought back to the foreground. On iOS a home-screen PWA resumes the old
+	 *  page instead of reloading, so data is fetched only once (in init) and the
+	 *  board would keep showing yesterday. Re-pull data + re-stamp the date so a
+	 *  reopen always reflects today. Throttled so quick tab-switches don't refetch. */
+	async onResume() {
+		const now = Date.now();
+		if (this._lastRefresh && now - this._lastRefresh < 30 * 1000) {
+			this.pollLiveScores();
+			return;
+		}
+		this._lastRefresh = now;
+		this.renderDate();   // the day may have rolled over since it was opened
+		try { await this.loadData(); } catch { /* keep showing what we have */ }
+		this.render();
+		this.pollLiveScores();
 	}
 
 	async loadData() {

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // SportSync v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-15';
+const CACHE_NAME = 'sportsync-v2-16';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [


### PR DESCRIPTION
## Problem
Åpnet appen i dag, men den viste fortsatt gårsdagen. **Rotårsak:** på iOS gjenåpner en hjemmeskjerm-PWA den eksisterende siden i stedet for å laste på nytt, og dashboardet hentet data kun én gang (i `init()`). Ved gjenåpning kjørte bare live-score-polling — datoen ble aldri re-stemplet — så den hang på dagen den først ble åpnet.

(Serveren + Pages var oppdatert, og SW-en er allerede network-first — siden hentet bare aldri på nytt.)

## Fiks
- **dashboard:** `onResume()` henter data + re-stempler datoen på `visibilitychange` (throttlet 30s), så gjenåpning alltid viser i dag.
- **SW-registrering:** `reg.update()` ved last og ved forgrunn; reload én gang på `controllerchange` (kun hvis allerede kontrollert) så shippede oppdateringer lander uten manuell refresh. Cache bumpet til v2-16.

## Verifisert
`npm test`: 253 grønne. Headless: gjenåpning trigger en ny `events.json`-henting (1 → 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)