### PR TITLE
WP-06: gylne feed-vektorer

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -38,7 +38,7 @@ mennesket, aldri av en agent.
 | WP-03 | manifest.json | 0A | – | todo |
 | WP-04 | Deltakelse-normalisering | 0A | WP-01 | todo |
 | WP-05 | Entitets-indeks | 0A | WP-01 | todo |
-| WP-06 | Gylne feed-vektorer | 0A | WP-02 | todo |
+| WP-06 | Gylne feed-vektorer | 0A | WP-02 | PR åpnet |
 | WP-10 | iOS-scaffold | 0B | – | todo |
 | WP-11 | Codable-modeller | 0B | WP-01, WP-10 | todo |
 | WP-12 | SyncClient | 0B | WP-03, WP-11 | todo |

--- a/tests/feed-vectors.test.js
+++ b/tests/feed-vectors.test.js
@@ -1,0 +1,195 @@
+// WP-06 · Golden feed vectors.
+//
+// Freezes the personalisation semantics — relevance, must-watch (bell),
+// must-see (accent), the agenda time window, and series collapse — as
+// declarative JSON fixtures in tests/fixtures/feed-vectors/. Each fixture is a
+// pure-data pair of { input, expected }: no JS inside the fixtures, so the exact
+// same files can be replayed from XCTest to prove the Swift FeedCompiler
+// (WP-13) equivalent. See tests/fixtures/feed-vectors/README.md for the format
+// and tests/fixtures/feed-vectors/DIVERGENCES.md for the server/client mismatches
+// this test pins (deliberately NOT fixed — WP-06 is non-fixing by contract).
+//
+// Where the same logic exists on BOTH sides, the vector is run against both:
+//   • isEventInWindow → server scripts/lib/helpers.js AND client
+//     docs/js/shared-constants.js (the two must agree — a divergence would be a
+//     real bug; the test asserts parity).
+//   • mustWatch (bell) → server helper mustWatchEntity (client only reads the
+//     precomputed e.mustWatch, so there is no second implementation to run).
+//   • mustSee (accent) + collapseSeries → client only (docs/js/dashboard.js).
+//   • relevant (feed inclusion) → a faithful mirror of scripts/build-events.js
+//     (isRelevant + the 14-day retention cutoff), built on the exported
+//     matchInterest. isRelevant is not exported, so it is reconstructed here and
+//     annotated with its source lines; this reconstruction IS the JS reference
+//     the Swift port is proven against.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+	isEventInWindow as serverInWindow,
+	mustWatchEntity,
+	matchInterest,
+	MS_PER_DAY,
+} from "../scripts/lib/helpers.js";
+import { createClientSandbox, loadClientScript } from "./helpers/load-client.js";
+
+const FIX_DIR = path.resolve(process.cwd(), "tests", "fixtures", "feed-vectors");
+
+// --- Load every JSON vector (deterministic order by filename) ----------------
+function loadVectors() {
+	return fs
+		.readdirSync(FIX_DIR)
+		.filter((f) => f.endsWith(".json"))
+		.sort()
+		.map((f) => ({ file: f, ...JSON.parse(fs.readFileSync(path.join(FIX_DIR, f), "utf-8")) }));
+}
+const VECTORS = loadVectors();
+
+// --- Server reference: relevance (feed inclusion) ----------------------------
+// Mirrors scripts/build-events.js:405-432 verbatim:
+//   • the default followBroadly list (build-events.js:406)
+//   • isRelevant() (build-events.js:414-421) — NOTE: matchInterest is called
+//     WITHOUT a sport scope here, unlike mustWatchEntity (see DIVERGENCES.md)
+//   • the 14-day retention cutoff (build-events.js:424-432), which keys off
+//     endTime when present, else start.
+const DEFAULT_FOLLOW_BROADLY = [
+	"football", "golf", "f1", "cycling", "chess", "esports",
+	"biathlon", "cross-country", "alpine", "nordic", "ski jumping",
+];
+
+function serverRelevant(event, interests, nowMs) {
+	if (!event.time) return false;
+	const relevantTime = event.endTime ? Date.parse(event.endTime) : Date.parse(event.time);
+	if (relevantTime < nowMs - 14 * MS_PER_DAY) return false; // dropped: too old
+
+	const followBroadly = new Set(
+		(interests.followBroadly || DEFAULT_FOLLOW_BROADLY).map((s) => s.toLowerCase())
+	);
+	if (followBroadly.has((event.sport || "").toLowerCase())) return true;
+	if (event.norwegian || event.isFavorite || (event.importance || 0) >= 4 || event.source === "ai-research") return true;
+
+	const trackedEntities = [
+		...(interests.alwaysTrack?.teams || []),
+		...(interests.alwaysTrack?.athletes || []),
+		...(interests.alwaysTrack?.tournaments || []),
+	];
+	const hay = [
+		event.title, event.tournament, event.homeTeam, event.awayTeam,
+		...(event.norwegianPlayers || []).map((p) => p.name || p),
+		...(event.participants || []),
+	].join(" ");
+	return matchInterest(hay, trackedEntities) != null; // NOT sport-scoped
+}
+
+// --- Client reference: shared sandbox ----------------------------------------
+let dash; // docs/js/dashboard.js Dashboard instance
+let clientInWindow; // docs/js/shared-constants.js isEventInWindow
+
+beforeAll(() => {
+	const sandbox = createClientSandbox();
+	loadClientScript(sandbox, "shared-constants.js");
+	loadClientScript(sandbox, "sport-config.js");
+	loadClientScript(sandbox, "asset-maps.js");
+	loadClientScript(sandbox, "dashboard.js");
+	dash = sandbox.window.dashboard;
+	clientInWindow = sandbox.window.isEventInWindow;
+});
+
+// --- Comparison helpers ------------------------------------------------------
+const sortIds = (arr) => [...arr].sort();
+const idsWhere = (events, pred) => sortIds(events.filter(pred).map((e) => e.id));
+
+function describeSeriesItem(item) {
+	return item.isSeries
+		? {
+			isSeries: true,
+			id: item.id,
+			tournament: item.tournament,
+			stageCount: item.stages.length,
+			nextStageId: item.nextStage ? item.nextStage.id : null,
+		}
+		: { isSeries: false, id: item.id };
+}
+const sortByIdField = (arr) => [...arr].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+// --- Structural guards -------------------------------------------------------
+describe("feed-vector suite integrity", () => {
+	it("ships at least 10 vectors (WP-06 acceptance)", () => {
+		expect(VECTORS.length).toBeGreaterThanOrEqual(10);
+	});
+
+	it("every event carries a unique id and every expected id resolves to an event", () => {
+		for (const v of VECTORS) {
+			const events = v.input.events || [];
+			const ids = events.map((e) => e.id);
+			expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+			expect(new Set(ids).size, `${v.file}: duplicate event id`).toBe(ids.length);
+			const known = new Set(ids);
+			for (const key of ["relevant", "mustWatch", "mustSee", "inWindow"]) {
+				for (const id of v.expected[key] || []) {
+					expect(known.has(id), `${v.file}: expected.${key} references unknown id "${id}"`).toBe(true);
+				}
+			}
+		}
+	});
+
+	it("every vector declares at least one expectation", () => {
+		for (const v of VECTORS) {
+			const keys = Object.keys(v.expected || {});
+			expect(keys.length, `${v.file}: no expectations`).toBeGreaterThan(0);
+		}
+	});
+});
+
+// --- Run each vector against the reference implementations -------------------
+for (const v of VECTORS) {
+	describe(`${v.file} — ${v.name}`, () => {
+		const events = v.input.events || [];
+		const interests = v.input.interests || {};
+		const nowMs = v.input.now ? Date.parse(v.input.now) : Date.now();
+
+		if (v.expected.relevant) {
+			it("server: relevant events match (build-events.js isRelevant + 14d cutoff)", () => {
+				expect(idsWhere(events, (e) => serverRelevant(e, interests, nowMs))).toEqual(sortIds(v.expected.relevant));
+			});
+		}
+
+		if (v.expected.mustWatch) {
+			it("server: must-watch (bell) events match (helpers.js mustWatchEntity)", () => {
+				expect(idsWhere(events, (e) => mustWatchEntity(e, interests) != null)).toEqual(sortIds(v.expected.mustWatch));
+			});
+		}
+
+		if (v.expected.mustSee) {
+			it("client: must-see (accent) events match (dashboard.js isMustSee)", () => {
+				dash.interests = interests;
+				expect(idsWhere(events, (e) => dash.isMustSee(e))).toEqual(sortIds(v.expected.mustSee));
+			});
+		}
+
+		if (v.expected.inWindow) {
+			const win = v.input.window;
+			it("has a window when it expects inWindow results", () => {
+				expect(win && win.start && win.end, `${v.file}: expected.inWindow requires input.window`).toBeTruthy();
+			});
+			it("server & client isEventInWindow agree and match the expected set", () => {
+				const ws = Date.parse(win.start), we = Date.parse(win.end);
+				const serverIds = idsWhere(events, (e) => serverInWindow(e, ws, we));
+				const clientIds = idsWhere(events, (e) => clientInWindow(e, ws, we));
+				// The two implementations are byte-identical mirrors — pin parity so a
+				// future edit to one side fails loudly (this is the only true both-sides
+				// function; see CLAUDE.md "Event time filtering").
+				expect(clientIds, `${v.file}: server/client isEventInWindow DIVERGED`).toEqual(serverIds);
+				expect(serverIds).toEqual(sortIds(v.expected.inWindow));
+			});
+		}
+
+		if (v.expected.series) {
+			it("client: collapseSeries folds/keeps rows as expected (dashboard.js)", () => {
+				const actual = sortByIdField(dash.collapseSeries(events, nowMs).map(describeSeriesItem));
+				const expected = sortByIdField(v.expected.series);
+				expect(actual).toEqual(expected);
+			});
+		}
+	});
+}

