### PR TITLE
WP-02: stabil event-ID

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -34,7 +34,7 @@ mennesket, aldri av en agent.
 | WP | Tittel | Fase | Avhenger av | Status |
 |---|---|---|---|---|
 | WP-01 | events.schema.json | 0A | – | PR åpnet |
-| WP-02 | Stabil event-ID | 0A | – | todo |
+| WP-02 | Stabil event-ID | 0A | – | PR åpnet |
 | WP-03 | manifest.json | 0A | – | todo |
 | WP-04 | Deltakelse-normalisering | 0A | WP-01 | todo |
 | WP-05 | Entitets-indeks | 0A | WP-01 | todo |

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -57,7 +57,13 @@ class Dashboard {
 			load('events.json'), load('featured.json'), load('standings.json'), load('recent-results.json'), load('tracked.json'), load('interests.json'), load('meta.json'), load('usage-state.json'),
 		]);
 		this.allEvents = Array.isArray(events) ? events : [];
-		this.allEvents.forEach((e, i) => { e.id = `${e.sport}|${e.title}|${e.time}|${i}`; });
+		// Prefer the server's stable id (build-events.js, WP-02) — a hash of
+		// sport|title|time that survives re-renders/reorders. Fall back to the
+		// old array-index synthesis only for a payload from before this field
+		// existed (backward-compatible until the next rebuild republishes
+		// events.json with ids). The live-score overlay (this.liveScores) keys
+		// on this same e.id, so either source stays internally consistent.
+		this.allEvents.forEach((e, i) => { if (!e.id) e.id = `${e.sport}|${e.title}|${e.time}|${i}`; });
 		this.featured = featured;
 		this.standings = standings;
 		this.recentResults = results;

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -1,10 +1,22 @@
 #!/usr/bin/env node
 import fs from "fs";
 import path from "path";
+import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, MS_PER_DAY, matchInterest, mustWatchEntity } from "./lib/helpers.js";
 import { resolveStreaming } from "./lib/norwegian-rights.js";
 
 const dataDir = rootDataPath();
+
+// Stable event ID: first 12 hex chars of a sha256 hash of the same dedupe key
+// used throughout this file (`${sport}|${title}|${time}`, see the preservation
+// pass below). Known limitation, accepted by design: if the verify agent later
+// amends an event's title or time, the NEXT build computes a DIFFERENT id for
+// it — a client/notification diff then sees remove+add rather than an
+// in-place update. That's fine; it's still far more stable than the old
+// client-side `array-index` synthesis, which changed on every reorder.
+function computeEventId(sport, title, time) {
+	return crypto.createHash("sha256").update(`${sport}|${title}|${time}`).digest("hex").slice(0, 12);
+}
 
 // Auto-discover sport files by convention: any JSON with a { tournaments: [...] } structure
 const dataFiles = fs.readdirSync(dataDir).filter((f) => f.endsWith(".json"));
@@ -41,6 +53,12 @@ function pushEvent(ev, sport, tournament) {
 		isFavorite: ev.isFavorite || false,
 		round: ev.round || null,
 	};
+	// See computeEventId() above for the stability contract. This covers events
+	// built fresh in this pass; the final normalization loop before write (see
+	// "kept" below) recomputes it for every output event regardless of path, so
+	// preserved ai-research / kept-on-board events (pushed directly from a
+	// previous events.json, which may predate this field) get one too.
+	event.id = computeEventId(event.sport, event.title, event.time);
 	if (ev.format) event.format = ev.format;
 	if (ev.stage) event.stage = ev.stage;
 	if (ev.result) event.result = ev.result;
