### PR TITLE
WP-01: events.schema.json

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -33,7 +33,7 @@ mennesket, aldri av en agent.
 
 | WP | Tittel | Fase | Avhenger av | Status |
 |---|---|---|---|---|
-| WP-01 | events.schema.json | 0A | – | todo |
+| WP-01 | events.schema.json | 0A | – | PR åpnet |
 | WP-02 | Stabil event-ID | 0A | – | todo |
 | WP-03 | manifest.json | 0A | – | todo |
 | WP-04 | Deltakelse-normalisering | 0A | WP-01 | todo |

--- a/scripts/config/events.schema.json
+++ b/scripts/config/events.schema.json
@@ -1,0 +1,194 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "SportSync – event",
+	"description": "Skjemaet for ETT event-objekt i docs/data/events.json (som selv er et flatt array av slike objekter — hvert element valideres mot dette skjemaet). Feltunionen er hentet fra pushEvent() (scripts/build-events.js) + de betingede AI-research-feltene i scripts/validate-events.js. Validert med den hjemmelagde scripts/lib/validate-schema.js, som kun støtter: type, required, properties, additionalProperties, items, enum, minimum, anyOf, lokal $ref — ingen maximum/minItems/format-nøkkelord, derfor brukes enum der en øvre grense trengs (f.eks. importance). norwegianPlayers er bevisst polymorf i dag (streng | {name} | {name, teeTime, teeTimeUTC, status} | null) — innstramming til én kanonisk form er WP-04, ikke dette skjemaet.",
+	"type": "object",
+	"required": ["time", "title", "sport"],
+	"additionalProperties": false,
+	"properties": {
+		"sport": {
+			"type": "string",
+			"description": "Sport-nøkkel, f.eks. \"football\", \"golf\", \"chess\"."
+		},
+		"tournament": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Turnering/serie eventet hører til."
+		},
+		"title": {
+			"type": "string",
+			"description": "Visningstittel."
+		},
+		"time": {
+			"type": "string",
+			"description": "ISO 8601 starttidspunkt (UTC)."
+		},
+		"endTime": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "ISO 8601 sluttidspunkt, eller null for punkt-i-tid-events."
+		},
+		"venue": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Sted/arena."
+		},
+		"meta": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Fri-tekst turnering/tour-kontekst brukt av streaming-oppslag og build-ics."
+		},
+		"norwegian": {
+			"type": "boolean",
+			"description": "Norsk relevans (utøver/lag/kringkasting)."
+		},
+		"streaming": {
+			"type": "array",
+			"description": "Norske visningsmuligheter, i prioritert rekkefølge.",
+			"items": { "$ref": "#/definitions/streamingChannel" }
+		},
+		"participants": {
+			"type": "array",
+			"description": "Deltakernavn (individuelle idretter/turneringer).",
+			"items": { "type": "string" }
+		},
+		"norwegianPlayers": {
+			"type": "array",
+			"description": "Norske utøvere involvert i eventet. Se definitions/norwegianPlayer for dagens polymorfi.",
+			"items": { "$ref": "#/definitions/norwegianPlayer" }
+		},
+		"totalPlayers": {
+			"anyOf": [{ "type": "number" }, { "enum": [null] }],
+			"description": "Antall deltakere i feltet (golf mv.)."
+		},
+		"link": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Ekstern lenke (kilde/resultatside)."
+		},
+		"status": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "F.eks. \"cancelled\"/\"postponed\", eller en live-status fra kilden."
+		},
+		"featuredGroups": {
+			"type": "array",
+			"description": "Golf: fremhevede spillegrupper rundt en norsk spiller.",
+			"items": { "$ref": "#/definitions/featuredGroup" }
+		},
+		"homeTeam": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Hjemmelag (kamp-sporter)."
+		},
+		"awayTeam": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Bortelag (kamp-sporter)."
+		},
+		"isFavorite": {
+			"type": "boolean",
+			"description": "Agent-/config-flagget favoritt."
+		},
+		"round": {
+			"anyOf": [{ "type": "string" }, { "enum": [null] }],
+			"description": "Runde-/fase-etikett (f.eks. \"Semifinale\")."
+		},
+		"mustWatch": {
+			"type": "boolean",
+			"description": "Beregnet av build-events.js — true når eventet treffer en tracked/must-watch-entitet."
+		},
+		"format": {
+			"type": "string",
+			"description": "F.eks. \"BO3\" (esports)."
+		},
+		"stage": {
+			"type": "string",
+			"description": "Delfase/stage-etikett satt av agent-enrichment."
+		},
+		"result": {
+			"type": "string",
+			"description": "Sluttresultat, satt av agent-enrichment."
+		},
+		"context": {
+			"type": "string",
+			"description": "Fri-tekst kontekst fra en kuratert config (scripts/config/*.json)."
+		},
+		"importance": {
+			"enum": [1, 2, 3, 4, 5],
+			"description": "1–5, agent-satt viktighet. enum brukt fremfor minimum/maximum siden validatoren ikke støtter maximum."
+		},
+		"summary": {
+			"type": "string",
+			"description": "Kort AI-generert oppsummering."
+		},
+		"source": {
+			"type": "string",
+			"description": "\"ai-research\" markerer et event research-agenten fant/skrev."
+		},
+		"confidence": {
+			"enum": ["high", "medium", "low"],
+			"description": "AI-research-kontrakt: \"high\" krever 2+ evidence-URLer (håndhevet separat i validate-events.js, ikke uttrykkelig i dette skjemaet siden validatoren mangler minItems)."
+		},
+		"evidence": {
+			"type": "array",
+			"description": "Kilde-URLer for et ai-research-event.",
+			"items": { "type": "string" }
+		},
+		"researchedAt": {
+			"type": "string",
+			"description": "ISO 8601 – når research-agenten fant eventet."
+		},
+		"verifiedAt": {
+			"type": "string",
+			"description": "ISO 8601 – når verify-agenten sist sjekket eventet."
+		},
+		"verificationStatus": {
+			"enum": ["confirmed", "amended", "removed"],
+			"description": "Se scripts/agents/verify.md."
+		},
+		"verificationSources": {
+			"type": "array",
+			"description": "Kildene verify-agenten brukte.",
+			"items": { "type": "string" }
+		},
+		"norwegianRelevance": {
+			"enum": [1, 2, 3, 4, 5],
+			"description": "Legacy enrichment-felt, håndhevet av validate-events.js."
+		},
+		"tags": {
+			"type": "array",
+			"description": "Legacy enrichment-felt, håndhevet av validate-events.js.",
+			"items": { "type": "string" }
+		}
+	},
+	"definitions": {
+		"streamingChannel": {
+			"description": "Én visningsmulighet. platform/url er kjernefeltene; tentative markerer et uverifisert kanalgjett (f.eks. det delte \"NRK / TV 2\"-gjettet før verify løser det).",
+			"type": "object",
+			"properties": {
+				"platform": { "type": "string" },
+				"url": { "anyOf": [{ "type": "string" }, { "enum": [null] }] },
+				"tentative": { "type": "boolean" }
+			}
+		},
+		"norwegianPlayer": {
+			"description": "Bevisst polymorf (WP-04 er innstrammingen til én kanonisk form, ikke dette skjemaet): en ren streng, null, eller et objekt med minst \"name\" og valgfrie tee-time/status-felter (golf).",
+			"anyOf": [
+				{ "type": "string" },
+				{ "enum": [null] },
+				{
+					"type": "object",
+					"required": ["name"],
+					"properties": {
+						"name": { "type": "string" },
+						"teeTime": { "anyOf": [{ "type": "string" }, { "enum": [null] }] },
+						"teeTimeUTC": { "anyOf": [{ "type": "string" }, { "enum": [null] }] },
+						"status": { "anyOf": [{ "type": "string" }, { "enum": [null] }] }
+					}
+				}
+			]
+		},
+		"featuredGroup": {
+			"description": "Golf: en fremhevet gruppe rundt en norsk spiller.",
+			"type": "object",
+			"properties": {
+				"player": { "type": "string" },
+				"teeTime": { "anyOf": [{ "type": "string" }, { "enum": [null] }] },
+				"groupmates": { "type": "array" }
+			}
+		}
+	}
+}