--- a/tests/fixtures/feed-vectors/01-multiday-window-golf.json
+++ b/tests/fixtures/feed-vectors/01-multiday-window-golf.json
@@ -1,0 +1,69 @@
+{
+	"name": "Multi-day golf tournament straddles the window edge",
+	"description": "isEventInWindow must keep a multi-day event that STARTED before the window but ENDS inside it (golf/major spanning several days). Point-in-time events are kept only when their start falls inside the window. An event with no time is never in-window. Run against BOTH server (scripts/lib/helpers.js) and client (docs/js/shared-constants.js) — they must agree.",
+	"input": {
+		"now": "2026-07-17T12:00:00Z",
+		"window": { "start": "2026-07-16T00:00:00Z", "end": "2026-07-20T00:00:00Z" },
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "g-straddle",
+				"sport": "golf",
+				"title": "The Open Championship",
+				"time": "2026-07-15T06:00:00Z",
+				"endTime": "2026-07-18T18:00:00Z"
+			},
+			{
+				"id": "g-inside",
+				"sport": "golf",
+				"title": "One-day pro-am",
+				"time": "2026-07-17T06:00:00Z",
+				"endTime": null
+			},
+			{
+				"id": "g-before",
+				"sport": "golf",
+				"title": "Last week's event",
+				"time": "2026-07-10T06:00:00Z",
+				"endTime": "2026-07-12T06:00:00Z"
+			},
+			{
+				"id": "g-after",
+				"sport": "golf",
+				"title": "Next week's event",
+				"time": "2026-07-25T06:00:00Z",
+				"endTime": null
+			},
+			{
+				"id": "g-notime",
+				"sport": "golf",
+				"title": "Undated event",
+				"time": null,
+				"endTime": null
+			}
+		]
+	},
+	"expected": {
+		"inWindow": ["g-inside", "g-straddle"]
+	}
+}

--- a/tests/fixtures/feed-vectors/02-multiday-window-stagerace.json
+++ b/tests/fixtures/feed-vectors/02-multiday-window-stagerace.json
@@ -1,0 +1,59 @@
+{
+	"name": "Grand tour + a single stage against today's agenda window",
+	"description": "A three-week stage race (endTime weeks out) overlaps TODAY's window even though it started days ago; today's stage overlaps; a stage that already finished does NOT overlap today's window but is STILL relevant (kept in the feed under the 14-day retention floor). Separates the agenda's day-window (isEventInWindow) from the server retention cutoff.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"window": { "start": "2026-07-13T00:00:00Z", "end": "2026-07-14T00:00:00Z" },
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "tdf",
+				"sport": "cycling",
+				"title": "Tour de France 2026",
+				"tournament": "Tour de France",
+				"time": "2026-07-05T11:00:00Z",
+				"endTime": "2026-07-27T17:00:00Z"
+			},
+			{
+				"id": "stage-today",
+				"sport": "cycling",
+				"title": "Etappe 9",
+				"tournament": "Tour de France",
+				"time": "2026-07-13T11:00:00Z",
+				"endTime": "2026-07-13T16:00:00Z"
+			},
+			{
+				"id": "stage-past",
+				"sport": "cycling",
+				"title": "Etappe 1",
+				"tournament": "Tour de France",
+				"time": "2026-07-05T11:00:00Z",
+				"endTime": "2026-07-05T16:00:00Z"
+			}
+		]
+	},
+	"expected": {
+		"inWindow": ["stage-today", "tdf"],
+		"relevant": ["stage-past", "stage-today", "tdf"]
+	}
+}

