### PR TITLE
F1 detail: surface championship standings + last race

### DIFF
--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -528,12 +528,27 @@ class Dashboard {
 	}
 
 	/** True only when there's genuinely more to show — flat rows stay non-interactive. */
+	/** F1 detail: the championship top + the last race's podium — context we
+	 *  already fetch (standings.f1 + recent-results.f1) but never surfaced. */
+	addF1Context(add) {
+		const drivers = this.standings?.f1?.drivers;
+		if (Array.isArray(drivers) && drivers.length) {
+			add('VM-stilling', drivers.slice(0, 5).map((d) => `${d.position}. ${escapeHtml(ssShortName(d.driver))} <span class="tbd">${d.points}</span>`).join(' · '));
+		}
+		const last = this.recentResults?.f1?.[0];
+		if (last && Array.isArray(last.topDrivers) && last.topDrivers.length) {
+			const podium = last.topDrivers.slice(0, 3).map((d) => `${d.position}. ${escapeHtml(ssShortName(d.driver))}`).join(' · ');
+			add('Forrige løp', `${escapeHtml(ssShortName(last.raceName || ''))} — ${podium}`);
+		}
+	}
+
 	hasDetail(e) {
 		if (e.isSeries) return true;
 		return !!(
 			this.footballStanding(e) ||
 			this.finishedResult(e) ||
 			this.golfContext(e) ||
+			(e.sport === 'f1' && (this.standings?.f1?.drivers?.length || this.recentResults?.f1?.length)) ||
 			(e.venue && e.venue !== 'TBD') ||
 			e.summary ||
 			e.norwegianPlayers?.length ||
@@ -553,6 +568,7 @@ class Dashboard {
 		if (result) add('Resultat', result);
 		add('Tabell', this.footballStanding(e));
 		add('Ledende', this.golfContext(e));
+		if (e.sport === 'f1') this.addF1Context(add);
 		if (e.venue && e.venue !== 'TBD') add('Arena', escapeHtml(e.venue));
 		if (e.sport === 'golf' && (e.norwegianPlayers?.length || e.featuredGroups?.length)) {
 			this.addGolfField(e, add);

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -155,6 +155,25 @@ describe("golf detail: who plays, tee times, featured group", () => {
 	});
 });
 
+describe("F1 detail: championship + last race (data we already fetch)", () => {
+	it("shows the F1 standings top and the previous race podium", () => {
+		dash.standings = { f1: { drivers: [
+			{ position: 1, driver: "Kimi Antonelli", team: "Mercedes", points: 179 },
+			{ position: 2, driver: "George Russell", team: "Mercedes", points: 154 },
+		] } };
+		dash.recentResults = { f1: [{ raceName: "British Grand Prix", topDrivers: [
+			{ position: 1, driver: "Charles Leclerc" }, { position: 2, driver: "George Russell" }, { position: 3, driver: "Lewis Hamilton" },
+		] }] };
+		const html = dash.eventDetail({ sport: "f1", title: "Belgian GP", time: soon() });
+		expect(html).toContain("VM-stilling");
+		expect(html).toContain("Kimi Antonelli");
+		expect(html).toContain("179");
+		expect(html).toContain("Forrige løp");
+		expect(html).toContain("Charles Leclerc");
+		expect(dash.hasDetail({ sport: "f1", title: "Belgian GP", time: soon() })).toBe(true);
+	});
+});
+
 describe("whereToWatch — the core 'hvor kan jeg se det'", () => {
 	it("links a channel when a url is present", () => {
 		const html = dash.whereToWatch({ streaming: [{ platform: "NRK 1", url: "https://tv.nrk.no" }] });


### PR DESCRIPTION
Vi henter allerede `standings.f1.drivers` + `recent-results.f1`, men viste det aldri. F1-eventets trykk-for-utvid inneholder nå:
- **VM-stilling** — topp 5 (plass · fører · poeng)
- **Forrige løp** — forrige GP + podium

Null nye kilder — bare surface data vi allerede har. `npm test`: 260 grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)