### PR TITLE
Live leaderboard for golf + F1 (quiet line, tap for the board)

### DIFF
--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -26,7 +26,22 @@
 	font-size: 16px;
 }
 .live-item .live-score { font-weight: 600; font-variant-numeric: tabular-nums; }
-.live-item .live-meta { color: var(--fg-2); font-size: 14px; margin-left: auto; }
+.live-item .live-meta { color: var(--fg-2); font-size: 14px; margin-left: auto; white-space: nowrap; }
+
+/* Live golf/F1: a quiet line — leader on the right, your athletes' live position
+   under the name — that expands to the top of the leaderboard on tap. */
+.live-body { display: flex; flex-direction: column; min-width: 0; }
+.live-you { font-size: 12.5px; color: var(--fg-2); margin-top: 2px; overflow-wrap: anywhere; }
+.live-you .live-pos { color: var(--fg-3); }
+.live-item.live-expand { cursor: pointer; }
+.live-caret { color: var(--fg-3); font-size: 13px; opacity: 0.55; margin-left: 6px; display: inline-block; transition: transform 0.15s; }
+.live-item.live-expand[aria-expanded="true"] .live-caret { transform: rotate(90deg); }
+.live-detail { padding: 6px 0 8px 15px; display: grid; gap: 3px; }
+.lb-row { display: grid; grid-template-columns: 30px 1fr auto; gap: 10px; align-items: baseline; font-size: 13.5px; }
+.lb-pos { color: var(--fg-3); font-variant-numeric: tabular-nums; text-align: right; }
+.lb-name { color: var(--fg-2); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lb-x { color: var(--fg); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.lb-row.mine .lb-name, .lb-row.mine .lb-x { color: var(--accent); font-weight: 600; }
 
 .live-dot {
 	width: 7px; height: 7px; border-radius: 50%;

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -11,6 +11,7 @@ class Dashboard {
 		this.meta = null;
 		this.liveScores = {};
 		this.liveLeaderboard = null;
+		this.liveF1 = null;
 		this._liveInterval = null;
 		this._liveVisible = !document.hidden;
 	}
@@ -25,6 +26,7 @@ class Dashboard {
 		this.startLivePolling();
 		this.bindAgendaExpand();
 		this.bindFollowed();
+		this.bindLive();
 		this.maybeShowInstallHint();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
@@ -243,18 +245,68 @@ class Dashboard {
 	renderLive() {
 		const box = document.getElementById('live-now');
 		if (!box) return;
-		const rows = [];
+		const items = [];
 		for (const [id, live] of Object.entries(this.liveScores)) {
 			if (live.state !== 'in') continue;
-			rows.push(`<div class="live-item"><span class="live-dot"></span><span>${escapeHtml(ssShortName(live.homeName))} <span class="live-score">${live.home}–${live.away}</span> ${escapeHtml(ssShortName(live.awayName))}</span><span class="live-meta">${escapeHtml(live.clock || '')}</span></div>`);
+			items.push(`<div class="live-wrap"><div class="live-item"><span class="live-dot"></span><span class="live-body"><span class="live-name">${escapeHtml(ssShortName(live.homeName))} <span class="live-score">${live.home}–${live.away}</span> ${escapeHtml(ssShortName(live.awayName))}</span></span><span class="live-meta">${escapeHtml(live.clock || '')}</span></div></div>`);
 		}
-		if (this.liveLeaderboard?.state === 'in' && this.liveLeaderboard.players?.length) {
-			const p = this.liveLeaderboard.players[0];
-			rows.push(`<div class="live-item"><span class="live-dot"></span><span>${escapeHtml(this.liveLeaderboard.name)}</span><span class="live-meta">${escapeHtml(p.player)} ${escapeHtml(p.score)}</span></div>`);
-		}
-		if (rows.length === 0) { box.hidden = true; return; }
-		box.innerHTML = `<div class="live-label"><span class="live-dot"></span>Direkte nå</div>${rows.join('')}`;
+		if (this.liveLeaderboard?.state === 'in' && this.liveLeaderboard.top?.length) items.push(this.liveGolfItem(this.liveLeaderboard));
+		if (this.liveF1?.state === 'in' && this.liveF1.top?.length) items.push(this.liveF1Item(this.liveF1));
+		if (items.length === 0) { box.hidden = true; return; }
+		box.innerHTML = `<div class="live-label"><span class="live-dot"></span>Direkte nå</div>${items.join('')}`;
 		box.hidden = false;
+	}
+
+	/** One leaderboard row (position · name · trailing value), your player highlighted. */
+	lbRow(pos, name, trail, mine) {
+		return `<div class="lb-row${mine ? ' mine' : ''}"><span class="lb-pos">${escapeHtml(String(pos ?? ''))}</span><span class="lb-name">${mine ? '🇳🇴 ' : ''}${escapeHtml(ssShortName(name || ''))}</span><span class="lb-x">${escapeHtml(String(trail ?? ''))}</span></div>`;
+	}
+
+	/** Golf live: quiet line (tournament + leader + your Norwegians' live position),
+	 *  tap to expand the top of the leaderboard (with your players appended if lower). */
+	liveGolfItem(g) {
+		const open = !!(this._liveOpen && this._liveOpen.golf);
+		const leader = g.top[0];
+		const you = (g.tracked || []).map((t) => `🇳🇴 ${escapeHtml(ssShortName(t.player))} ${escapeHtml(t.score)} <span class="live-pos">${escapeHtml(String(t.pos))}.</span>`).join(' · ');
+		const board = g.top.map((r) => this.lbRow(r.pos, r.player, r.score, false))
+			.concat((g.tracked || []).filter((t) => !g.top.some((r) => r.player === t.player)).map((t) => this.lbRow(t.pos, t.player, t.score, true)))
+			.join('');
+		return `<div class="live-wrap"><div class="live-item live-expand" role="button" tabindex="0" aria-expanded="${open}" data-live="golf">
+			<span class="live-dot"></span>
+			<span class="live-body"><span class="live-name">${escapeHtml(g.name)}</span>${you ? `<span class="live-you">${you}</span>` : ''}</span>
+			<span class="live-meta">${escapeHtml(leader.player)} ${escapeHtml(leader.score)}<span class="live-caret">›</span></span>
+		</div><div class="live-detail"${open ? '' : ' hidden'}>${board}</div></div>`;
+	}
+
+	/** F1 live: quiet line (GP + session + leader), tap to expand the running order. */
+	liveF1Item(f) {
+		const open = !!(this._liveOpen && this._liveOpen.f1);
+		const leader = f.top[0];
+		const board = f.top.map((r) => this.lbRow(r.pos, r.player, r.team, false)).join('');
+		return `<div class="live-wrap"><div class="live-item live-expand" role="button" tabindex="0" aria-expanded="${open}" data-live="f1">
+			<span class="live-dot"></span>
+			<span class="live-body"><span class="live-name">${escapeHtml(f.name)}</span>${f.session ? `<span class="live-you">${escapeHtml(f.session)}</span>` : ''}</span>
+			<span class="live-meta">${escapeHtml(leader.player)}<span class="live-caret">›</span></span>
+		</div><div class="live-detail"${open ? '' : ' hidden'}>${board}</div></div>`;
+	}
+
+	/** Tap/keyboard expand for a live leaderboard; remembers open state across the
+	 *  60s re-render so a poll doesn't collapse what you're reading. */
+	bindLive() {
+		const box = document.getElementById('live-now');
+		if (!box || this._liveBound) return;
+		this._liveBound = true;
+		const toggle = (row) => {
+			const detail = row.parentElement.querySelector('.live-detail');
+			if (!detail) return;
+			const open = row.getAttribute('aria-expanded') === 'true';
+			row.setAttribute('aria-expanded', String(!open));
+			detail.hidden = open;
+			this._liveOpen = this._liveOpen || {};
+			this._liveOpen[row.dataset.live] = !open;
+		};
+		box.addEventListener('click', (e) => { const r = e.target.closest('.live-item.live-expand'); if (r) toggle(r); });
+		box.addEventListener('keydown', (e) => { if (e.key !== 'Enter' && e.key !== ' ') return; const r = e.target.closest('.live-item.live-expand'); if (r) { e.preventDefault(); toggle(r); } });
 	}
 
 	// ── The agenda: one list, grouped by day ─────────────────────────────────
@@ -908,13 +960,13 @@ class Dashboard {
 		return this.allEvents.some((e) => {
 			const start = new Date(e.time).getTime();
 			const end = e.endTime ? new Date(e.endTime).getTime() : start + 4 * SS_CONSTANTS.MS_PER_HOUR;
-			return start <= now && now <= end && (e.sport === 'football' || e.sport === 'golf');
+			return start <= now && now <= end && ['football', 'golf', 'f1'].includes(e.sport);
 		});
 	}
 	async pollLiveScores() {
 		if (!this._liveVisible || !this.hasLiveEvents()) return;
 		try {
-			await Promise.all([this.pollFootballScores(), this.pollGolfScores()]);
+			await Promise.all([this.pollFootballScores(), this.pollGolfScores(), this.pollF1Scores()]);
 			this.renderLive();
 			this.renderAgenda();
 		} catch { /* live scores are best-effort */ }
@@ -948,13 +1000,38 @@ class Dashboard {
 			const data = await resp.json();
 			const ev = data.events?.[0], comp = ev?.competitions?.[0], state = ev?.status?.type?.state;
 			if (!comp || state === 'pre') return;
-			this.liveLeaderboard = {
-				name: ev.name || '', state,
-				players: (comp.competitors || []).slice(0, 5).map((c, i) => ({
-					player: c.athlete?.displayName || c.athlete?.fullName || '—',
-					score: typeof c.score === 'object' ? (c.score?.displayValue || 'E') : (c.score?.toString() || 'E'),
-				})),
-			};
+			const row = (c) => ({
+				pos: c.status?.position?.displayName || (c.order != null ? String(c.order) : ''),
+				player: c.athlete?.displayName || c.athlete?.fullName || '—',
+				score: typeof c.score === 'object' ? (c.score?.displayValue || 'E') : (c.score?.toString() || 'E'),
+			});
+			const comps = comp.competitors || [];
+			// Your tracked Norwegian golfers' live positions — the thing you actually want.
+			const terms = trackedTerms((this.interests?.alwaysTrack?.athletes || []).filter((a) => (a && a.sport) === 'golf')).map((t) => t.toLowerCase());
+			const tracked = comps.map(row).filter((r) => terms.some((t) => ssContainsTerm(r.player, t)));
+			this.liveLeaderboard = { name: ev.name || '', state, top: comps.slice(0, 8).map(row), tracked };
+		} catch { /* ignore */ }
+	}
+
+	/** F1 live: during a session (practice/quali/race), the running order. ESPN's
+	 *  F1 scoreboard nests each session under the GP weekend's competitions. */
+	async pollF1Scores() {
+		const now = Date.now();
+		if (!this.allEvents.some((e) => { if (e.sport !== 'f1') return false; const s = new Date(e.time).getTime(); const end = e.endTime ? new Date(e.endTime).getTime() : s + 4 * SS_CONSTANTS.MS_PER_HOUR; return s <= now && now <= end; })) return;
+		try {
+			const resp = await fetch('https://site.api.espn.com/apis/site/v2/sports/racing/f1/scoreboard');
+			if (!resp.ok) return;
+			const data = await resp.json();
+			const ev = data.events?.[0];
+			const live = (ev?.competitions || []).find((c) => c.status?.type?.state === 'in');
+			if (!ev || !live) { this.liveF1 = null; return; }
+			const row = (c) => ({
+				pos: c.order != null ? String(c.order) : '',
+				player: c.athlete?.displayName || c.athlete?.shortName || '—',
+				team: c.athlete?.team?.name || c.athlete?.team?.abbreviation || '',
+			});
+			const top = (live.competitors || []).slice(0, 8).map(row).filter((r) => r.player !== '—');
+			this.liveF1 = top.length ? { name: ev.shortName || ev.name || 'Formel 1', session: live.type?.text || live.type?.abbreviation || '', state: 'in', top } : null;
 		} catch { /* ignore */ }
 	}
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // SportSync v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-16';
+const CACHE_NAME = 'sportsync-v2-17';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -269,6 +269,29 @@ describe("'Dine neste' top glance — upcoming-only, nearest first", () => {
 	});
 });
 
+describe("live leaderboard (golf/F1) — quiet line + expandable board", () => {
+	it("golf: leader on the line, your Norwegians' live position, full board on expand", () => {
+		const html = dash.liveGolfItem({
+			name: "Genesis Scottish Open", state: "in",
+			top: [{ pos: "1", player: "Tom Kim", score: "-5" }, { pos: "2", player: "Rory McIlroy", score: "-5" }],
+			tracked: [{ pos: "26", player: "Viktor Hovland", score: "-2" }],
+		});
+		expect(html).toContain("Genesis Scottish Open");
+		expect(html).toContain("Tom Kim");          // leader
+		expect(html).toContain("Viktor Hovland");     // your player's live position
+		expect(html).toContain("-2");
+		expect(html).toContain('data-live="golf"');
+		expect(html).toContain("mine");               // tracked player highlighted in the board
+	});
+	it("F1: session + leader on the line, running order on expand", () => {
+		const html = dash.liveF1Item({ name: "Belgian GP", state: "in", session: "Race", top: [{ pos: "1", player: "Max Verstappen", team: "Red Bull" }] });
+		expect(html).toContain("Belgian GP");
+		expect(html).toContain("Race");
+		expect(html).toContain("Max Verstappen");
+		expect(html).toContain('data-live="f1"');
+	});
+});
+
 describe("must-see selection follows the goal's priorities", () => {
 	it("favorite, importance>=4, or Norwegian participation", () => {
 		expect(dash.isMustSee({ isFavorite: true })).toBe(true);


### PR DESCRIPTION
«Direkte nå» viste bare golf-**lederen** og hadde ingen F1. Nå, i tråd med det rolige designet:

- **Golf:** den rolige linja viser lederen til høyre + dine fulgte nordmenns **LIVE-posisjon/score** under navnet (det du faktisk sjekker); trykk for å utvide topp 8, med dine spillere lagt til + amber-fremhevet hvis de ligger lenger nede. Data fra ESPNs live PGA-scoreboard.
- **F1:** under en økt (trening/kval/løp) viser linja GP + økt + leder; trykk for kjørerrekkefølgen. Vises kun når en økt faktisk er live.
- Utvidet tilstand huskes over 60s-refresh, så en poll ikke kollapser det du leser.

## Verifisert
Mot **ekte live-data** (Scottish Open pågår): leder, Hovland (26., −2) + Reitan (97., +1), full tavle ved trykk, begge temaer. `npm test`: 255 grønne (+2). F1 speiler golf-mønsteret; kunne ikke verifiseres live (ingen økt akkurat nå) — defensiv, vises kun under en økt. SW → v2-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)