--- a/tests/fixtures/feed-vectors/03-relevance-14day-cutoff.json
+++ b/tests/fixtures/feed-vectors/03-relevance-14day-cutoff.json
@@ -1,0 +1,68 @@
+{
+	"name": "Server retention cutoff uses endTime, not start",
+	"description": "The server keeps events whose relevant time (endTime when present, else start) is within the last 14 days or in the future. A multi-day event that STARTED 4 weeks ago but ENDED 3 days ago is kept (endTime-based). A single old event is dropped. The exact-cutoff boundary is kept (strict < drop). Sport is golf (broadly followed) so ONLY the time gate decides.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "fresh",
+				"sport": "golf",
+				"title": "Ended yesterday",
+				"time": "2026-07-12T06:00:00Z",
+				"endTime": null
+			},
+			{
+				"id": "old-single",
+				"sport": "golf",
+				"title": "Three weeks ago, single day",
+				"time": "2026-06-20T06:00:00Z",
+				"endTime": null
+			},
+			{
+				"id": "old-start-recent-end",
+				"sport": "golf",
+				"title": "Started a month ago, ended recently",
+				"time": "2026-06-15T06:00:00Z",
+				"endTime": "2026-07-10T06:00:00Z"
+			},
+			{
+				"id": "future",
+				"sport": "golf",
+				"title": "Next month",
+				"time": "2026-08-01T06:00:00Z",
+				"endTime": null
+			},
+			{
+				"id": "boundary",
+				"sport": "golf",
+				"title": "Exactly at the 14-day cutoff",
+				"time": "2026-06-29T12:00:00Z",
+				"endTime": null
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["boundary", "fresh", "future", "old-start-recent-end"]
+	}
+}

--- a/tests/fixtures/feed-vectors/04-mustsee-favorite-importance.json
+++ b/tests/fixtures/feed-vectors/04-mustsee-favorite-importance.json
@@ -1,0 +1,56 @@
+{
+	"name": "Favorite and importance>=4 drive relevance + accent, but never the bell",
+	"description": "isFavorite and importance>=4 pull an otherwise-unfollowed event (tennis is NOT broadly followed) onto the board (relevant) and give it the must-see accent (client isMustSee). They do NOT arm the reminder bell (server mustWatchEntity keys only off interests.json notify entities). importance:3 clears none of the gates.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "fav",
+				"sport": "tennis",
+				"title": "Exhibition match",
+				"time": "2026-07-15T12:00:00Z",
+				"isFavorite": true
+			},
+			{
+				"id": "imp4",
+				"sport": "tennis",
+				"title": "A big final",
+				"time": "2026-07-15T13:00:00Z",
+				"importance": 4
+			},
+			{
+				"id": "imp3",
+				"sport": "tennis",
+				"title": "A minor round",
+				"time": "2026-07-15T14:00:00Z",
+				"importance": 3
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["fav", "imp4"],
+		"mustSee": ["fav", "imp4"],
+		"mustWatch": []
+	}
+}

--- a/tests/fixtures/feed-vectors/05-mustsee-golf-lens.json
+++ b/tests/fixtures/feed-vectors/05-mustsee-golf-lens.json
@@ -1,0 +1,59 @@
+{
+	"name": "Golf lens: Norwegian flag alone is not enough — a Norwegian in the field is",
+	"description": "The client must-see rule (norwegian && norwegianPlayers.length) is the golf lens: a golf event carrying a Norwegian in the field gets the accent even when that player is not a tracked athlete. The same event marked norwegian:true but with an EMPTY norwegianPlayers list does NOT get the accent, though it stays relevant (server keeps it on norwegian:true). The bell fires only when a tracked notify-athlete (Hovland) is actually on the card.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "lens",
+				"sport": "golf",
+				"title": "Made in HimmerLand",
+				"time": "2026-07-16T06:00:00Z",
+				"norwegian": true,
+				"norwegianPlayers": [{ "name": "Ola Nordmann" }]
+			},
+			{
+				"id": "flag-only",
+				"sport": "golf",
+				"title": "Some Open",
+				"time": "2026-07-16T07:00:00Z",
+				"norwegian": true,
+				"norwegianPlayers": []
+			},
+			{
+				"id": "hovland",
+				"sport": "golf",
+				"title": "Genesis Scottish Open",
+				"time": "2026-07-16T08:00:00Z",
+				"norwegian": true,
+				"norwegianPlayers": [{ "name": "Viktor Hovland", "teeTime": "09:39" }]
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["flag-only", "hovland", "lens"],
+		"mustSee": ["hovland", "lens"],
+		"mustWatch": ["hovland"]
+	}
+}

--- a/tests/fixtures/feed-vectors/06-mustsee-tracked-team-and-national.json
+++ b/tests/fixtures/feed-vectors/06-mustsee-tracked-team-and-national.json
@@ -1,0 +1,71 @@
+{
+	"name": "Tracked clubs and the Norway national team get the accent; only interests-notify entities get the bell",
+	"description": "The client accents the Norway men's team (homeTeam/awayTeam matches norway/norge) and tracked clubs (substring against tracked team terms). The bell (server mustWatchEntity) fires only for notify entities from interests.json: Norway is NOT tracked here, so it is accented but not belled; a Premier League match with no tracked club is neither; tracked clubs (Lyn, Barcelona) get both.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "norway",
+				"sport": "football",
+				"title": "Norway vs Brazil",
+				"tournament": "Landskamp",
+				"homeTeam": "Norway",
+				"awayTeam": "Brazil",
+				"time": "2026-07-18T18:00:00Z"
+			},
+			{
+				"id": "lyn",
+				"sport": "football",
+				"title": "Lyn – Fram",
+				"tournament": "OBOS-ligaen",
+				"homeTeam": "Lyn",
+				"awayTeam": "Fram",
+				"time": "2026-07-18T15:00:00Z"
+			},
+			{
+				"id": "barca",
+				"sport": "football",
+				"title": "Barcelona vs Sevilla",
+				"tournament": "La Liga",
+				"homeTeam": "FC Barcelona",
+				"awayTeam": "Sevilla",
+				"time": "2026-07-19T20:00:00Z"
+			},
+			{
+				"id": "arsenal",
+				"sport": "football",
+				"title": "Arsenal vs Chelsea",
+				"tournament": "Premier League",
+				"homeTeam": "Arsenal",
+				"awayTeam": "Chelsea",
+				"time": "2026-07-19T16:00:00Z"
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["arsenal", "barca", "lyn", "norway"],
+		"mustSee": ["barca", "lyn", "norway"],
+		"mustWatch": ["barca", "lyn"]
+	}
+}

--- a/tests/fixtures/feed-vectors/07-mustsee-tracked-athlete.json
+++ b/tests/fixtures/feed-vectors/07-mustsee-tracked-athlete.json
@@ -1,0 +1,55 @@
+{
+	"name": "A tracked athlete on the card aligns all three predicates",
+	"description": "When a tracked notify-athlete appears (in the title or in norwegianPlayers), the event is relevant, accented (client isMustSee athlete path) and belled (server mustWatchEntity). A tennis event (not broadly followed) is even pulled onto the board purely because Casper Ruud is on it. The client accent path reads norwegianPlayers names + title but NOT participants.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "scottish",
+				"sport": "golf",
+				"title": "Genesis Scottish Open",
+				"time": "2026-07-16T08:00:00Z",
+				"norwegian": false,
+				"norwegianPlayers": [{ "name": "Viktor Hovland" }]
+			},
+			{
+				"id": "carlsen",
+				"sport": "chess",
+				"title": "Magnus Carlsen vs Hikaru Nakamura",
+				"time": "2026-07-17T15:00:00Z"
+			},
+			{
+				"id": "ruud-tennis",
+				"sport": "tennis",
+				"title": "Casper Ruud vs Alexander Zverev",
+				"time": "2026-07-17T13:00:00Z"
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["carlsen", "ruud-tennis", "scottish"],
+		"mustSee": ["carlsen", "ruud-tennis", "scottish"],
+		"mustWatch": ["carlsen", "ruud-tennis", "scottish"]
+	}
+}