@@ -420,6 +438,13 @@ let mustWatchCount = 0;
 for (const e of kept) {
 	e.mustWatch = mustWatchEntity(e, interests) != null;
 	if (e.mustWatch) mustWatchCount++;
+	// Recompute the stable id from the event's CURRENT sport|title|time so every
+	// output path emits one — including preserved ai-research / kept-on-board
+	// events pushed directly from a previous events.json (which may predate
+	// this field, or carry a stale id if an upstream agent amended title/time
+	// without recomputing it). Idempotent for unchanged events: same inputs,
+	// same hash, same id across consecutive builds.
+	e.id = computeEventId(e.sport, e.title, e.time);
 }
 fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(kept, null, 2));
 console.log(

--- a/tests/build-events-schema.test.js
+++ b/tests/build-events-schema.test.js
@@ -34,3 +34,126 @@ describe("build-events output schema", () => {
 		fs.rmSync(configDir, { recursive: true, force: true });
 	});
 });
+
+// WP-02: stable event ID — a hash of the sport|title|time dedupe key, emitted
+// by every path that produces output events (fresh fetch, curated config,
+// ai-research/kept-on-board preservation).
+describe("build-events stable event id (WP-02)", () => {
+	function freshDirs() {
+		return {
+			dataDir: fs.mkdtempSync(path.join(os.tmpdir(), "ss-id-")),
+			configDir: fs.mkdtempSync(path.join(os.tmpdir(), "ss-id-cfg-")),
+		};
+	}
+	function runBuild(dataDir, configDir) {
+		execFileSync("node", ["scripts/build-events.js"], {
+			env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir, SPORTSYNC_CONFIG_DIR: configDir },
+		});
+		return JSON.parse(fs.readFileSync(path.join(dataDir, "events.json"), "utf-8"));
+	}
+
+	it("gives every output event a stable, hash-shaped id", () => {
+		const { dataDir, configDir } = freshDirs();
+		const future = (d) => new Date(Date.now() + d * 86400000).toISOString();
+		fs.writeFileSync(
+			path.join(dataDir, "golf.json"),
+			JSON.stringify({ tournaments: [{ name: "PGA Tour", events: [
+				{ title: "Open", time: future(1), norwegian: true },
+			] }] })
+		);
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "biathlon", title: "Mixed relay", time: future(5), source: "ai-research", confidence: "high", evidence: ["a", "b"] },
+			])
+		);
+		const events = runBuild(dataDir, configDir);
+		expect(events.length).toBeGreaterThan(0);
+		for (const e of events) {
+			expect(typeof e.id).toBe("string");
+			expect(e.id).toMatch(/^[0-9a-f]{12}$/); // first 12 hex chars of sha256
+		}
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+
+	it("gives two consecutive builds on the same input identical ids", () => {
+		const { dataDir, configDir } = freshDirs();
+		const future = (d) => new Date(Date.now() + d * 86400000).toISOString();
+		fs.writeFileSync(
+			path.join(dataDir, "football.json"),
+			JSON.stringify({ tournaments: [{ name: "Premier League", events: [
+				{ title: "Liverpool vs Arsenal", time: future(2), homeTeam: "Liverpool", awayTeam: "Arsenal" },
+			] }] })
+		);
+		// An ai-research event with no static counterpart — preserved as-is across
+		// rebuilds, exercising the "carried forward without going through
+		// pushEvent()" path.
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "chess", title: "World Cup Round 1", time: future(3), source: "ai-research", confidence: "high", evidence: ["a", "b"] },
+			])
+		);
+		const first = runBuild(dataDir, configDir);
+		const second = runBuild(dataDir, configDir); // reads the events.json the first run just wrote
+		const idsOf = (evts) => Object.fromEntries(evts.map((e) => [`${e.sport}|${e.title}|${e.time}`, e.id]));
+		const firstIds = idsOf(first), secondIds = idsOf(second);
+		expect(Object.keys(secondIds).sort()).toEqual(Object.keys(firstIds).sort());
+		for (const key of Object.keys(firstIds)) {
+			expect(secondIds[key]).toBe(firstIds[key]);
+		}
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+
+	it("mints a new id when the verify agent amends an event's title", () => {
+		// Known, accepted property (see computeEventId() in build-events.js):
+		// an amendment changes the dedupe key, so the id changes too — a
+		// client/notification diff treats it as remove+add, not an update.
+		const { dataDir, configDir } = freshDirs();
+		const time = new Date(Date.now() + 4 * 86400000).toISOString();
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{ sport: "chess", title: "World Cup Round 1", time, source: "ai-research", confidence: "high", evidence: ["a", "b"] },
+			])
+		);
+		const before = runBuild(dataDir, configDir);
+		const beforeId = before.find((e) => e.title === "World Cup Round 1").id;
+
+		// Simulate a verify-agent amendment: title changed in-place in events.json.
+		const amended = JSON.parse(fs.readFileSync(path.join(dataDir, "events.json"), "utf-8"))
+			.map((e) => (e.title === "World Cup Round 1" ? { ...e, title: "World Cup Round 1 (rescheduled)" } : e));
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(amended));
+
+		const after = runBuild(dataDir, configDir);
+		const afterId = after.find((e) => e.title === "World Cup Round 1 (rescheduled)").id;
+		expect(afterId).not.toBe(beforeId);
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+
+	it("has no id collisions when built from today's real data files", () => {
+		// Exercise the real pipeline against a copy of today's actual fetcher
+		// output + curated configs (never the real dataDir — build-events.js
+		// writes events.json in place, and this must not mutate committed data).
+		const realDataDir = path.resolve(process.cwd(), "docs", "data");
+		const realConfigDir = path.resolve(process.cwd(), "scripts", "config");
+		if (!fs.existsSync(realDataDir)) return; // no published data in this environment
+		const { dataDir, configDir } = freshDirs();
+		for (const f of fs.readdirSync(realDataDir)) {
+			if (f.endsWith(".json")) fs.copyFileSync(path.join(realDataDir, f), path.join(dataDir, f));
+		}
+		for (const f of fs.readdirSync(realConfigDir)) {
+			if (f.endsWith(".json")) fs.copyFileSync(path.join(realConfigDir, f), path.join(configDir, f));
+		}
+		const events = runBuild(dataDir, configDir);
+		expect(events.length).toBeGreaterThan(0);
+		const ids = events.map((e) => e.id).filter(Boolean);
+		expect(ids.length).toBe(events.length); // every event got an id
+		expect(new Set(ids).size).toBe(ids.length); // and none collide
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+});

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -345,3 +345,48 @@ describe("must-see selection follows the goal's priorities", () => {
 		expect(dash.isMustSee({ importance: 2 })).toBe(false);
 	});
 });
