### PR TITLE
TdF detail: Norwegian squad + current-stage context

### DIFF
--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -485,13 +485,26 @@ class Dashboard {
 	/** Expanded series: every stage as a quiet line (past ones dimmed). */
 	seriesDetail(s) {
 		const now = Date.now();
-		return s.stages.map((st) => {
+		// Header: the Norwegian squad + the current-stage context. A stage race (TdF)
+		// has no standings feed, but the research agent captures the riders and a
+		// per-stage note — surface those instead of leaving the detail a bare list.
+		let head = '';
+		const riders = [];
+		const seen = new Set();
+		for (const st of s.stages) for (const p of (st.norwegianPlayers || [])) {
+			const n = (p && p.name) || p;
+			if (n && !seen.has(n)) { seen.add(n); riders.push(n); }
+		}
+		if (riders.length) head += `<div class="d-row"><span class="d-k">Norske</span><span class="d-v">${escapeHtml(riders.join(', '))}</span></div>`;
+		if (s.nextStage?.summary) head += `<div class="d-row"><span class="d-k">Nå</span><span class="d-v">${escapeHtml(s.nextStage.summary)}</span></div>`;
+		const rows = s.stages.map((st) => {
 			const d = new Date(st.time);
 			const when = d.toLocaleDateString('nb-NO', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'Europe/Oslo' });
 			const ch = (st.streaming || []).map((x) => x.platform || x)[0];
 			const past = (st.endTime ? Date.parse(st.endTime) : Date.parse(st.time)) < now;
 			return `<div class="d-row stage${past ? ' past' : ''}"><span class="d-k">${escapeHtml(when)} ${escapeHtml(this.osloTime(d))}</span><span class="d-v">${escapeHtml(ssShortName(st.title))}${ch ? ` · <span class="tbd">${escapeHtml(ch)}</span>` : ''}</span></div>`;
 		}).join('');
+		return head + rows;
 	}
 
 	// ── Progressive disclosure: extra context on tap (calm — hidden by default) ──

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -59,6 +59,14 @@ Static fetchers (ESPN-driven) miss:
 - Olympic / multi-sport events when active games run
 - Cross-sport notable moments
 
+**Stage races (Tour de France etc.) — keep the `summary` a live stat line.** For an
+in-progress stage race, write the current standings context into each near-term
+stage's `summary`: the overall (sammenlagt/GC) leader + the tracked Norwegians'
+GC position, and the current jersey holders (gul/grønn/prikket/hvit) when known.
+The dashboard surfaces the next stage's `summary` as the "Nå" line, so this is
+where TdF live-ish stats live (there's no cycling standings API). Keep it short
+and factual; cite in `evidence`.
+
 **Next-fixture coverage per followed entity.** The dashboard answers "when is X
 next?" for every `alwaysTrack` athlete/team — UNWINDOWED (even months out). So for
 each one, make sure `events.json` holds at least their **next known dated fixture**;

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -155,6 +155,21 @@ describe("golf detail: who plays, tee times, featured group", () => {
 	});
 });
 
+describe("stage-race detail (TdF): Norwegian squad + current context", () => {
+	it("surfaces the Norwegian riders (deduped) and the current-stage note", () => {
+		const stages = [
+			{ title: "Etappe 1", time: new Date(Date.now() - 86400000).toISOString(), norwegianPlayers: [{ name: "Tobias Halland Johannessen" }, { name: "Jonas Abrahamsen" }] },
+			{ title: "Etappe 2", time: new Date(Date.now() + 86400000).toISOString(), norwegianPlayers: [{ name: "Tobias Halland Johannessen" }, { name: "Søren Wærenskjold" }], summary: "Uno-X jakter etappeseier; Johannessen 4. sammenlagt." },
+		];
+		const html = dash.seriesDetail({ isSeries: true, stages, nextStage: stages[1] });
+		expect(html).toContain("Norske");
+		expect(html).toContain("Tobias Halland Johannessen");
+		expect(html).toContain("Søren Wærenskjold"); // union across stages
+		expect(html).toContain("Nå");
+		expect(html).toContain("sammenlagt");          // current context from the summary
+	});
+});
+
 describe("F1 detail: championship + last race (data we already fetch)", () => {
 	it("shows the F1 standings top and the previous race podium", () => {
 		dash.standings = { f1: { drivers: [


### PR DESCRIPTION
Sykkel har ingen standings-API (AI-vedlikeholdt), men research-agenten fanger allerede **de norske rytterne + en narrativ per etappe**. Den kollapsede serie-detaljen listet bare etapper — nå leder den med:
- **Norske**: den norske troppen (Uno-X m.fl.), deduplisert på tvers av etapper
- **Nå**: neste etappes `summary` (nåværende kontekst)

Pluss en research.md-nudge: for et pågående etapperitt skal hver nær-term etappes `summary` være ei live stat-linje — GC-leder, de fulgte nordmennenes GC-plass, og trøyeholderne — siden «Nå»-linja er der TdF-stats bor (ingen sykkel-feed).

Verifisert mot live data (Touren pågår): tropp + Pyreneene-etappenote + full etappeliste, alt på TV 2 Play. `npm test`: 261 grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)