--- a/tests/fixtures/feed-vectors/08-mustwatch-tournament-notify-gating.json
+++ b/tests/fixtures/feed-vectors/08-mustwatch-tournament-notify-gating.json
@@ -1,0 +1,66 @@
+{
+	"name": "Notify tournaments arm the bell; a followed-but-not-notify tournament does not; none earn the accent on their own",
+	"description": "A tournament in interests.json only arms the reminder bell when notify:true. F1 and Tour de France are notify:true → their sessions/stages bell. Premier League is followed (relevant) but notify:false → no bell. None of these clear the client accent (no tracked team/athlete, no norwegian+players, no importance), so must-see is empty even where the bell rings — the bell and the accent are different features.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "f1race",
+				"sport": "f1",
+				"title": "Belgian Grand Prix",
+				"tournament": "F1 World Championship",
+				"time": "2026-07-27T13:00:00Z"
+			},
+			{
+				"id": "f1quali",
+				"sport": "f1",
+				"title": "Qualifying — Belgian GP",
+				"tournament": "F1 World Championship",
+				"time": "2026-07-26T13:00:00Z"
+			},
+			{
+				"id": "plmatch",
+				"sport": "football",
+				"title": "Everton vs Fulham",
+				"tournament": "Premier League",
+				"homeTeam": "Everton",
+				"awayTeam": "Fulham",
+				"time": "2026-07-20T14:00:00Z"
+			},
+			{
+				"id": "tdfstage",
+				"sport": "cycling",
+				"title": "Etappe 15",
+				"tournament": "Tour de France",
+				"time": "2026-07-19T11:00:00Z",
+				"norwegianPlayers": [{ "name": "Tobias Halland Johannessen" }]
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["f1quali", "f1race", "plmatch", "tdfstage"],
+		"mustWatch": ["f1quali", "f1race", "tdfstage"],
+		"mustSee": []
+	}
+}

--- a/tests/fixtures/feed-vectors/09-series-collapse.json
+++ b/tests/fixtures/feed-vectors/09-series-collapse.json
@@ -1,0 +1,43 @@
+{
+	"name": "Series collapse: 4+ stages of one tournament fold into a single series row",
+	"description": "The client folds same-tournament stage races (titles matching /etappe|stage N/) into ONE expandable series item when there are 4 or more stages. The series item's next stage is the first whose end is at/after now (else the last). A non-stage event in the same list passes through untouched. Grouping order is not part of the contract (the agenda re-sorts by time), so the runner compares as an unordered set.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{ "id": "st1", "sport": "cycling", "title": "Etappe 1", "tournament": "Tour de France 2026", "time": "2026-07-05T11:00:00Z", "endTime": "2026-07-05T16:00:00Z" },
+			{ "id": "st2", "sport": "cycling", "title": "Etappe 2", "tournament": "Tour de France 2026", "time": "2026-07-06T11:00:00Z", "endTime": "2026-07-06T16:00:00Z" },
+			{ "id": "st3", "sport": "cycling", "title": "Etappe 3", "tournament": "Tour de France 2026", "time": "2026-07-07T11:00:00Z", "endTime": "2026-07-07T16:00:00Z" },
+			{ "id": "st4", "sport": "cycling", "title": "Etappe 4", "tournament": "Tour de France 2026", "time": "2026-07-13T11:00:00Z", "endTime": "2026-07-13T16:00:00Z" },
+			{ "id": "st5", "sport": "cycling", "title": "Etappe 5", "tournament": "Tour de France 2026", "time": "2026-07-14T11:00:00Z", "endTime": "2026-07-14T16:00:00Z" },
+			{ "id": "st6", "sport": "cycling", "title": "Etappe 6", "tournament": "Tour de France 2026", "time": "2026-07-15T11:00:00Z", "endTime": "2026-07-15T16:00:00Z" },
+			{ "id": "gc", "sport": "cycling", "title": "Sammenlagt-seremoni", "tournament": "Tour de France 2026", "time": "2026-07-15T17:00:00Z" }
+		]
+	},
+	"expected": {
+		"series": [
+			{ "isSeries": false, "id": "gc" },
+			{ "isSeries": true, "id": "series|cycling|Tour de France 2026", "tournament": "Tour de France 2026", "stageCount": 6, "nextStageId": "st4" }
+		]
+	}
+}

--- a/tests/fixtures/feed-vectors/10-series-too-few.json
+++ b/tests/fixtures/feed-vectors/10-series-too-few.json
@@ -1,0 +1,42 @@
+{
+	"name": "Series collapse threshold: fewer than 4 stages stay as individual rows",
+	"description": "A short stage race (3 stages) is NOT collapsed — each stage passes through as its own row, because collapsing only helps when 20+ near-identical rows would drown the week. A non-stage event also passes through. All output items are ordinary (isSeries:false).",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{ "id": "st1", "sport": "cycling", "title": "Etappe 1", "tournament": "Tour of Norway 2026", "time": "2026-07-16T11:00:00Z", "endTime": "2026-07-16T15:00:00Z" },
+			{ "id": "st2", "sport": "cycling", "title": "Etappe 2", "tournament": "Tour of Norway 2026", "time": "2026-07-17T11:00:00Z", "endTime": "2026-07-17T15:00:00Z" },
+			{ "id": "st3", "sport": "cycling", "title": "Etappe 3", "tournament": "Tour of Norway 2026", "time": "2026-07-18T11:00:00Z", "endTime": "2026-07-18T15:00:00Z" },
+			{ "id": "prologue", "sport": "cycling", "title": "Prolog i Oslo", "tournament": "Tour of Norway 2026", "time": "2026-07-15T17:00:00Z" }
+		]
+	},
+	"expected": {
+		"series": [
+			{ "isSeries": false, "id": "prologue" },
+			{ "isSeries": false, "id": "st1" },
+			{ "isSeries": false, "id": "st2" },
+			{ "isSeries": false, "id": "st3" }
+		]
+	}
+}