+
+// WP-02: loadData() must prefer the server's stable id (build-events.js hash)
+// and only fall back to the old index-based synthesis for a payload from
+// before that field existed. Uses its own sandbox so the stubbed fetch/response
+// doesn't interfere with the shared `dash` instance used above.
+describe("loadData: stable id from the server, index fallback for old payloads", () => {
+	function sandboxWithEvents(events) {
+		const sandbox = createClientSandbox();
+		loadClientScript(sandbox, "shared-constants.js");
+		loadClientScript(sandbox, "sport-config.js");
+		loadClientScript(sandbox, "asset-maps.js");
+		loadClientScript(sandbox, "dashboard.js");
+		sandbox.fetch = (url) => {
+			const name = String(url).split("data/")[1]?.split("?")[0];
+			if (name === "events.json") return Promise.resolve({ ok: true, json: () => Promise.resolve(events) });
+			return Promise.resolve({ ok: false });
+		};
+		return sandbox.window.dashboard;
+	}
+
+	it("uses e.id from data when the server already sent one", async () => {
+		const d = sandboxWithEvents([{ id: "abc123def456", sport: "football", title: "X", time: soon() }]);
+		await d.loadData();
+		expect(d.allEvents[0].id).toBe("abc123def456");
+	});
+
+	it("falls back to the index-based synthesis when a payload has no id (pre-WP-02)", async () => {
+		const time = soon();
+		const d = sandboxWithEvents([{ sport: "football", title: "Y", time }]);
+		await d.loadData();
+		expect(d.allEvents[0].id).toBe(`football|Y|${time}|0`);
+	});
+
+	it("keeps the live-score overlay keyed on the same id loadData assigned", async () => {
+		// The live poller (pollFootballScores etc.) writes this.liveScores[matched.id]
+		// using the SAME e.id set here — so whichever id source loadData picked
+		// (server-sent or synthesized fallback), lookups by e.id must line up.
+		const d = sandboxWithEvents([{ id: "liveid1", sport: "football", title: "Live match", time: soon() }]);
+		await d.loadData();
+		const id = d.allEvents[0].id;
+		d.liveScores[id] = { home: 1, away: 0, state: "in" };
+		const html = d.eventRow(d.allEvents[0]);
+		expect(html).toContain("1–0"); // eventRow reads this.liveScores[e.id] and rendered the live score
+	});
+});


