### PR TITLE
WP-03: manifest.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ npm-debug.log*
 !/docs/data/usage-state.json
 !/docs/data/usage-history.jsonl
 !/docs/data/usage-summary.json
+!/docs/data/manifest.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,7 +35,7 @@ mennesket, aldri av en agent.
 |---|---|---|---|---|
 | WP-01 | events.schema.json | 0A | – | ✅ merget (#235) |
 | WP-02 | Stabil event-ID | 0A | – | ✅ merget (#234) |
-| WP-03 | manifest.json | 0A | – | todo |
+| WP-03 | manifest.json | 0A | – | PR åpnet |
 | WP-04 | Deltakelse-normalisering | 0A | WP-01 | todo |
 | WP-05 | Entitets-indeks | 0A | WP-01 | todo |
 | WP-06 | Gylne feed-vektorer | 0A | WP-02 | todo |

--- a/docs/data/manifest.json
+++ b/docs/data/manifest.json
@@ -1,0 +1,134 @@
+{
+  "generatedAt": "2026-07-13T15:25:32.105Z",
+  "schemaVersion": 1,
+  "files": {
+    "calibration.json": {
+      "bytes": 9325,
+      "sha256": "d31a4f839c38640c811818581774ef16060c77f7a02a1c1f3d40dde3e99b5624"
+    },
+    "chess.json": {
+      "bytes": 105,
+      "sha256": "8becf263737484790d8e4c883c7a42e8c75101ad53ed9fa6b9c49d4160311d6b",
+      "sourceLastUpdated": "2026-07-13T14:46:45.025Z"
+    },
+    "coverage-audit.json": {
+      "bytes": 5022,
+      "sha256": "ea269dfbe307051862d659671b1416793b7a5e52653b0dfae0a9d96795eda2ef"
+    },
+    "coverage-gaps.json": {
+      "bytes": 779,
+      "sha256": "229c554c79b28fa893fa58d633176828a7472b4178eb2bcd9c1a4f36c0026448"
+    },
+    "cycling.json": {
+      "bytes": 99,
+      "sha256": "4d718607b21c5e8f9f7f2c4b671b115b01da6c17b52e8a4b577e917bc89dfaaa",
+      "sourceLastUpdated": "2026-07-13T14:46:43.794Z"
+    },
+    "esports.json": {
+      "bytes": 120,
+      "sha256": "891bd8ef6970e7ea20bb1205817047eb68dc9cabd40a1883f51f57a88eb8e8e6",
+      "sourceLastUpdated": "2026-07-13T14:46:45.012Z"
+    },
+    "events.ics": {
+      "bytes": 25823,
+      "sha256": "a852841e6e6e28aecc0ae041f164f68f2d35371f60ca2753ce70848476010bb4"
+    },
+    "events.json": {
+      "bytes": 62774,
+      "sha256": "058fad222055cd761cd2f14bca275002bedde65f9814d33fbc167a0772bea0be"
+    },
+    "f1.json": {
+      "bytes": 1633,
+      "sha256": "985dd360fe0f9406e3e47fec96846243454a1d35cd215057f9944e62556d235e",
+      "sourceLastUpdated": "2026-07-13T14:46:45.145Z"
+    },
+    "featured.json": {
+      "bytes": 221,
+      "sha256": "e3ee0afc36bb06c7afb95c4766701c5478936dd0c4074c6c498299a74847cb4b"
+    },
+    "football.json": {
+      "bytes": 3742,
+      "sha256": "6525bb7f10dfd9de2a3549c0a336edc437bda9fbfa89c46be78e6028a0746095",
+      "sourceLastUpdated": "2026-07-13T14:46:56.764Z"
+    },
+    "golf.json": {
+      "bytes": 1231,
+      "sha256": "6fd9f52e0b575d94c54b0a36b732417d5a8550744c326c500af5fd467d84b06e",
+      "sourceLastUpdated": "2026-07-13T14:46:49.259Z"
+    },
+    "improve-log.json": {
+      "bytes": 2352,
+      "sha256": "f6a06415548d45a80ff5c57cb09ceb79eee48b81bfb6d198e021108af41871cd"
+    },
+    "interests.json": {
+      "bytes": 4719,
+      "sha256": "a2742e46075b90824a7dee7ee2de417c4742c6c49f3a1c815064787d97fe20c2"
+    },
+    "meta.json": {
+      "bytes": 39,
+      "sha256": "0bb9e3d6f9fae1beb04cfbe4d56af86a5c6ed48d369b1e4f8b78e05e61ce0049",
+      "sourceLastUpdated": "2026-07-13T14:47:22Z"
+    },
+    "recent-results.json": {
+      "bytes": 17366,
+      "sha256": "191e577ca3905b0ec7bac19b12e08ac5d74f146267b92d1da1076a6f6b28f1d4",
+      "sourceLastUpdated": "2026-07-13T14:47:06.526Z"
+    },
+    "research-log.json": {
+      "bytes": 5155,
+      "sha256": "7f263a507a57360ee70891db4a401d6e0c6adcca60907bd75256a75216929317"
+    },
+    "rss-digest.json": {
+      "bytes": 17070,
+      "sha256": "b6c43c42aa26d3e75dda12cc093ae23de185d262ea713215267138b58fca03ae",
+      "sourceLastUpdated": "2026-07-13T14:46:59.250Z"
+    },
+    "scout-log.json": {
+      "bytes": 36722,
+      "sha256": "d6470d4837cf1a839b95d1dcf0febde12e4c3d1c1f5d7d2e0d575937705fd1d2"
+    },
+    "self-repair-log.json": {
+      "bytes": 2070,
+      "sha256": "3f5fc07ccbc76b49d231c8406f6cd1f645ad59afcd956ec5b6f905f316500770"
+    },
+    "standings.json": {
+      "bytes": 30987,
+      "sha256": "1230daa2b13e06ee434edb405dcd8fdce92fe6d96d66cc8e2a6da95ff975dd03",
+      "sourceLastUpdated": "2026-07-13T14:46:56.818Z"
+    },
+    "tennis.json": {
+      "bytes": 3288,
+      "sha256": "0bf62ac64da21a7f3840e503e7cc75370f78a67f24d600a5b02813945a417dc5",
+      "sourceLastUpdated": "2026-07-12T07:27:01.875Z"
+    },
+    "tracked.json": {
+      "bytes": 35102,
+      "sha256": "6048c84855cd158b6649c7cc6a4f8e01f53ce4032d1c62b87f1189a8d3308a53",
+      "sourceLastUpdated": "2026-07-13T11:44:00Z"
+    },
+    "tv-listings.json": {
+      "bytes": 522,
+      "sha256": "874ee5693bdb47f66a6d5801a1c9f76c7dd39cc379a257077225ef8b02eb9927"
+    },
+    "ui-fix-log.json": {
+      "bytes": 1535,
+      "sha256": "46df876fa9dd749a724e90711ac2af0ed622455ed2f4ea6ced330f9d01466020"
+    },
+    "usage-state.json": {
+      "bytes": 514,
+      "sha256": "a0ae3c7ca0a1dccf38c5b6a1f6dd7ecda57c697868ea7a97a375893cd0cec7a4"
+    },
+    "usage-summary.json": {
+      "bytes": 496,
+      "sha256": "0eaf3f0813f56f931ed93f38162cf39e3cff5f7eb3ce02fd676582332bb86b82"
+    },
+    "verify-log.json": {
+      "bytes": 1882,
+      "sha256": "1757302489e197c2befc2ac98f7d944f76ba32fbefe86ef1db6fc913d7f79b4a"
+    },
+    "visual-qa-log.json": {
+      "bytes": 2367,
+      "sha256": "4ab0f8ccb99b011bd8f2557cff02321670d9c79af1d7c3e30c09a1139601fd57"
+    }
+  }
+}

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -4,6 +4,7 @@ import path from "path";
 import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, MS_PER_DAY, matchInterest, mustWatchEntity } from "./lib/helpers.js";
 import { resolveStreaming } from "./lib/norwegian-rights.js";
+import { writeManifest } from "./build-manifest.js";
 
 const dataDir = rootDataPath();
 
@@ -460,3 +461,9 @@ for (const name of ["tracked.json", "interests.json"]) {
 		console.log(`Published ${name} to docs/data/`);
 	}
 }