--- a/tests/fixtures/feed-vectors/11-edge-cancelled.json
+++ b/tests/fixtures/feed-vectors/11-edge-cancelled.json
@@ -1,0 +1,56 @@
+{
+	"name": "Cancelled / postponed status does not change any selection predicate",
+	"description": "status is a rendering concern (the row shows 'Avlyst'/'Utsatt'); it does NOT demote an event out of the feed, off the bell, or off the accent. A cancelled Barcelona match and a postponed Lyn match stay relevant + belled + accented exactly as if they were scheduled.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "cancelled-barca",
+				"sport": "football",
+				"title": "Barcelona vs Girona",
+				"tournament": "La Liga",
+				"homeTeam": "FC Barcelona",
+				"awayTeam": "Girona",
+				"time": "2026-07-18T20:00:00Z",
+				"status": "cancelled",
+				"streaming": []
+			},
+			{
+				"id": "postponed-lyn",
+				"sport": "football",
+				"title": "Lyn – Sandnes Ulf",
+				"tournament": "OBOS-ligaen",
+				"homeTeam": "Lyn",
+				"awayTeam": "Sandnes Ulf",
+				"time": "2026-07-19T15:00:00Z",
+				"status": "postponed"
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["cancelled-barca", "postponed-lyn"],
+		"mustWatch": ["cancelled-barca", "postponed-lyn"],
+		"mustSee": ["cancelled-barca", "postponed-lyn"]
+	}
+}

--- a/tests/fixtures/feed-vectors/12-edge-airesearch-lowconf-empty-streaming.json
+++ b/tests/fixtures/feed-vectors/12-edge-airesearch-lowconf-empty-streaming.json
@@ -1,0 +1,64 @@
+{
+	"name": "AI-research events stay on the board regardless of confidence; empty streaming never drops an event",
+	"description": "source:'ai-research' makes an event relevant on its own — even a low-confidence one in a sport that is not broadly followed and with no tracked entity. confidence does NOT gate feed inclusion today (a notification planner, WP-15, may gate low confidence later — the FEED does not). Empty streaming is a 'where to watch unknown' rendering state, never a reason to drop. The accent still follows the ordinary must-see rules, so a low-confidence Norwegian biathlon sprint with a Norwegian in the field is accented while a bare tennis challenger is not.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "ai-low-tennis",
+				"sport": "tennis",
+				"title": "Oslo Challenger — first round",
+				"time": "2026-07-20T10:00:00Z",
+				"source": "ai-research",
+				"confidence": "low",
+				"evidence": ["https://example.no/a"],
+				"streaming": []
+			},
+			{
+				"id": "ai-low-norsk",
+				"sport": "biathlon",
+				"title": "Sprint kvinner",
+				"time": "2026-07-21T13:00:00Z",
+				"source": "ai-research",
+				"confidence": "low",
+				"evidence": ["https://example.no/b"],
+				"norwegian": true,
+				"norwegianPlayers": [{ "name": "Ingrid Landmark Tandrevold" }],
+				"streaming": []
+			},
+			{
+				"id": "plain-empty",
+				"sport": "golf",
+				"title": "Local Open — round 1",
+				"time": "2026-07-20T06:00:00Z",
+				"streaming": []
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["ai-low-norsk", "ai-low-tennis", "plain-empty"],
+		"mustWatch": [],
+		"mustSee": ["ai-low-norsk"]
+	}
+}

--- a/tests/fixtures/feed-vectors/13-edge-sportscope-and-substring.json
+++ b/tests/fixtures/feed-vectors/13-edge-sportscope-and-substring.json
@@ -1,0 +1,60 @@
+{
+	"name": "Divergence showcase: unscoped relevance vs scoped bell; substring accent vs word-boundary bell",
+	"description": "Two documented behavioural mismatches between the server and client predicates (see DIVERGENCES.md), pinned as today's actual behaviour — NOT fixed here. (1) The server relevance filter is NOT sport-scoped, so a football club name in a tennis title ('Barcelona Open') pulls the event onto the board, while the sport-scoped bell correctly ignores it and the accent never reads the title for teams. (2) The client accent uses naive lowercase substring matching, so 'Brooklyn FC' matches the tracked club 'Lyn' and gets the accent, while the word-boundary server bell does not. A real Vålerenga–Lyn derby is the control where all sides agree.",
+	"input": {
+		"now": "2026-07-13T12:00:00Z",
+		"interests": {
+			"followBroadly": ["football", "golf", "f1", "cycling", "chess", "esports", "biathlon", "cross-country", "alpine"],
+			"alwaysTrack": {
+				"athletes": [
+					{ "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf" },
+					{ "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis" },
+					{ "name": "Magnus Carlsen", "aliases": ["Carlsen"], "sport": "chess" }
+				],
+				"teams": [
+					{ "name": "Barcelona", "aliases": ["FC Barcelona", "Barça", "Barca"], "sport": "football" },
+					{ "name": "Lyn", "aliases": ["Lyn Oslo"], "sport": "football" },
+					{ "name": "100 Thieves", "aliases": ["100T"], "sport": "esports" }
+				],
+				"tournaments": [
+					{ "name": "Premier League", "aliases": ["EPL"], "sport": "football" },
+					{ "name": "F1 World Championship", "aliases": ["Formula 1", "F1", "Formel 1"], "sport": "f1", "notify": true },
+					{ "name": "Tour de France", "aliases": ["TdF"], "sport": "cycling", "notify": true }
+				]
+			},
+			"notify": { "leadMinutes": 30 }
+		},
+		"events": [
+			{
+				"id": "barca-open-tennis",
+				"sport": "tennis",
+				"title": "Barcelona Open — final",
+				"tournament": "ATP Barcelona",
+				"time": "2026-07-22T12:00:00Z"
+			},
+			{
+				"id": "brooklyn",
+				"sport": "football",
+				"title": "Brooklyn vs New York",
+				"tournament": "Summer Friendly",
+				"homeTeam": "Brooklyn FC",
+				"awayTeam": "New York RB",
+				"time": "2026-07-22T23:00:00Z"
+			},
+			{
+				"id": "valerenga-lyn",
+				"sport": "football",
+				"title": "Vålerenga – Lyn",
+				"tournament": "OBOS-ligaen",
+				"homeTeam": "Vålerenga",
+				"awayTeam": "Lyn",
+				"time": "2026-07-23T17:00:00Z"
+			}
+		]
+	},
+	"expected": {
+		"relevant": ["barca-open-tennis", "brooklyn", "valerenga-lyn"],
+		"mustWatch": ["valerenga-lyn"],
+		"mustSee": ["brooklyn", "valerenga-lyn"]
+	}
+}