--- a/scripts/validate-events.js
+++ b/scripts/validate-events.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { rootDataPath } from "./lib/helpers.js";
+import { validateAgainstSchema } from "./lib/validate-schema.js";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const GRACE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days — matches build-events.js day navigator history window
 const dataDir = rootDataPath();
+const schemaPath = path.join(__dirname, "config", "events.schema.json");
+const eventSchema = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
 const file = path.join(dataDir, "events.json");
 if (!fs.existsSync(file)) {
 	console.error("events.json not found. Run build-events.js first.");
@@ -92,6 +97,13 @@ for (const ev of events) {
 				streamingMissing++;
 			}
 		}
+	}
+	// Formal schema check (scripts/config/events.schema.json) — catches shape
+	// drift (wrong types, bad enums) that the ad-hoc checks above don't cover.
+	const schemaErrors = validateAgainstSchema(ev, eventSchema, eventSchema);
+	if (schemaErrors.length) {
+		for (const msg of schemaErrors) console.warn(`Schema violation for ${key}:${msg}`);
+		errors += schemaErrors.length;
 	}
 	// Timezone bleed check: endTime crossing midnight in CET but not UTC
 	if (ev.endTime) {

--- a/tests/events-schema.test.js
+++ b/tests/events-schema.test.js
@@ -1,0 +1,106 @@
+// events.json is a flat array of event objects; events.schema.json describes ONE
+// such object. Same pattern as tests/interests-schema.test.js: the schema drives
+// both this CI check and (via scripts/validate-events.js) the pipeline gate,
+// through the shared dependency-free validator in scripts/lib/validate-schema.js.
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { validateAgainstSchema } from "../scripts/lib/validate-schema.js";
+
+const configDir = path.resolve(process.cwd(), "scripts", "config");
+const dataDir = path.resolve(process.cwd(), "docs", "data");
+const schema = JSON.parse(fs.readFileSync(path.join(configDir, "events.schema.json"), "utf-8"));
+const events = JSON.parse(fs.readFileSync(path.join(dataDir, "events.json"), "utf-8"));
+
+const validate = (event) => validateAgainstSchema(event, schema, schema);
+
+describe("docs/data/events.json against events.schema.json", () => {
+	it("is a non-empty array", () => {
+		expect(Array.isArray(events)).toBe(true);
+		expect(events.length).toBeGreaterThan(0);
+	});
+
+	it("every real event validates with zero errors", () => {
+		for (const event of events) {
+			expect(validate(event), JSON.stringify({ sport: event.sport, title: event.title, time: event.time })).toEqual([]);
+		}
+	});
+});
+
+describe("events.schema.json — the validator actually catches violations (so the contract has teeth)", () => {
+	// A minimal valid event to mutate — matches the schema's only required fields.
+	const base = () => ({
+		sport: "golf",
+		title: "Open",
+		time: "2026-08-01T10:00:00Z",
+	});
+
+	it("passes a minimal valid event", () => {
+		expect(validate(base())).toEqual([]);
+	});
+
+	it("catches a missing title", () => {
+		const event = base();
+		delete event.title;
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("catches a missing sport", () => {
+		const event = base();
+		delete event.sport;
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("catches a missing time", () => {
+		const event = base();
+		delete event.time;
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("catches an invalid confidence enum value", () => {
+		const event = { ...base(), source: "ai-research", confidence: "certain" };
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("accepts a valid confidence enum value", () => {
+		const event = { ...base(), source: "ai-research", confidence: "medium" };
+		expect(validate(event)).toEqual([]);
+	});
+
+	it("catches importance outside 1-5", () => {
+		expect(validate({ ...base(), importance: 0 }).length).toBeGreaterThan(0);
+		expect(validate({ ...base(), importance: 6 }).length).toBeGreaterThan(0);
+	});
+
+	it("accepts importance within 1-5", () => {
+		expect(validate({ ...base(), importance: 3 })).toEqual([]);
+	});
+
+	it("catches streaming that isn't an array", () => {
+		const event = { ...base(), streaming: "NRK" };
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("accepts a well-formed streaming array", () => {
+		const event = { ...base(), streaming: [{ platform: "NRK", url: "https://tv.nrk.no" }] };
+		expect(validate(event)).toEqual([]);
+	});
+
+	it("catches an unexpected top-level property (typo guard)", () => {
+		const event = { ...base(), toornament: "Oops" };
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+
+	it("tolerates today's norwegianPlayers polymorphism (string | {name} | {name, teeTime, teeTimeUTC, status} | null) — tightening this is WP-04", () => {
+		const event = {
+			...base(),
+			norwegianPlayers: ["Casper Ruud", { name: "Viktor Hovland" }, { name: "Kris Ventura", teeTime: "14:20", teeTimeUTC: null, status: null }, null],
+		};
+		expect(validate(event)).toEqual([]);
+	});
+
+	it("catches a malformed norwegianPlayers entry (object missing name)", () => {
+		const event = { ...base(), norwegianPlayers: [{ teeTime: "14:20" }] };
+		expect(validate(event).length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

Implements WP-01 from PLAN.md: a formal draft-07 JSON Schema for `docs/data/events.json`.

- New `scripts/config/events.schema.json` describes ONE event object (events.json is a flat array of these). The field union is drawn straight from `pushEvent()` in `scripts/build-events.js` plus the conditional AI-research fields already checked in `scripts/validate-events.js`.
- Validated with the existing hand-rolled `scripts/lib/validate-schema.js` (no new dependency) — kept strictly within its supported keywords (`type`, `required`, `properties`, `additionalProperties`, `items`, `enum`, `minimum`, `anyOf`, local `$ref`). Since the validator has no `maximum`/`minItems` keyword, ranged fields (`importance`, `norwegianRelevance`) use `enum` instead of `minimum`/`maximum`.
- Wired into `scripts/validate-events.js`: every event is now also run through the schema, in addition to (not instead of) all existing ad-hoc checks.
- `norwegianPlayers` stays deliberately polymorphic (`string | {name} | {name, teeTime, teeTimeUTC, status} | null`) via `anyOf` — per PLAN.md, tightening this to one canonical shape is WP-04, out of scope here.
- New `tests/events-schema.test.js`, patterned on `tests/interests-schema.test.js`.
- Updated the WP-01 status row in PLAN.md to "PR åpnet".

## Acceptance criteria (from PLAN.md)

- [x] Today's real `docs/data/events.json` validates cleanly against the schema (0 errors)
- [x] Mutated fixtures are caught: missing `title`/`sport`/`time`, invalid `confidence` enum value, `importance` outside 1–5, `streaming` not an array (also: malformed `norwegianPlayers` entry, unexpected top-level property)
- [x] `npm test` green (278 tests / 26 files)

## Non-goals (respected)

- No event content, fetcher, or polymorphic-field-shape changes
- `scripts/config/interests.json`, `.github/workflows/**`, `scripts/hooks/**` untouched

## Test plan

- [x] `npm test` — 26 files / 278 tests passing
- [x] `node scripts/validate-events.js` against the real `docs/data/events.json` — `Validated 44 events with 0 error(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)