+
+// WP-03: publish manifest.json (bytes + sha256 per published data file) —
+// last thing this script does, so it reflects everything build-events.js
+// itself just wrote (events.json, tracked.json, interests.json).
+const manifest = writeManifest(dataDir);
+console.log(`Wrote manifest.json (${Object.keys(manifest.files).length} file(s)).`);

--- a/scripts/build-manifest.js
+++ b/scripts/build-manifest.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Publishes docs/data/manifest.json: one entry per published data file, with
+ * `bytes` + `sha256` so a client (the WP-12 SyncClient) can diff its local
+ * cache against the server without re-downloading every file on each poll.
+ *
+ * Deliberately NOT fs mtime: git doesn't preserve file mtimes, so in CI a
+ * file's mtime is meaningless (checkout time, not last-content-change time).
+ * Hash-diff is the sync contract. If a file happens to carry its own
+ * `lastUpdated` field (meta.json, the per-sport fetcher files, …) it's
+ * mirrored onto the entry as `sourceLastUpdated` — informational only, never
+ * used for diffing.
+ *
+ * Called directly from build-events.js (last statement in that script's run)
+ * rather than wired into static-pipeline.yml as its own step — no workflow
+ * change needed, and `.github/workflows/**` is a protected path.
+ */
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { rootDataPath, iso } from "./lib/helpers.js";
+
+export const MANIFEST_NAME = "manifest.json";
+
+function sha256Hex(buf) {
+	return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Which files in dataDir are "published data" — the exact set the manifest
+ * covers: every docs/data/*.json (except manifest.json itself) plus
+ * events.ics. Never *.jsonl — those are append-only ledgers, not published
+ * snapshots a client would sync.
+ */
+export function listPublishedFiles(dataDir) {
+	if (!fs.existsSync(dataDir)) return [];
+	return fs
+		.readdirSync(dataDir)
+		.filter((f) => f !== MANIFEST_NAME && !f.endsWith(".jsonl") && (f.endsWith(".json") || f === "events.ics"))
+		.sort();
+}
+
+/**
+ * Build the manifest object for dataDir. Pure with respect to the
+ * filesystem (reads only, never writes). `now` is injectable for
+ * deterministic tests. File keys are inserted in sorted order, so
+ * JSON.stringify emits a stable, alphabetically-ordered `files` object —
+ * the manifest only diffs when content actually changes (generatedAt aside).
+ */
+export function buildManifest(dataDir, now = Date.now()) {
+	const files = {};
+	for (const name of listPublishedFiles(dataDir)) {
+		const buf = fs.readFileSync(path.join(dataDir, name));
+		const entry = { bytes: buf.length, sha256: sha256Hex(buf) };
+		if (name.endsWith(".json")) {
+			try {
+				const parsed = JSON.parse(buf.toString("utf-8"));
+				if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && typeof parsed.lastUpdated === "string") {
+					entry.sourceLastUpdated = parsed.lastUpdated;
+				}
+			} catch {
+				// Not parseable JSON despite the extension — skip the optional mirror,
+				// bytes/sha256 above are still correct for whatever's on disk.
+			}
+		}
+		files[name] = entry;
+	}
+	return {
+		generatedAt: iso(now),
+		schemaVersion: 1,
+		files,
+	};
+}
+
+/** Build + write manifest.json into dataDir. Returns the manifest object. */
+export function writeManifest(dataDir = rootDataPath(), now = Date.now()) {
+	const manifest = buildManifest(dataDir, now);
+	fs.writeFileSync(path.join(dataDir, MANIFEST_NAME), JSON.stringify(manifest, null, 2));
+	return manifest;
+}
+
+function main() {
+	const manifest = writeManifest();
+	console.log(`manifest.json: ${Object.keys(manifest.files).length} file(s) covered.`);
+}
+
+if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+	main();
+}