--- a/tests/fixtures/feed-vectors/DIVERGENCES.md
+++ b/tests/fixtures/feed-vectors/DIVERGENCES.md
@@ -1,0 +1,134 @@
+# Divergences (WP-06)
+
+WP-06 froze the personalisation semantics as golden vectors and ran them against
+**both** implementations wherever the logic exists on both sides. This file
+records where the server (`scripts/build-events.js` + `scripts/lib/helpers.js`)
+and the client (`docs/js/dashboard.js` + `docs/js/shared-constants.js`) behave
+differently.
+
+**Binding non-goal:** WP-06 does **not** fix any of these — the vectors pin
+*today's actual behaviour per side*, and the JS test asserts each side against its
+own expected set. Consolidation is separate work; when the Swift `FeedCompiler`
+(WP-13) is written it should reproduce these behaviours, not silently "correct"
+them.
+
+---
+
+## 0. Structural finding: there is no single shared "special?" predicate
+
+The premise "the personalisation logic is duplicated between server and client"
+is only half true. There is **no one predicate** computed on both sides. There
+are **three distinct predicates**, each answering a different product question,
+and they are *intended* to differ:
+
+| Predicate  | Product question         | Where it lives                         | Inputs it keys off                                            |
+|------------|--------------------------|----------------------------------------|---------------------------------------------------------------|
+| `relevant` | In the feed at all?      | server `isRelevant` + 14-day cutoff    | sport, norwegian, isFavorite, importance≥4, ai-research, any tracked entity (unscoped) |
+| `mustWatch`| Reminder bell 🔔?        | server `mustWatchEntity`               | interests notify-set only (teams+athletes, tournaments if notify:true), **sport-scoped** |
+| `mustSee`  | Visual accent?           | client `isMustSee`                     | isFavorite, importance≥4, norwegian+players, national team, tracked team/athlete (substring) |
+
+So `mustWatch != mustSee` is the norm, not a bug. The only genuinely mirrored
+function is `isEventInWindow`. Everything below follows from this.
+
+The single always-both-sides function, `isEventInWindow`, is **byte-identical**
+between `scripts/lib/helpers.js` and `docs/js/shared-constants.js`. Every
+`inWindow` vector runs against both and the test asserts they agree — **no
+divergence found**, and the assertion now guards against a future one-sided edit.
+
+---
+
+## 1. Relevance is NOT sport-scoped; the bell IS
+
+- Server `isRelevant` calls `matchInterest(hay, trackedEntities)` **without** a
+  `sport` option (`build-events.js:420`).
+- Server `mustWatchEntity` calls `matchInterest(hay, notifyEntities, { sport: event.sport })`
+  (`helpers.js:171`).
+
+**Consequence.** A tracked entity from one sport can pull an unrelated sport's
+event onto the board, while the (scoped) bell correctly ignores it.
+
+**Pinned by** `13-edge-sportscope-and-substring.json`, event `barca-open-tennis`
+(the ATP "Barcelona Open", a tennis event, `sport` not in `followBroadly`):
+
+| Predicate  | Result | Why                                                                 |
+|------------|--------|---------------------------------------------------------------------|
+| `relevant` | `true` | unscoped match: the football club "Barcelona" is found in the title |
+| `mustWatch`| `false`| scoped: Barcelona is `sport:"football"`, event is tennis → skipped  |
+| `mustSee`  | `false`| the accent only checks tracked *teams* against homeTeam/awayTeam (a tennis event has neither), never the title |
+
+Net effect: the event appears on the board with **neither** a bell nor an accent
+— a mild false-positive in relevance that the other two predicates do not share.
+
+---
+
+## 2. The accent uses naive substring; the bell uses word boundaries
+
+- Client `isMustSee` matches tracked teams with
+  `homeTeam.toLowerCase().includes(term.toLowerCase())` and tracked athletes with
+  `haystack.toLowerCase().includes(term.toLowerCase())` (`dashboard.js:188,191`).
+  Plain substring, plain lowercase — **no** word boundaries, **no** diacritic
+  folding.
+- Server matching (`containsName`, used by both relevance and the bell) is
+  **word-boundary** and **diacritic-insensitive** (`helpers.js:81`).
+
+**Consequence.** The accent fires on substrings the server rejects.
+
+**Pinned by** `13-edge-sportscope-and-substring.json`, event `brooklyn`
+(homeTeam `"Brooklyn FC"`):
+
+| Predicate  | Result | Why                                                                        |
+|------------|--------|----------------------------------------------------------------------------|
+| `mustSee`  | `true` | `"brooklyn fc".includes("lyn")` → matches the tracked club **Lyn**         |
+| `mustWatch`| `false`| word-boundary `containsName("Brooklyn FC", "Lyn")` → no boundary → no match|
+
+The control event `valerenga-lyn` (a real Vålerenga–Lyn derby) matches on **both**
+sides — so the divergence is specifically the substring false-positive, not Lyn
+matching in general. (The reverse risk — the server's diacritic folding matching
+`"Barça"`≡`"Barca"` where the client's plain lowercase would not — is not
+currently exercised by a vector because the aliases list already carries both
+spellings; noted here for the port.)
+
+---
+
+## 3. `mustWatch` (bell) and `mustSee` (accent) legitimately diverge
+
+Direct fallout of finding §0. Representative, pinned cases:
+
+| Case                                                   | `mustWatch` | `mustSee` | Vector                                   |
+|--------------------------------------------------------|-------------|-----------|------------------------------------------|
+| Favorite / importance≥4 event, no tracked entity       | `false`     | `true`    | `04-mustsee-favorite-importance.json`    |
+| Norway men's national team (not in interests notify)   | `false`     | `true`    | `06-mustsee-tracked-team-and-national.json` (`norway`) |
+| Golf lens — a non-tracked Norwegian in the field       | `false`     | `true`    | `05-mustsee-golf-lens.json` (`lens`)     |
+| F1 session (F1 is a notify tournament)                 | `true`      | `false`   | `08-mustwatch-tournament-notify-gating.json` (`f1race`,`f1quali`) |
+| Tour de France stage (TdF is a notify tournament)      | `true`      | `false`   | `08-…` (`tdfstage`)                      |
+
+Reading: **the bell follows interests.json; the accent follows the goal's
+"someone/something you clearly care about is on screen" heuristic.** They are not
+meant to be equal. The Swift port must keep them as two functions.
+
+---
+
+## 4. `confidence` does not gate feed inclusion
+
+`source == "ai-research"` makes an event `relevant` regardless of `confidence`
+(`build-events.js:416`) — a `confidence: "low"` research event in an
+otherwise-unfollowed sport still reaches the board.
+
+**Pinned by** `12-edge-airesearch-lowconf-empty-streaming.json` (`ai-low-tennis`:
+low-confidence, tennis, no tracked player → `relevant: true`).
+
+This is not a server/client divergence, but it is a semantic the port must not
+"tighten" by reflex: the WP-15 NotificationPlanner may withhold notifications for
+`confidence: low` without a fresh re-fetch, but the **feed** does not filter on
+confidence today.
+
+---
+
+## Summary for the porter
+
+- Implement **three** predicates, not one. Keep the bell sport-scoped +
+  word-boundary; keep relevance unscoped; keep the accent's naive-substring
+  behaviour (or change it *deliberately*, with a vector update + note).
+- `isEventInWindow` is the shared truth — port it once, use it everywhere.
+- Reproduce §1, §2, §4 exactly to pass WP-13; if any is later judged a real bug,
+  fix it in one place and update the affected vector in the same change.