### PR DESCRIPTION
## Sammendrag

Implementerer WP-02 fra PLAN.md: server-generert stabil `id` på hvert event,
så klienten slipper å syntetisere en ustabil array-indeks-basert ID.

- **`scripts/build-events.js`**: `pushEvent()` emitter nå `id` — de første 12
  hex-tegnene av en sha256-hash av samme dedupe-nøkkel som brukes ellers i
  filen (`sport|title|time`). En siste normaliseringsrunde rett før
  `events.json` skrives, rekalkulerer `id` for hvert event i `kept` — det
  garanterer at ALLE utgangsstier (fersk fetch, kuraterte configs,
  ai-research/kept-on-board-preservering, som pusher `prev`-objekter direkte
  uten å gå via `pushEvent()`) får en id, selv fra data skrevet før dette
  feltet fantes.
- Kjent, akseptert egenskap (dokumentert i kode): hvis verify-agenten amender
  et events tittel/tid, får eventet en NY id på neste build — en klient/varsel-
  diff ser da fjern+legg-til i stedet for en oppdatering in-place. Dette er
  fortsatt langt mer stabilt enn den gamle klient-side array-indeks-syntesen,
  som endret seg ved enhver omsortering.
- **`docs/js/dashboard.js`**: `loadData()` bruker nå `e.id` fra dataene når den
  finnes, med fallback til den gamle `sport|title|time|index`-syntesen kun for
  en payload fra før WP-02 (bakoverkompatibelt til første rebuild). Live-score-
  overlayet (`this.liveScores`) nøkler fortsatt på samme `e.id`, uansett kilde.

## Testdekning

- `tests/build-events-schema.test.js`: id har riktig hash-form på alle events;
  to påfølgende builds på samme input (inkl. en ai-research-preservert event)
  gir identiske id-er; en verify-lik tittel-amendering gir en NY id; ingen
  id-kollisjoner når bygget mot en kopi av dagens ekte data-filer
  (`docs/data/*.json` + `scripts/config/*.json`, aldri de ekte filene selv).
- `tests/dashboard-cards.test.js`: `loadData()` bruker server-id når den
  finnes, faller tilbake til indeks-syntese når den mangler, og
  live-score-overlayet forblir riktig nøklet uansett id-kilde.

## Akseptkriterier (fra PLAN.md)

- [x] To påfølgende builds på samme input gir identiske ID-er (test)
- [x] Ingen kollisjoner i dagens datasett (test mot kopi av ekte data)
- [x] `npm test` grønt (270 tester, 25 filer)

## Ikke-mål (overholdt)

Ingen endring i `scripts/config/events.schema.json` eller
`scripts/validate-events.js` (WP-01, egen agent), ingen endring i
`norwegianPlayers`/participants-form, `interests.json`,
`.github/workflows/**`, `scripts/hooks/**` er ikke rørt.

Kun WP-02-raden i PLAN.md-statustabellen er oppdatert (til "PR åpnet").

🤖 Generated with [Claude Code](https://claude.com/claude-code)