--- a/tests/build-manifest.test.js
+++ b/tests/build-manifest.test.js
@@ -1,0 +1,266 @@
+// build-manifest.js (WP-03): docs/data/manifest.json — bytes + sha256 per
+// published data file, the ground truth a client diffs against (never fs
+// mtime — git doesn't preserve mtimes, so hash-diff is the only sync contract
+// that survives a checkout).
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { buildManifest, listPublishedFiles, writeManifest, MANIFEST_NAME } from "../scripts/build-manifest.js";
+
+function tmpDir(prefix) {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function sha256(buf) {
+	return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+describe("listPublishedFiles", () => {
+	it("includes every docs/data/*.json and events.ics, excludes manifest.json and *.jsonl", () => {
+		const dataDir = tmpDir("ss-manifest-list-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), "[]");
+		fs.writeFileSync(path.join(dataDir, "meta.json"), '{"lastUpdated":"2026-07-13T10:00:00Z"}');
+		fs.writeFileSync(path.join(dataDir, "events.ics"), "BEGIN:VCALENDAR\nEND:VCALENDAR\n");
+		fs.writeFileSync(path.join(dataDir, "calibration-ledger.jsonl"), '{"a":1}\n{"a":2}\n');
+		fs.writeFileSync(path.join(dataDir, MANIFEST_NAME), "{}"); // a stale manifest from a prior run
+		fs.writeFileSync(path.join(dataDir, ".DS_Store"), "junk"); // non-data cruft, ignored
+
+		const files = listPublishedFiles(dataDir);
+
+		expect(files).toContain("events.json");
+		expect(files).toContain("meta.json");
+		expect(files).toContain("events.ics");
+		expect(files).not.toContain(MANIFEST_NAME);
+		expect(files).not.toContain("calibration-ledger.jsonl");
+		expect(files).not.toContain(".DS_Store");
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("returns an empty list for a directory that doesn't exist", () => {
+		expect(listPublishedFiles(path.join(os.tmpdir(), "ss-manifest-does-not-exist-xyz"))).toEqual([]);
+	});
+});
+
+describe("buildManifest", () => {
+	it("covers all published files and stamps the required top-level fields", () => {
+		const dataDir = tmpDir("ss-manifest-cover-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf", title: "Open" }]));
+		fs.writeFileSync(path.join(dataDir, "featured.json"), JSON.stringify({ headline: "x" }));
+		fs.writeFileSync(path.join(dataDir, "events.ics"), "BEGIN:VCALENDAR\nEND:VCALENDAR\n");
+		fs.writeFileSync(path.join(dataDir, "calibration-ledger.jsonl"), '{"a":1}\n');
+
+		const now = Date.parse("2026-07-13T12:00:00Z");
+		const manifest = buildManifest(dataDir, now);
+
+		expect(manifest.schemaVersion).toBe(1);
+		expect(manifest.generatedAt).toBe(new Date(now).toISOString());
+		expect(Object.keys(manifest.files).sort()).toEqual(["events.ics", "events.json", "featured.json"]);
+		expect(manifest.files["events.json"]).toMatchObject({ bytes: expect.any(Number), sha256: expect.any(String) });
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("never includes itself even if manifest.json already exists on disk", () => {
+		const dataDir = tmpDir("ss-manifest-self-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), "[]");
+		fs.writeFileSync(path.join(dataDir, MANIFEST_NAME), JSON.stringify({ schemaVersion: 1, files: {} }));
+		const manifest = buildManifest(dataDir);
+		expect(manifest.files).not.toHaveProperty(MANIFEST_NAME);
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("excludes .jsonl ledgers from the covered set", () => {
+		const dataDir = tmpDir("ss-manifest-jsonl-");
+		fs.writeFileSync(path.join(dataDir, "usage-history.jsonl"), '{"a":1}\n{"a":2}\n');
+		fs.writeFileSync(path.join(dataDir, "usage-state.json"), '{"level":"green"}');
+		const manifest = buildManifest(dataDir);
+		expect(Object.keys(manifest.files)).toEqual(["usage-state.json"]);
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("computes correct bytes and sha256 for each entry (regenerate and compare)", () => {
+		const dataDir = tmpDir("ss-manifest-hash-");
+		const eventsContent = JSON.stringify([{ sport: "chess", title: "World Cup", time: "2026-08-01T10:00:00Z" }], null, 2);
+		const icsContent = "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n";
+		fs.writeFileSync(path.join(dataDir, "events.json"), eventsContent);
+		fs.writeFileSync(path.join(dataDir, "events.ics"), icsContent);
+
+		const manifest = buildManifest(dataDir);
+
+		const expectedEventsBuf = Buffer.from(eventsContent);
+		const expectedIcsBuf = Buffer.from(icsContent);
+		expect(manifest.files["events.json"].bytes).toBe(expectedEventsBuf.length);
+		expect(manifest.files["events.json"].sha256).toBe(sha256(expectedEventsBuf));
+		expect(manifest.files["events.ics"].bytes).toBe(expectedIcsBuf.length);
+		expect(manifest.files["events.ics"].sha256).toBe(sha256(expectedIcsBuf));
+		// sha256 is hex-encoded (64 lowercase hex chars)
+		expect(manifest.files["events.json"].sha256).toMatch(/^[0-9a-f]{64}$/);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("mirrors a file's own lastUpdated as sourceLastUpdated, without using fs mtime", () => {
+		const dataDir = tmpDir("ss-manifest-lastupdated-");
+		fs.writeFileSync(path.join(dataDir, "meta.json"), JSON.stringify({ lastUpdated: "2026-07-01T05:00:00Z" }));
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf" }])); // no lastUpdated field
+
+		const manifest = buildManifest(dataDir);
+
+		expect(manifest.files["meta.json"].sourceLastUpdated).toBe("2026-07-01T05:00:00Z");
+		expect(manifest.files["events.json"]).not.toHaveProperty("sourceLastUpdated");
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("does not crash on a .json file that isn't valid JSON", () => {
+		const dataDir = tmpDir("ss-manifest-badjson-");
+		fs.writeFileSync(path.join(dataDir, "broken.json"), "{ not actually json");
+		const manifest = buildManifest(dataDir);
+		expect(manifest.files["broken.json"]).toBeTruthy();
+		expect(manifest.files["broken.json"]).not.toHaveProperty("sourceLastUpdated");
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+});
+
+describe("determinism (WP-03 acceptance)", () => {
+	it("sorts file keys alphabetically regardless of on-disk / creation order", () => {
+		const dataDir = tmpDir("ss-manifest-sort-");
+		// Write in a deliberately non-alphabetical order.
+		fs.writeFileSync(path.join(dataDir, "zzz.json"), "{}");
+		fs.writeFileSync(path.join(dataDir, "aaa.json"), "{}");
+		fs.writeFileSync(path.join(dataDir, "mmm.json"), "{}");
+		const manifest = buildManifest(dataDir);
+		expect(Object.keys(manifest.files)).toEqual(["aaa.json", "mmm.json", "zzz.json"]);
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("produces byte-identical JSON.stringify output across two builds with the same generatedAt", () => {
+		const dataDir = tmpDir("ss-manifest-stable-");
+		fs.writeFileSync(path.join(dataDir, "b.json"), JSON.stringify({ x: 1 }));
+		fs.writeFileSync(path.join(dataDir, "a.json"), JSON.stringify({ y: 2 }));
+		const now = Date.parse("2026-07-13T12:00:00Z");
+		const first = JSON.stringify(buildManifest(dataDir, now));
+		const second = JSON.stringify(buildManifest(dataDir, now));
+		expect(first).toBe(second);
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+});
+
+describe("idempotence (WP-03 acceptance)", () => {
+	it("gives two runs over unchanged input identical content, aside from generatedAt", () => {
+		const dataDir = tmpDir("ss-manifest-idem-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf", title: "Open" }]));
+		fs.writeFileSync(path.join(dataDir, "tracked.json"), JSON.stringify({ athletes: ["Viktor Hovland"] }));
+		fs.writeFileSync(path.join(dataDir, "events.ics"), "BEGIN:VCALENDAR\nEND:VCALENDAR\n");
+
+		const first = buildManifest(dataDir, Date.parse("2026-07-13T10:00:00Z"));
+		const second = buildManifest(dataDir, Date.parse("2026-07-13T14:00:00Z"));
+
+		const { generatedAt: g1, ...rest1 } = first;
+		const { generatedAt: g2, ...rest2 } = second;
+		expect(g1).not.toBe(g2); // sanity: the injected clock actually moved
+		expect(rest1).toEqual(rest2);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("writeManifest is idempotent across two real invocations on disk", () => {
+		const dataDir = tmpDir("ss-manifest-writeidem-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf" }]));
+
+		writeManifest(dataDir, Date.parse("2026-07-13T10:00:00Z"));
+		const firstOnDisk = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
+
+		writeManifest(dataDir, Date.parse("2026-07-13T11:00:00Z"));
+		const secondOnDisk = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
+
+		const { generatedAt: g1, ...rest1 } = firstOnDisk;
+		const { generatedAt: g2, ...rest2 } = secondOnDisk;
+		expect(g1).not.toBe(g2);
+		expect(rest1).toEqual(rest2);
+		// And the manifest never lists itself, even on the second run where it
+		// already existed on disk before writeManifest ran.
+		expect(secondOnDisk.files).not.toHaveProperty(MANIFEST_NAME);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+});
+
+describe("build-manifest CLI entrypoint", () => {
+	it("writes manifest.json when run directly with node", () => {
+		const dataDir = tmpDir("ss-manifest-cli-");
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf" }]));
+		execFileSync("node", ["scripts/build-manifest.js"], {
+			env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir },
+		});
+		const manifestPath = path.join(dataDir, MANIFEST_NAME);
+		expect(fs.existsSync(manifestPath)).toBe(true);
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+		expect(manifest.schemaVersion).toBe(1);
+		expect(manifest.files).toHaveProperty("events.json");
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+});
+
+describe("build-events.js integration (WP-03)", () => {
+	it("writes manifest.json as the last step of a build-events.js run, covering events.json/tracked.json it just published", () => {
+		const dataDir = tmpDir("ss-manifest-integ-");
+		const configDir = tmpDir("ss-manifest-integ-cfg-");
+		const future = new Date(Date.now() + 86400000).toISOString();
+		fs.writeFileSync(
+			path.join(dataDir, "golf.json"),
+			JSON.stringify({ tournaments: [{ name: "PGA Tour", events: [{ title: "Open", time: future, norwegian: true }] }] })
+		);
+		fs.writeFileSync(path.join(configDir, "tracked.json"), JSON.stringify({ athletes: [] }));
+
+		execFileSync("node", ["scripts/build-events.js"], {
+			env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir, SPORTSYNC_CONFIG_DIR: configDir },
+		});
+
+		const manifestPath = path.join(dataDir, MANIFEST_NAME);
+		expect(fs.existsSync(manifestPath)).toBe(true);
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+		expect(manifest.schemaVersion).toBe(1);
+		expect(manifest.files).toHaveProperty("events.json");
+		expect(manifest.files).toHaveProperty("tracked.json");
+		expect(manifest.files).not.toHaveProperty(MANIFEST_NAME);
+
+		// The hash must match what's actually on disk after the build.
+		const eventsBuf = fs.readFileSync(path.join(dataDir, "events.json"));
+		expect(manifest.files["events.json"].sha256).toBe(sha256(eventsBuf));
+		expect(manifest.files["events.json"].bytes).toBe(eventsBuf.length);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+
+	it("running build-events.js twice on unchanged input yields an identical manifest, aside from generatedAt", () => {
+		const dataDir = tmpDir("ss-manifest-integ2-");
+		const configDir = tmpDir("ss-manifest-integ2-cfg-");
+		const future = new Date(Date.now() + 2 * 86400000).toISOString();
+		fs.writeFileSync(
+			path.join(dataDir, "football.json"),
+			JSON.stringify({
+				tournaments: [{ name: "Premier League", events: [{ title: "Liverpool vs Arsenal", time: future, homeTeam: "Liverpool", awayTeam: "Arsenal" }] }],
+			})
+		);
+		const env = { ...process.env, SPORTSYNC_DATA_DIR: dataDir, SPORTSYNC_CONFIG_DIR: configDir };
+
+		execFileSync("node", ["scripts/build-events.js"], { env });
+		const first = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
+
+		execFileSync("node", ["scripts/build-events.js"], { env }); // re-reads its own events.json output, rebuilds
+		const second = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
+
+		const { generatedAt: g1, ...rest1 } = first;
+		const { generatedAt: g2, ...rest2 } = second;
+		expect(rest1).toEqual(rest2);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+});


### PR DESCRIPTION
## Summary

Implements WP-03 from PLAN.md: `docs/data/manifest.json`, the sync contract a future thin client (WP-12 SyncClient) will poll to know which published data files changed, without re-downloading everything.

- New `scripts/build-manifest.js`: builds one manifest entry per published data file — every `docs/data/*.json` (except `manifest.json` itself) plus `docs/data/events.ics`. `*.jsonl` ledgers (`calibration-ledger.jsonl`, `usage-history.jsonl`) are excluded — they're append-only, not published snapshots. Each entry carries `bytes` and `sha256` (hex). Top level: `generatedAt` (ISO 8601) and `schemaVersion: 1`.
- **No fs mtime anywhere** — git doesn't preserve mtimes, so they'd be meaningless in CI. Hash-diff is the only contract. If a file happens to carry its own `lastUpdated` field, it's mirrored onto its entry as the optional, informational `sourceLastUpdated` (never used for diffing).
- Deterministic output: file keys sorted alphabetically, stable `JSON.stringify` — the manifest only diffs when content actually changes (`generatedAt` excepted).
- Wired in as **one import + one call at the very end of `scripts/build-events.js`** (which already runs last in the static pipeline's script sequence) — no `.github/workflows/**` change needed; that path is protected and untouched.
- `docs/data/manifest.json` whitelisted in `.gitignore` alongside the existing whitelist pattern.
- Ran `node scripts/build-events.js` locally to generate and check in the manifest for today's real data (29 files covered); `node scripts/validate-events.js` passes clean afterward.

## Test plan

New `tests/build-manifest.test.js` (15 tests), plus full suite:

- [x] Manifest covers all published files and excludes itself + `.jsonl` ledgers (`listPublishedFiles` unit tests + `buildManifest` coverage tests)
- [x] sha256/bytes are correct — regenerated independently and compared byte-for-byte
- [x] Idempotence: two builds over unchanged input produce identical content, `generatedAt` aside (both at the pure-function level and via two real `build-events.js` invocations through `execFileSync`)
- [x] Determinism: file keys are alphabetically sorted regardless of on-disk/creation order
- [x] Integration: `build-events.js` writes `manifest.json` as its last step, covering `events.json`/`tracked.json` it just published, with hashes matching what's actually on disk
- [x] `npm test` — 300/300 passing across 27 files
- [x] `node scripts/validate-events.js` — clean after the local build

Non-goals (per PLAN.md, respected): no sharding, `meta.json` untouched, no workflow/hook/`interests.json` changes, no other script touched besides the single call-site added to `build-events.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)