--- a/tests/fixtures/feed-vectors/README.md
+++ b/tests/fixtures/feed-vectors/README.md
@@ -1,0 +1,230 @@
+# Golden feed vectors (WP-06)
+
+These fixtures freeze the **personalisation semantics** of Zenji — which events
+reach the feed, which get the reminder bell, which get the visual accent, how the
+agenda time window behaves, and how stage races collapse — as pure declarative
+JSON. They are the contract the future Swift `FeedCompiler` (WP-13) must satisfy
+**bit-for-bit**: `f(superset-events, interests) → expected feed`.
+
+Today the same logic is duplicated between the Node server (`scripts/build-events.js`
++ `scripts/lib/helpers.js`) and the browser client (`docs/js/dashboard.js` +
+`docs/js/shared-constants.js`). The JS test `tests/feed-vectors.test.js` replays
+every vector against those real implementations. A Swift `FeedCompiler` should
+decode the very same files and assert the very same expectations from XCTest.
+
+> **These vectors pin _current_ behaviour, not ideal behaviour.** Where the server
+> and client disagree, the disagreement is recorded in
+> [`DIVERGENCES.md`](./DIVERGENCES.md) and the vector encodes what each side does
+> today. Do not "fix" a divergence by editing production code as part of a port —
+> reproduce it, or change the vector deliberately with a note.
+
+## Layout
+
+```
+tests/fixtures/feed-vectors/
+  NN-slug.json      one vector = one self-contained { input, expected } case
+  README.md         this file
+  DIVERGENCES.md    server/client behavioural mismatches, pinned
+```
+
+Each `NN-slug.json` is standalone: it embeds its own `interests` config and event
+superset, so a single file fully determines one test case. There are no shared
+references to resolve — decode one file, run the checks in it.
+
+## Fixture schema
+
+```jsonc
+{
+  "name": "short human title",
+  "description": "what this vector proves + any quirk it pins",
+  "input": {
+    "now": "2026-07-13T12:00:00Z",      // reference clock (ISO-8601 UTC).
+                                        // Drives the 14-day relevance cutoff and
+                                        // series 'next stage' selection. REQUIRED
+                                        // when 'relevant' or 'series' is expected.
+    "window": {                         // OPTIONAL. Only present with 'inWindow'.
+      "start": "2026-07-16T00:00:00Z",  // agenda window [start, end)
+      "end":   "2026-07-20T00:00:00Z"
+    },
+    "interests": { /* see below */ },
+    "events":   [ /* superset of event objects, each with a unique "id" */ ]
+  },
+  "expected": {
+    "relevant":  ["id", ...],           // server feed inclusion (see §relevant)
+    "mustWatch": ["id", ...],           // server reminder bell (see §mustWatch)
+    "mustSee":   ["id", ...],           // client visual accent (see §mustSee)
+    "inWindow":  ["id", ...],           // isEventInWindow == true (server & client)
+    "series":    [ /* see §series */ ]  // client collapseSeries output
+  }
+}
+```
+
+Only the `expected` keys a vector cares about are present; a runner asserts each
+one it finds and skips the rest. Every `id` in an expectation set is one of the
+`input.events[].id`. **The order of ids in an expectation set is not significant**
+— compare as an unordered set (sort before comparing).
+
+### `input.events`
+
+Each event mirrors an entry in `docs/data/events.json` (schema:
+`scripts/config/events.schema.json`). The fixtures only populate the fields each
+predicate reads; unlisted fields are absent (treat as `nil`/default). The `id` is
+a stable, fixture-local handle used purely to name events in the expectation sets
+— it is not computed from anything and need not be a real WP-02 hash.
+
+Fields the predicates read: `sport`, `title`, `tournament`, `time`, `endTime`,
+`homeTeam`, `awayTeam`, `norwegian` (bool), `norwegianPlayers` (array of
+`{name}`), `participants` (array of string), `isFavorite` (bool), `importance`
+(1–5), `source` ("ai-research"), `confidence`, `status`.
+
+### `input.interests`
+
+A trimmed copy of `scripts/config/interests.json` — the same canonical config is
+reused across every vector so results are comparable:
+
+```jsonc
+{
+  "followBroadly": ["football","golf","f1","cycling","chess","esports",
+                    "biathlon","cross-country","alpine"],   // sports kept wholesale
+  "alwaysTrack": {
+    "athletes":    [{ "name","aliases":[...],"sport" }, ...],
+    "teams":       [{ "name","aliases":[...],"sport" }, ...],
+    "tournaments": [{ "name","aliases":[...],"sport","notify"? }, ...]
+  },
+  "notify": { "leadMinutes": 30 }
+}
+```
+
+Note `tennis` is deliberately **absent** from `followBroadly`, so tennis events
+only reach the feed via a tracked entity / Norwegian / favorite / importance —
+this is what makes the "Casper Ruud pulls a tennis event onto the board" and the
+"Barcelona Open false-positive" cases observable.
+
+## The five predicates (exact semantics + source of truth)
+
+| Predicate  | Question                                   | Server (Node)                                              | Client (browser)                                   |
+|------------|--------------------------------------------|------------------------------------------------------------|----------------------------------------------------|
+| `relevant` | Is the event in the feed at all?           | `build-events.js` `isRelevant` + 14-day cutoff (405–432)   | — (client renders whatever `events.json` contains) |
+| `mustWatch`| Does it get a reminder bell 🔔?            | `helpers.js` `mustWatchEntity` → `e.mustWatch`             | reads precomputed `e.mustWatch`                    |
+| `mustSee`  | Does it get the quiet visual accent?       | —                                                          | `dashboard.js` `isMustSee` (176–192)               |
+| `inWindow` | Does it overlap an agenda window?          | `helpers.js` `isEventInWindow`                             | `shared-constants.js` `isEventInWindow` (identical)|
+| `series`   | How do stage races collapse?               | —                                                          | `dashboard.js` `collapseSeries` (375–405)          |
+
+### §relevant — feed inclusion (server)
+
+Kept iff **both**:
+
+1. **Retention cutoff.** With `t = endTime ?? time`, keep only if
+   `t >= now - 14 days` (multi-day events survive on their *end*, not their start).
+2. **isRelevant.** Keep if any of:
+   - `sport ∈ followBroadly`, OR
+   - `norwegian == true`, OR `isFavorite == true`, OR `importance >= 4`, OR
+     `source == "ai-research"`, OR
+   - a tracked entity (teams ∪ athletes ∪ tournaments) matches the haystack
+     `title + tournament + homeTeam + awayTeam + norwegianPlayers[].name + participants`.
+     **This match is NOT sport-scoped** (see DIVERGENCES.md §1).
+
+Matching uses word-boundary, diacritic-insensitive containment (`helpers.js`
+`containsName`): `"Barça"` ≡ `"Barca"`; `"Lyn"` matches `"Lyn Oslo"` but not
+`"Brooklyn"`.
+
+### §mustWatch — the reminder bell (server)
+
+`mustWatchEntity(event, interests) != null`. The candidate entities are the
+**notify set**: every tracked team and athlete (bell by default) plus tournaments
+with `notify: true`. Matching is over the same haystack as relevance BUT **is
+sport-scoped**: a `sport:"football"` entity cannot match a non-football event.
+Uses `containsName` (word boundary + diacritics). Keyed strictly off
+`interests.json` — never off an event's own `isFavorite`/`importance`, so what
+interrupts the user stays user-governed.
+
+### §mustSee — the visual accent (client)
+
+`isMustSee(event)`, in order:
+
+1. `isSeries` → `false` (collapsed rows are never accented).
+2. `isFavorite`, OR `importance >= 4`, OR (`norwegian` AND `norwegianPlayers`
+   non-empty) → `true`. *(The last is the "golf lens": a Norwegian in the field.)*
+3. `homeTeam`/`awayTeam` matches `/\bnorway\b|\bnorge\b/` → `true`.
+4. `homeTeam`/`awayTeam` **contains** (naive lowercase substring) any tracked-team
+   term → `true`. *(Substring, not word-boundary — see DIVERGENCES.md §2.)*
+5. `title + norwegianPlayers[].name` **contains** any tracked-athlete term →
+   `true`. *(Substring; reads title + players, NOT participants, NOT tournament.)*
+
+Note the accent uses plain `toLowerCase()` + `includes()` (no diacritic
+stripping, no word boundaries) — deliberately different from the server matcher.
+
+### §inWindow — the agenda time window (server AND client, identical)
+
+`isEventInWindow(event, start, end)`: with `s = time`, `e = endTime ?? time`, the
+event overlaps `[start, end)` iff `s < end && e >= start`. No `time` → `false`.
+This is the one function implemented on both sides; the JS test asserts the two
+implementations agree on every vector.
+
+### §series — stage-race collapse (client)
+
+`collapseSeries(events, now)` groups events whose title matches
+`/\betappe\b|\bstage\s*\d/i` by `sport + "||" + tournament`. A group of **4 or
+more** collapses into one synthetic series row; fewer than 4 pass through as
+individual rows. Non-stage events always pass through. The synthetic row's
+"next stage" is the first stage whose `endTime ?? time >= now`, else the last.
+
+Expected `series` entries describe the collapsed output, order-independent:
+
+```jsonc
+{ "isSeries": false, "id": "gc" }                       // a passthrough event
+{ "isSeries": true,                                     // a collapsed series
+  "id": "series|<sport>|<tournament>",
+  "tournament": "<tournament>",
+  "stageCount": 6,
+  "nextStageId": "st4" }                                // id of the chosen next stage
+```
+
+## Running the reference (JS)
+
+```
+npm test -- feed-vectors     # just these vectors
+npm test                     # whole suite
+```
+
+`tests/feed-vectors.test.js` is the executable reference: it reconstructs
+`serverRelevant` from the exported `matchInterest` (mirroring build-events.js),
+calls the real `mustWatchEntity` and `isEventInWindow`, and drives the real client
+`isMustSee`/`collapseSeries` in a `vm` sandbox.
+
+## Replaying from XCTest (WP-13)
+
+The files are plain JSON with no JS, so decode them straight into Swift and assert.
+Sketch:
+
+```swift
+struct Vector: Decodable {
+  struct Window: Decodable { let start: String; let end: String }
+  struct Input: Decodable {
+    let now: String?
+    let window: Window?
+    let interests: Interests
+    let events: [Event]        // your Codable Event (WP-11); unknown keys ignored
+  }
+  struct Expected: Decodable {
+    let relevant, mustWatch, mustSee, inWindow: [String]?
+    let series: [SeriesItem]?
+  }
+  let name, description: String
+  let input: Input
+  let expected: Expected
+}
+
+// Load every tests/fixtures/feed-vectors/*.json (add the folder as a test
+// resource / bundle reference), then for each vector:
+//   • relevant  → FeedCompiler.isRelevant + 14-day cutoff, ids sorted == expected
+//   • mustWatch → FeedCompiler.mustWatchEntity != nil
+//   • mustSee   → FeedCompiler.isMustSee
+//   • inWindow  → FeedCompiler.isEventInWindow(event, start, end)
+//   • series    → FeedCompiler.collapseSeries(events, now) mapped to {isSeries,id,…}
+// Compare id sets unordered (Set); compare series entries unordered by id.
+```
+
+The Swift port passes WP-13 when it reproduces **every** expectation in **every**
+file — including the divergent cases in `DIVERGENCES.md` (reproduce today's
+behaviour; changing it is a separate, deliberate decision).


### PR DESCRIPTION
## Hva

Fryser personaliserings-semantikken til Zenji som **13 deklarative JSON-vektorer** i `tests/fixtures/feed-vectors/`, slik at den fremtidige Swift-porten (WP-13 `FeedCompiler`) kan bevises bit-ekvivalent: `f(superset-events, interesse-config) → forventet feed`. Rent semantikk-arbeid — presisjon over fart.

## Dekning (fra WP-06-akseptet)

- **Multi-dag `isEventInWindow`** — golf/etapperitt som spenner over vinduskanten (`01`, `02`)
- **14-dagers retention-cutoff** — endTime-basert, ikke start (`03`)
- **Must-see-reglene** — favoritt / importance≥4 / norsk+norwegianPlayers (golf-linsen) / tracked lag / landslag / tracked utøver (`04`–`07`)
- **Must-watch notify-gating** — F1/TdF (notify:true) ringer bjella; Premier League (fulgt, men ikke notify) gjør det ikke (`08`)
- **Serie-kollaps** — ≥4 etapper → én rad; <4 beholdes som egne rader (`09`, `10`)
- **Kant-tilfeller** — cancelled/postponed, tom streaming, low-confidence ai-research, event uten endTime (`11`–`13`)

## Format

Hver vektor er selvstendig, ren JSON (embedded `interests` + event-superset + forventede id-sett) — ingen JS i fixtures, så de samme filene kan spilles av fra XCTest. `tests/fixtures/feed-vectors/README.md` beskriver format + semantikk for Swift-utvikleren (felt, de fem prediktatene med kildereferanser, Codable-skisse).

## Kjøring mot BEGGE implementasjoner

`tests/feed-vectors.test.js` kjører hver vektor mot de EKTE implementasjonene der de finnes:
- `isEventInWindow` → server (`helpers.js`) **og** klient (`shared-constants.js`), med en paritets-assertion (den ene ekte begge-sider-funksjonen)
- `mustWatchEntity` (bjelle) → server-helper
- `isMustSee` (aksent) + `collapseSeries` → klient i vm-sandbox
- `relevant` (feed-inklusjon) → trofast speiling av `build-events.js` (`isRelevant` + cutoff) bygget på eksportert `matchInterest`

## Ikke-mål (bindende): ingen produksjonskode endret

Avvik mellom server og klient er **dokumentert, ikke fikset** — pinnet per side i `DIVERGENCES.md`. Funn:
1. Relevans er IKKE sport-scopet mens bjella ER det → et fotball-klubbnavn drar et tennis-event ("Barcelona Open") inn på tavla uten bjelle/aksent.
2. Klient-aksenten bruker naiv substring mens server-bjella bruker ordgrense → "Brooklyn FC" trigger tracked-klubben "Lyn" som aksent, men ikke bjelle.
3. `mustWatch` (bjelle) og `mustSee` (aksent) er tre ulike prediktater, ikke ett — de avviker med hensikt.
4. `confidence` gater ikke feed-inklusjon i dag.

## Port

Endret KUN `tests/` + fixtures + WP-06-statusraden i `PLAN.md`. Rører ikke workflows/hooks/interests.json.

`npm test` grønt: 320 tester (+35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)