### PR TITLE
WP-13: FeedCompiler — består de gylne vektorene

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -42,7 +42,7 @@ mennesket, aldri av en agent.
 | WP-10 | iOS-scaffold | 0B | – | ✅ merget (#237) + bygg bevist (Xcode 26.6, iOS 26.5-SDK) |
 | WP-11 | Codable-modeller | 0B | WP-01, WP-10 | ✅ merget (#241) — TEST SUCCEEDED 11/11 |
 | WP-12 | SyncClient | 0B | WP-03, WP-11 | ✅ merget (#242) — 37/37 tester |
-| WP-13 | FeedCompiler (Swift) | 0B | WP-06, WP-11 | todo |
+| WP-13 | FeedCompiler (Swift) | 0B | WP-06, WP-11 | PR åpnet |
 | WP-14 | Agenda-UI + widget | 0B | WP-13 | todo |
 | WP-15 | NotificationPlanner | 0B | WP-13 | todo |
 | WP-16 | FM-lekegrind (samtale→profil) | 0B | WP-10 | todo |

--- a/ios/README.md
+++ b/ios/README.md
@@ -357,16 +357,93 @@ the frozen fixture doesn't represent (a changed file, a corrupt download),
 manifest and mutates exactly one entry, computing its sha256 with the same
 `Data.sha256Hex` `SyncClient` itself uses.
 
+## Feed compiler (WP-13)
+
+`Zenji/Feed/` is the Swift port of the personalisation semantics — **which**
+events reach the feed, which get the reminder bell, which get the visual
+accent, how the agenda time window behaves, and how stage races collapse. Its
+one hard acceptance criterion: it reproduces **every** golden feed-vector
+(`tests/fixtures/feed-vectors/`, WP-06) **bit-for-bit**, including the four
+pinned server/client divergences (`DIVERGENCES.md`) — those are *reproduced*,
+never "fixed".
+
+### There is no single "special?" predicate — there are five
+
+Each answers a different product question and is ported faithful to the side
+that owns it (the web duplicates this logic across server and client, and the
+two are *intended* to differ):
+
+| Predicate | Question | Ported from | Semantics the port preserves |
+|---|---|---|---|
+| `isRelevant` | In the feed at all? | **server** `build-events.js` `isRelevant` + 14-day cutoff | `sport ∈ followBroadly` OR norwegian/isFavorite/importance≥4/ai-research OR a tracked entity matches — the entity match is **NOT sport-scoped**. Cutoff keys off `endTime ?? time` (multi-day events survive on their end); boundary inclusive. |
+| `mustWatch` | Reminder bell 🔔? | **server** `helpers.js` `mustWatchEntity` | Keyed **only** off `interests.json` notify-entities (teams+athletes by default, tournaments only when `notify:true`); **sport-scoped**; word-boundary + diacritic-folding matching. |
+| `isMustSee` | Quiet visual accent? | **client** `dashboard.js` `isMustSee` | isFavorite/importance≥4/(norwegian+players), national-team regex, then **naive lowercase-substring** team/athlete matching — the pinned substring behaviour (`"Brooklyn".contains("lyn")` fires) is kept deliberately. Reads title + player names, **not** participants/tournament. |
+| `isEventInWindow` | Overlaps the agenda window? | **server & client, byte-identical** | `s = time`, `e = endTime ?? time`; overlaps `[start,end)` iff `s < end && e >= start`; no time → false. |
+| `collapseSeries` | How do stage races fold? | **client** `dashboard.js` `collapseSeries` | Groups titles matching `/\betappe\b|\bstage\s*\d/i` by `sport||tournament`; **4 or more** fold into one synthetic row; next stage = first with `endTime ?? time >= now`, else the last. |
+
+The four pinned divergences the port reproduces: relevance is unscoped while the
+bell is sport-scoped (a football "Barcelona" pulls a tennis "Barcelona Open"
+onto the board but rings no bell); the accent's naive substring vs the bell's
+word boundary (`"Brooklyn FC"` gets the accent, not the bell); bell ≠ accent in
+general (favorite/national-team/golf-lens accent without a bell; F1/TdF bell
+without an accent); and `confidence` does **not** gate feed inclusion.
+
+### The dangerous part: text matching
+
+`TextMatch.swift` ports the server matchers as pure functions:
+`normalize` (NFD-decompose → strip Unicode Marks `\p{M}` → lowercase, so
+"Barça" ≡ "Barca", "Vålerenga" → "valerenga") and `containsName`
+(word-boundary, accent-insensitive containment via
+`(?:^|[^\p{L}\p{N}])name(?:[^\p{L}\p{N}]|$)`). These are the exact JS
+semantics from `scripts/lib/helpers.js`; `FeedCompilerUnitTests` guards them
+with named minimal cases. The client accent's **naive** `lowercased()` +
+substring `contains` deliberately does **not** route through this file — it
+lives inline in `FeedCompiler.isMustSee` because its lack of folding/boundaries
+is pinned behaviour.
+
+### Types
+
+- `FeedEvent.swift` — the small pure-data input the predicates read (only the
+  fields they use). Separate from WP-11's `Event` for one concrete reason:
+  `Event.time` is a **non-optional** `Date`, but the vectors include a pinned
+  `"time": null` case; `FeedEvent.time` is `Date?` so that decodes and the
+  predicates return the same `false` the JS does. `init(from event: Event)`
+  bridges the real cached `[Event]` (from `DataStore`) into the compiler for
+  WP-14.
+- `Interests.swift` — the personalisation config the vectors embed (a Swift
+  mirror of the fields of `scripts/config/interests.json` the predicates read).
+- `FeedCompiler.swift` — the five predicates + the `compile(events:interests:
+  now:)` facade (relevance filter → bell/accent annotation → series collapse →
+  Europe/Oslo day grouping). The day grouping is **not** vector-covered (kept
+  simple, unit-tested separately in `FeedCompilerUnitTests`).
+
+### Running the vectors
+
+`FeedVectorTests` decodes the **same** files the JS reference
+(`tests/feed-vectors.test.js`) replays — the repo-root
+`tests/fixtures/feed-vectors` folder is referenced directly from
+`project.yml` as a bundled folder reference (`buildPhase: resources`,
+`type: folder`, an out-of-`ios/` path XcodeGen resolves relative to
+`project.yml`), never copied, so the two runners can never drift. At runtime
+the tests enumerate the bundled `feed-vectors/*.json`, decode each into the
+`FeedEvent`/`Interests` models, and assert each declared expectation as an
+unordered id set. **The fixtures are frozen** — a failing vector is left red
+and escalated, never "fixed" by editing the fixture.
+
+```
+cd ios && xcodegen generate
+xcodebuild test -project Zenji.xcodeproj -scheme Zenji \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+# 49 tests: 37 WP-10/11/12 baseline + 12 WP-13
+#   (6 FeedVectorTests over all 13 vectors + 6 FeedCompilerUnitTests)
+```
+
 ## Architecture (what plugs in next)
 
-WP-10 was the shell, WP-11 added the Codable models, WP-12 (above) added
-sync + cache + background refresh. The pieces below are still separate work
-packages — **not implemented here**:
+WP-10 was the shell, WP-11 added the Codable models, WP-12 added sync + cache +
+background refresh, WP-13 (above) added the FeedCompiler. The pieces below are
+still separate work packages — **not implemented here**:
 
-- **FeedCompiler (WP-13)** — the Swift port of the server's personalization
-  logic (interest match → weighting → buckets → day grouping), proven against
-  the golden feed vectors from WP-06, consuming `DataStore.loadEvents()` /
-  `.loadEntities()`.
 - **NotificationPlanner (WP-15)** — diffs event IDs (WP-02) after each sync and
   (re)schedules local notifications from the must-see rules.
 - **Agenda UI + widget (WP-14)** — replaces `ContentView`'s placeholder row

--- a/ios/Zenji/Feed/FeedCompiler.swift
+++ b/ios/Zenji/Feed/FeedCompiler.swift
@@ -1,0 +1,356 @@
+//
+//  FeedCompiler.swift
+//  Zenji
+//
+//  WP-13 — the Swift port of the personalisation semantics frozen by the
+//  golden feed-vectors (tests/fixtures/feed-vectors/). Its sole hard
+//  acceptance criterion is: reproduce EVERY expectation in EVERY vector
+//  bit-for-bit, including the four pinned server/client divergences in
+//  DIVERGENCES.md (they are reproduced here, never "fixed").
+//
+//  There is NO single "special?" predicate — there are FIVE, each answering a
+//  different product question and keyed off different inputs, faithful to the
+//  side that owns it (README §"The five predicates"):
+//
+//    • isRelevant   — SERVER (scripts/build-events.js + helpers.js). Feed
+//      inclusion. NOT sport-scoped. + a 14-day retention cutoff on endTime.
+//    • mustWatch    — SERVER (helpers.js mustWatchEntity). The reminder bell.
+//      Keyed ONLY off interests.json notify-entities; sport-SCOPED;
+//      word-boundary matching.
+//    • isMustSee    — CLIENT (docs/js/dashboard.js). The quiet visual accent.
+//      NAIVE lowercase-substring team/athlete matching (pinned, DIVERGENCES §2).
+//    • isEventInWindow — SERVER & CLIENT, byte-identical. Agenda time window.
+//    • collapseSeries — CLIENT (dashboard.js). Stage-race folding.
+//
+//  The facade `compile(events:interests:now:)` chains the server-side stages
+//  (relevance filter → bell/accent annotation → series collapse → day
+//  grouping) for the app to consume; the day grouping is NOT vector-covered
+//  and is unit-tested separately.
+//
+
+import Foundation
+
+enum FeedCompiler {
+
+    // MARK: - Constants (mirror build-events.js:469 / helpers.js)
+
+    /// Server default when `interests.followBroadly` is ABSENT (nil). An
+    /// explicit `[]` in the config is honoured as-is — see Interests.followBroadly.
+    static let defaultFollowBroadly: [String] = [
+        "football", "golf", "f1", "cycling", "chess", "esports",
+        "biathlon", "cross-country", "alpine", "nordic", "ski jumping",
+    ]
+
+    private static let msPerDay: TimeInterval = 86_400 // seconds
+    static let osloTimeZone = TimeZone(identifier: "Europe/Oslo")!
+
+    // MARK: - Shared server matcher (helpers.js matchInterest)
+
+    /// Port of server `matchInterest` (helpers.js:127): the first entity whose
+    /// name/alias word-boundary-matches `haystack`, else nil. When `sport` is
+    /// supplied AND an entity carries its own `sport`, a mismatch skips it
+    /// (the bell's sport-scoping); an entity with no sport, or a nil `sport`
+    /// argument, matches freely.
+    static func matchInterest(_ haystack: String, _ entities: [Interests.Entity], sport: String? = nil) -> Interests.Entity? {
+        for entity in entities {
+            if let sport = sport, let entitySport = entity.sport,
+               TextMatch.normalize(entitySport) != TextMatch.normalize(sport) {
+                continue
+            }
+            if entity.terms.contains(where: { TextMatch.containsName(haystack, $0) }) {
+                return entity
+            }
+        }
+        return nil
+    }
+
+    /// The haystack the server relevance/bell matchers scan: title +
+    /// tournament + home/away teams + Norwegian players' names + participants'
+    /// names, space-joined (helpers.js:163 / build-events.js:480). Nil fields
+    /// contribute "" exactly as JS `[...].join(" ")` coerces undefined.
+    static func serverHaystack(_ e: FeedEvent) -> String {
+        var parts: [String] = [e.title, e.tournament ?? "", e.homeTeam ?? "", e.awayTeam ?? ""]
+        parts.append(contentsOf: e.norwegianPlayers.map { $0.name })
+        parts.append(contentsOf: e.participants.map { $0.name })
+        return parts.joined(separator: " ")
+    }
+
+    // MARK: - §relevant — feed inclusion (SERVER, build-events.js:477 + cutoff)
+
+    /// `isRelevant` on its own (no time gate) — build-events.js:477-484.
+    /// NOTE: the tracked-entity match is deliberately NOT sport-scoped
+    /// (DIVERGENCES §1), so e.g. the football club "Barcelona" can pull a
+    /// tennis "Barcelona Open" onto the board.
+    static func isRelevantIgnoringTime(_ e: FeedEvent, interests: Interests) -> Bool {
+        let follow = Set((interests.followBroadly ?? defaultFollowBroadly).map { $0.lowercased() })
+        if follow.contains(e.sport.lowercased()) { return true }
+        if e.norwegian || e.isFavorite || (e.importance ?? 0) >= 4 || e.source == "ai-research" { return true }
+        let tracked = interests.alwaysTrack.teams
+            + interests.alwaysTrack.athletes
+            + interests.alwaysTrack.tournaments
+        return matchInterest(serverHaystack(e), tracked) != nil // unscoped
+    }
+
+    /// Full server feed inclusion = the 14-day retention cutoff AND
+    /// `isRelevant`. With `t = endTime ?? time`, keep only if
+    /// `t >= now - 14 days` (multi-day events survive on their END). No time →
+    /// never relevant. Boundary is inclusive (strict `<` drops), matching
+    /// build-events.js:487-494.
+    static func isRelevant(_ e: FeedEvent, interests: Interests, now: Date) -> Bool {
+        guard let time = e.time else { return false }
+        let relevantTime = e.endTime ?? time
+        let cutoff = now.addingTimeInterval(-14 * msPerDay)
+        if relevantTime < cutoff { return false }
+        return isRelevantIgnoringTime(e, interests: interests)
+    }
+
+    // MARK: - §mustWatch — the reminder bell (SERVER, helpers.js)
+
+    /// Port of `notifyEntities` (helpers.js:146): the entities that arm the
+    /// bell. Teams & athletes default to notify:true; tournaments default to
+    /// notify:false — only entities that end up notify:true are candidates.
+    static func notifyEntities(_ interests: Interests) -> [Interests.Entity] {
+        var out: [Interests.Entity] = []
+        for e in interests.alwaysTrack.teams + interests.alwaysTrack.athletes {
+            if e.notify ?? true { out.append(e) }           // defaultNotify: true
+        }
+        for e in interests.alwaysTrack.tournaments {
+            if e.notify ?? false { out.append(e) }          // defaultNotify: false
+        }
+        return out
+    }
+
+    /// Which notify-entity (if any) makes this event a must-watch — else nil.
+    /// Sport-SCOPED (helpers.js:171), so a football club can't ring the bell on
+    /// a tennis event that merely mentions its name.
+    static func mustWatchEntity(_ e: FeedEvent, interests: Interests) -> Interests.Entity? {
+        matchInterest(serverHaystack(e), notifyEntities(interests), sport: e.sport)
+    }
+
+    static func mustWatch(_ e: FeedEvent, interests: Interests) -> Bool {
+        mustWatchEntity(e, interests: interests) != nil
+    }
+
+    // MARK: - §mustSee — the quiet visual accent (CLIENT, dashboard.js:180)
+
+    private static let norwayNationalRegex = try! NSRegularExpression(
+        pattern: "\\bnorway\\b|\\bnorge\\b", options: [.caseInsensitive]
+    )
+
+    /// Every term a set of tracked entities can be recognised by (name +
+    /// aliases), mirroring the client `trackedTerms` (shared-constants.js:98).
+    private static func clientTerms(_ entities: [Interests.Entity]) -> [String] {
+        entities.flatMap { [$0.name] + $0.aliases }.filter { !$0.isEmpty }
+    }
+
+    /// Port of client `isMustSee` (dashboard.js:180-192). Order matters:
+    ///  1. series rows are never accented (handled by the facade / not applied
+    ///     to raw events here);
+    ///  2. isFavorite OR importance>=4 OR (norwegian AND a Norwegian in the
+    ///     field) — the "golf lens";
+    ///  3. homeTeam/awayTeam matches /\bnorway\b|\bnorge\b/ (national team);
+    ///  4. homeTeam/awayTeam NAIVELY contains a tracked-team term (plain
+    ///     lowercase substring — pinned, DIVERGENCES §2: "Brooklyn" matches
+    ///     "Lyn");
+    ///  5. title + Norwegian players' names NAIVELY contains a tracked-athlete
+    ///     term (substring; reads title + players, NOT participants, NOT
+    ///     tournament).
+    static func isMustSee(_ e: FeedEvent, interests: Interests) -> Bool {
+        if e.isFavorite || (e.importance ?? 0) >= 4 || (e.norwegian && !e.norwegianPlayers.isEmpty) {
+            return true
+        }
+        let teams = [e.homeTeam ?? "", e.awayTeam ?? ""].map { $0.lowercased() }
+        if teams.contains(where: { matchesNorwayNational($0) }) { return true }
+
+        let trackedTeams = clientTerms(interests.alwaysTrack.teams).map { $0.lowercased() }
+        if teams.contains(where: { team in
+            !team.isEmpty && trackedTeams.contains { !$0.isEmpty && team.contains($0) }
+        }) {
+            return true
+        }
+
+        let playerNames = e.norwegianPlayers.map { $0.name }.joined(separator: " ")
+        let hay = "\(e.title) \(playerNames)".lowercased()
+        let trackedAthletes = clientTerms(interests.alwaysTrack.athletes).map { $0.lowercased() }
+        return trackedAthletes.contains { !$0.isEmpty && hay.contains($0) }
+    }
+
+    private static func matchesNorwayNational(_ lowercasedTeam: String) -> Bool {
+        let range = NSRange(lowercasedTeam.startIndex..., in: lowercasedTeam)
+        return norwayNationalRegex.firstMatch(in: lowercasedTeam, options: [], range: range) != nil
+    }
+
+    // MARK: - §inWindow — agenda time window (SERVER & CLIENT, identical)
+
+    /// Port of `isEventInWindow` (helpers.js:52 ≡ shared-constants.js:23). With
+    /// `s = time`, `e = endTime ?? time`, the event overlaps `[start, end)`
+    /// iff `s < end && e >= start`. No time → false.
+    static func isEventInWindow(_ event: FeedEvent, start: Date, end: Date) -> Bool {
+        guard let time = event.time else { return false }
+        let eventEnd = event.endTime ?? time
+        return time < end && eventEnd >= start
+    }
+
+    // MARK: - §series — stage-race collapse (CLIENT, dashboard.js:375)
+
+    /// A synthetic collapsed series row (dashboard.js:391-402).
+    struct SeriesRow: Equatable {
+        var id: String
+        var sport: String
+        var tournament: String?
+        var title: String
+        var time: Date?
+        var endTime: Date?
+        var stages: [FeedEvent]
+        var nextStage: FeedEvent
+    }
+
+    /// One item of the collapse output: either an untouched event or a folded
+    /// series row.
+    enum SeriesItem {
+        case event(FeedEvent)
+        case series(SeriesRow)
+    }
+
+    private static let stageRegex = try! NSRegularExpression(
+        pattern: "\\betappe\\b|\\bstage\\s*\\d", options: [.caseInsensitive]
+    )
+
+    private static func isStageTitle(_ title: String) -> Bool {
+        let range = NSRange(title.startIndex..., in: title)
+        return stageRegex.firstMatch(in: title, options: [], range: range) != nil
+    }
+
+    /// JS template-literal coercion of an optional string (`${x}` → "undefined"
+    /// when x is undefined). Keeps the group key / series id bit-identical even
+    /// in the (vector-untested) nil-tournament case.
+    private static func jsString(_ value: String?) -> String { value ?? "undefined" }
+
+    /// Port of client `collapseSeries` (dashboard.js:375-405). Groups events
+    /// whose title matches /\betappe\b|\bstage\s*\d/i by `sport||tournament`;
+    /// a group of 4 OR MORE folds into one synthetic series row (fewer pass
+    /// through as individual rows). Non-stage events always pass through. The
+    /// series row's "next stage" is the first stage whose `endTime ?? time >=
+    /// now`, else the last.
+    static func collapseSeries(_ events: [FeedEvent], now: Date) -> [SeriesItem] {
+        var out: [SeriesItem] = []
+        var groups: [String] = []             // preserves insertion order (Map semantics)
+        var byKey: [String: [FeedEvent]] = [:]
+
+        for e in events {
+            if isStageTitle(e.title) {
+                let key = "\(e.sport)||\(jsString(e.tournament))"
+                if byKey[key] == nil { groups.append(key) }
+                byKey[key, default: []].append(e)
+            } else {
+                out.append(.event(e))
+            }
+        }
+
+        for key in groups {
+            var stages = byKey[key] ?? []
+            if stages.count < 4 {
+                out.append(contentsOf: stages.map { .event($0) }) // too few — keep as rows
+                continue
+            }
+            // sort by start time ascending (stable; all vector stages distinct)
+            stages.sort { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+            let upcoming = stages.first { ($0.endTime ?? $0.time ?? .distantPast) >= now }
+            let next = upcoming ?? stages[stages.count - 1]
+            let s0 = stages[0]
+            let last = stages[stages.count - 1]
+            let row = SeriesRow(
+                id: "series|\(s0.sport)|\(jsString(s0.tournament))",
+                sport: s0.sport,
+                tournament: s0.tournament,
+                title: s0.tournament ?? "",
+                time: next.time,
+                endTime: last.endTime ?? last.time,
+                stages: stages,
+                nextStage: next
+            )
+            out.append(.series(row))
+        }
+        return out
+    }
+
+    // MARK: - Facade: compile the feed for the app (WP-14 consumes this)
+
+    /// A fully annotated feed, grouped by Europe/Oslo calendar day.
+    struct CompiledFeed: Equatable {
+        struct Day: Equatable {
+            /// "YYYY-MM-DD" in Europe/Oslo.
+            var key: String
+            var items: [Item]
+        }
+        enum Item: Equatable {
+            /// A single event with its bell/accent annotations.
+            case event(FeedEvent, mustWatch: Bool, mustSee: Bool)
+            /// A folded stage-race row (never accented; the web reads no
+            /// precomputed mustWatch on synthetic rows).
+            case series(SeriesRow)
+
+            var time: Date? {
+                switch self {
+                case .event(let e, _, _): return e.time
+                case .series(let s): return s.time
+                }
+            }
+        }
+        var days: [Day]
+    }
+
+    /// relevance filter → bell/accent annotation → series collapse → day
+    /// grouping (Europe/Oslo). The pipeline order matches the WP-13 contract;
+    /// the day grouping is not vector-covered (unit-tested separately).
+    static func compile(events: [FeedEvent], interests: Interests, now: Date) -> CompiledFeed {
+        let relevant = events.filter { isRelevant($0, interests: interests, now: now) }
+        let collapsed = collapseSeries(relevant, now: now)
+
+        let todayKey = osloDayKey(now)
+        var order: [String] = []
+        var byDay: [String: [CompiledFeed.Item]] = [:]
+
+        for item in collapsed {
+            let mapped: CompiledFeed.Item
+            let time: Date?
+            let endTime: Date?
+            switch item {
+            case .event(let e):
+                mapped = .event(e, mustWatch: mustWatch(e, interests: interests), mustSee: isMustSee(e, interests: interests))
+                time = e.time
+                endTime = e.endTime
+            case .series(let s):
+                mapped = .series(s)
+                time = s.time
+                endTime = s.endTime
+            }
+            var key = time.map { osloDayKey($0) } ?? todayKey
+            // Multi-day item that started before today but is still running
+            // belongs under "today", not its past start day (dashboard.js:352).
+            if key < todayKey, let end = endTime, end >= now { key = todayKey }
+            if byDay[key] == nil { order.append(key) }
+            byDay[key, default: []].append(mapped)
+        }
+
+        let days = order.sorted().map { key in
+            CompiledFeed.Day(
+                key: key,
+                items: (byDay[key] ?? []).sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+            )
+        }
+        return CompiledFeed(days: days)
+    }
+
+    // MARK: - Day key (Europe/Oslo, mirrors dashboard.js osloDayKey)
+
+    /// "YYYY-MM-DD" for `date` in Europe/Oslo — the same key
+    /// `toLocaleDateString('en-CA', { timeZone: 'Europe/Oslo' })` produces on
+    /// the web (dashboard.js:175).
+    static func osloDayKey(_ date: Date) -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = osloTimeZone
+        let c = cal.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+}

--- a/ios/Zenji/Feed/FeedEvent.swift
+++ b/ios/Zenji/Feed/FeedEvent.swift
@@ -1,0 +1,156 @@
+//
+//  FeedEvent.swift
+//  Zenji
+//
+//  WP-13: the input value the FeedCompiler predicates operate on. It carries
+//  exactly the fields the five personalisation predicates read (see
+//  tests/fixtures/feed-vectors/README.md §"The five predicates") and nothing
+//  more — a deliberately small, pure-data surface that decodes straight from
+//  a golden feed-vector's `events[]` element AND bridges from the WP-11
+//  `Event` model for the real app (see `init(from:)` overloads below).
+//
+//  Why a separate type from WP-11's `Event`, rather than porting the
+//  predicates onto it directly:
+//
+//    • `Event.time` is a NON-optional `Date` (events.schema.json makes `time`
+//      required, and the pipeline always emits it). The golden vectors,
+//      however, deliberately include a `"time": null` case
+//      (01-multiday-window-golf.json, event `g-notime`) to pin the
+//      "no time → never in window / never relevant" branch of the JS
+//      predicates. Decoding that element into `Event` would THROW, so the
+//      vector suite could not be replayed against `Event` at all. `FeedEvent`
+//      models `time` as `Date?` so the null case decodes and the predicate
+//      returns the same `false` the JS reference does.
+//    • It keeps the predicate layer independent of the full 40-field Event
+//      contract; only the handful of fields the predicates actually read are
+//      here, matching the README's "unlisted fields are absent" convention.
+//
+//  Forward compatibility: unknown/new JSON keys are ignored automatically by
+//  Codable synthesis. Fields the pipeline always writes but that a vector may
+//  omit are defaulted (via a hand-written `init(from:)`), exactly as `Event`
+//  does — Swift's synthesized Decodable does not apply stored-property
+//  defaults for missing keys, only genuine Optionals decode to nil for free.
+//
+
+import Foundation
+
+struct FeedEvent: Codable, Equatable {
+    /// Stable handle. In the golden vectors this is a fixture-local id used to
+    /// name events in the expectation sets; in real data it is the WP-02 hash.
+    var id: String?
+
+    var sport: String
+    var title: String
+    var tournament: String?
+
+    /// Optional so the pinned `"time": null` vector case decodes; the
+    /// predicates treat a nil `time` exactly as the JS `!event.time` guard.
+    var time: Date?
+    var endTime: Date?
+
+    var homeTeam: String?
+    var awayTeam: String?
+
+    var norwegian: Bool
+    var norwegianPlayers: [NorwegianPlayer]
+    var participants: [Participant]
+
+    var isFavorite: Bool
+    var importance: Int?
+
+    /// "ai-research" makes an event relevant regardless of confidence — see
+    /// DIVERGENCES.md §4 (confidence does NOT gate feed inclusion today).
+    var source: String?
+    var confidence: String?
+
+    /// Rendering-only ("cancelled"/"postponed"); pinned NOT to affect any
+    /// selection predicate (11-edge-cancelled.json).
+    var status: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id, sport, title, tournament, time, endTime, homeTeam, awayTeam,
+             norwegian, norwegianPlayers, participants, isFavorite, importance,
+             source, confidence, status
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id)
+        // JS reads `(e.sport || "")` / `e.title || ''`; mirror the tolerant
+        // default so a missing field never crashes the port.
+        sport = try c.decodeIfPresent(String.self, forKey: .sport) ?? ""
+        title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+        tournament = try c.decodeIfPresent(String.self, forKey: .tournament)
+        time = try c.decodeIfPresent(Date.self, forKey: .time)
+        endTime = try c.decodeIfPresent(Date.self, forKey: .endTime)
+        homeTeam = try c.decodeIfPresent(String.self, forKey: .homeTeam)
+        awayTeam = try c.decodeIfPresent(String.self, forKey: .awayTeam)
+        norwegian = try c.decodeIfPresent(Bool.self, forKey: .norwegian) ?? false
+        norwegianPlayers = try c.decodeIfPresent([NorwegianPlayer].self, forKey: .norwegianPlayers) ?? []
+        participants = try c.decodeIfPresent([Participant].self, forKey: .participants) ?? []
+        isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
+        importance = try c.decodeIfPresent(Int.self, forKey: .importance)
+        source = try c.decodeIfPresent(String.self, forKey: .source)
+        confidence = try c.decodeIfPresent(String.self, forKey: .confidence)
+        status = try c.decodeIfPresent(String.self, forKey: .status)
+    }
+
+    /// Direct memberwise-style initializer for tests / synthetic rows.
+    init(
+        id: String? = nil,
+        sport: String,
+        title: String,
+        tournament: String? = nil,
+        time: Date? = nil,
+        endTime: Date? = nil,
+        homeTeam: String? = nil,
+        awayTeam: String? = nil,
+        norwegian: Bool = false,
+        norwegianPlayers: [NorwegianPlayer] = [],
+        participants: [Participant] = [],
+        isFavorite: Bool = false,
+        importance: Int? = nil,
+        source: String? = nil,
+        confidence: String? = nil,
+        status: String? = nil
+    ) {
+        self.id = id
+        self.sport = sport
+        self.title = title
+        self.tournament = tournament
+        self.time = time
+        self.endTime = endTime
+        self.homeTeam = homeTeam
+        self.awayTeam = awayTeam
+        self.norwegian = norwegian
+        self.norwegianPlayers = norwegianPlayers
+        self.participants = participants
+        self.isFavorite = isFavorite
+        self.importance = importance
+        self.source = source
+        self.confidence = confidence
+        self.status = status
+    }
+
+    /// Bridge from the WP-11 `Event` (the shape the SyncClient cache decodes)
+    /// so the real app (WP-14) can feed cached events straight into the
+    /// FeedCompiler. `Event.time` is non-optional, so it maps 1:1.
+    init(from event: Event) {
+        self.id = event.id
+        self.sport = event.sport
+        self.title = event.title
+        self.tournament = event.tournament
+        self.time = event.time
+        self.endTime = event.endTime
+        self.homeTeam = event.homeTeam
+        self.awayTeam = event.awayTeam
+        self.norwegian = event.norwegian
+        self.norwegianPlayers = event.norwegianPlayers
+        self.participants = event.participants
+        self.isFavorite = event.isFavorite
+        self.importance = event.importance
+        self.source = event.source
+        self.confidence = event.confidence
+        self.status = event.status
+    }
+}

--- a/ios/Zenji/Feed/Interests.swift
+++ b/ios/Zenji/Feed/Interests.swift
@@ -1,0 +1,122 @@
+//
+//  Interests.swift
+//  Zenji
+//
+//  WP-13: the personalisation config the FeedCompiler predicates key off — a
+//  Swift port of the fields of scripts/config/interests.json that the golden
+//  feed-vectors embed (see tests/fixtures/feed-vectors/README.md
+//  §"input.interests"). This is the USER's source of truth on the server; on
+//  the client it arrives as data and is only ever read here.
+//
+//  Shape (per the vectors' trimmed copy):
+//
+//    {
+//      "followBroadly": ["football", "golf", ...],   // sports kept wholesale
+//      "alwaysTrack": {
+//        "athletes":    [{ name, aliases[], sport }],
+//        "teams":       [{ name, aliases[], sport }],
+//        "tournaments": [{ name, aliases[], sport, notify? }]
+//      },
+//      "notify": { "leadMinutes": 30 }
+//    }
+//
+//  `Entity.notify` is optional and its DEFAULT depends on the bucket, exactly
+//  like the server's `normalizeEntity(entry, { defaultNotify })`
+//  (scripts/lib/helpers.js): teams & athletes default to notify:true, while
+//  tournaments default to notify:false. That default is applied by
+//  `FeedCompiler.notifyEntities`, not stored here, so the raw config stays a
+//  faithful mirror of the JSON.
+//
+
+import Foundation
+
+struct Interests: Codable, Equatable {
+    struct Entity: Codable, Equatable {
+        var name: String
+        var aliases: [String]
+        /// Sport tag used by the sport-scoped bell matcher; nil = matches any
+        /// sport (server `matchInterest` only scopes when BOTH the entity and
+        /// the event name a sport).
+        var sport: String?
+        /// Explicit notify flag; nil means "use the bucket default" — see the
+        /// file header and `FeedCompiler.notifyEntities`.
+        var notify: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case name, aliases, sport, notify
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            name = try c.decode(String.self, forKey: .name)
+            aliases = try c.decodeIfPresent([String].self, forKey: .aliases) ?? []
+            sport = try c.decodeIfPresent(String.self, forKey: .sport)
+            notify = try c.decodeIfPresent(Bool.self, forKey: .notify)
+        }
+
+        init(name: String, aliases: [String] = [], sport: String? = nil, notify: Bool? = nil) {
+            self.name = name
+            self.aliases = aliases
+            self.sport = sport
+            self.notify = notify
+        }
+
+        /// Every string this entity can be recognised by (name + aliases),
+        /// mirroring server `entityTerms`.
+        var terms: [String] {
+            ([name] + aliases).filter { !$0.isEmpty }
+        }
+    }
+
+    struct AlwaysTrack: Codable, Equatable {
+        var athletes: [Entity]
+        var teams: [Entity]
+        var tournaments: [Entity]
+
+        private enum CodingKeys: String, CodingKey {
+            case athletes, teams, tournaments
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            athletes = try c.decodeIfPresent([Entity].self, forKey: .athletes) ?? []
+            teams = try c.decodeIfPresent([Entity].self, forKey: .teams) ?? []
+            tournaments = try c.decodeIfPresent([Entity].self, forKey: .tournaments) ?? []
+        }
+
+        init(athletes: [Entity] = [], teams: [Entity] = [], tournaments: [Entity] = []) {
+            self.athletes = athletes
+            self.teams = teams
+            self.tournaments = tournaments
+        }
+    }
+
+    struct Notify: Codable, Equatable {
+        var leadMinutes: Int?
+    }
+
+    /// nil = the field was absent (fall back to the server DEFAULT list); an
+    /// explicit empty array means "follow no sport broadly" — the JS
+    /// `interests.followBroadly || DEFAULT` treats `[]` as present, so the
+    /// port must distinguish absent from empty. Hence Optional, not defaulted.
+    var followBroadly: [String]?
+    var alwaysTrack: AlwaysTrack
+    var notify: Notify?
+
+    private enum CodingKeys: String, CodingKey {
+        case followBroadly, alwaysTrack, notify
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        followBroadly = try c.decodeIfPresent([String].self, forKey: .followBroadly)
+        alwaysTrack = try c.decodeIfPresent(AlwaysTrack.self, forKey: .alwaysTrack) ?? AlwaysTrack()
+        notify = try c.decodeIfPresent(Notify.self, forKey: .notify)
+    }
+
+    init(followBroadly: [String]? = nil, alwaysTrack: AlwaysTrack = AlwaysTrack(), notify: Notify? = nil) {
+        self.followBroadly = followBroadly
+        self.alwaysTrack = alwaysTrack
+        self.notify = notify
+    }
+}

--- a/ios/Zenji/Feed/TextMatch.swift
+++ b/ios/Zenji/Feed/TextMatch.swift
@@ -1,0 +1,85 @@
+//
+//  TextMatch.swift
+//  Zenji
+//
+//  WP-13 — the single most correctness-critical port. These are bit-faithful
+//  Swift ports of the SERVER text matchers in scripts/lib/helpers.js
+//  (`normalizeText`, `containsName`) — the diacritic-insensitive,
+//  word-boundary containment used by relevance (unscoped) and the reminder
+//  bell (sport-scoped). Kept as pure, side-effect-free functions so they are
+//  unit-testable in isolation and give identical answers to the JS for every
+//  golden feed-vector input.
+//
+//  IMPORTANT — two DIFFERENT matchers coexist by design (DIVERGENCES.md §2):
+//    • SERVER matching (this file: `normalize` + `containsName`) folds
+//      diacritics ("Barça" ≡ "Barca") AND requires word boundaries ("Lyn"
+//      matches "Lyn Oslo"/"Vålerenga-Lyn" but NOT "Brooklyn").
+//    • CLIENT accent matching (FeedCompiler.isMustSee) uses a NAIVE plain
+//      `lowercased()` + substring `contains` — no diacritic folding, no word
+//      boundaries — so it fires on "Brooklyn".contains("lyn"). That naive
+//      behaviour is PINNED, so it lives inline in isMustSee and must NOT be
+//      routed through this file.
+//
+
+import Foundation
+
+enum TextMatch {
+
+    /// Port of server `normalizeText` (helpers.js:69): NFD-decompose, strip
+    /// every Unicode Mark (JS `/\p{M}/gu` == general categories Mn/Mc/Me),
+    /// then lowercase — in that order.
+    ///
+    /// - "Barça" → "barca"  (ç → c + combining cedilla, mark stripped)
+    /// - "Vålerenga" → "valerenga" (å → a + combining ring, mark stripped)
+    /// - "Tromsø" → "tromsø"  (ø has no canonical decomposition — stays, as
+    ///   in JS; parity holds even though it is not vector-exercised)
+    static func normalize(_ s: String?) -> String {
+        guard let s = s, !s.isEmpty else { return "" }
+        let decomposed = s.decomposedStringWithCanonicalMapping // NFD
+        var scalars = String.UnicodeScalarView()
+        for scalar in decomposed.unicodeScalars {
+            switch scalar.properties.generalCategory {
+            case .nonspacingMark, .spacingMark, .enclosingMark:
+                continue // JS: .replace(/\p{M}/gu, "")
+            default:
+                scalars.append(scalar)
+            }
+        }
+        return String(scalars).lowercased()
+    }
+
+    /// Port of the JS metacharacter escape `/[.*+?^${}()|[\]\\]/g` — the exact
+    /// same character set the reference escapes before building its RegExp, so
+    /// a name containing a regex special is treated literally, identically.
+    static func escapeRegex(_ s: String) -> String {
+        let specials: Set<Character> = [".", "*", "+", "?", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"]
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            if specials.contains(ch) { out.append("\\") }
+            out.append(ch)
+        }
+        return out
+    }
+
+    /// Port of server `containsName` (helpers.js:81): word-boundary,
+    /// accent-insensitive containment. Both sides are `normalize`d first, then
+    /// the name is matched with the boundary regex
+    /// `(?:^|[^\p{L}\p{N}])<name>(?:[^\p{L}\p{N}]|$)`.
+    ///
+    /// "Lyn" matches "Lyn Oslo" and "Vålerenga – Lyn" but NOT "Brooklyn" —
+    /// boundaries kill the substring false-positive class.
+    static func containsName(_ haystack: String, _ name: String) -> Bool {
+        let n = normalize(name).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !n.isEmpty else { return false }
+        let h = normalize(haystack)
+        let pattern = "(?:^|[^\\p{L}\\p{N}])\(escapeRegex(n))(?:[^\\p{L}\\p{N}]|$)"
+        // ICU (NSRegularExpression) supports \p{L}/\p{N}; case-insensitive is
+        // redundant after normalize() but matches the JS "iu" flags exactly.
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return false
+        }
+        let range = NSRange(h.startIndex..., in: h)
+        return re.firstMatch(in: h, options: [], range: range) != nil
+    }
+}

--- a/ios/ZenjiTests/FeedCompilerUnitTests.swift
+++ b/ios/ZenjiTests/FeedCompilerUnitTests.swift
@@ -1,0 +1,114 @@
+//
+//  FeedCompilerUnitTests.swift
+//  ZenjiTests
+//
+//  WP-13 — unit tests for the parts of the FeedCompiler that the golden
+//  vectors do NOT cover: the Europe/Oslo day grouping (explicitly out of
+//  vector scope per the WP-13 brief — kept simple, tested here), plus
+//  focused checks on the text-normalisation primitives (TextMatch) that the
+//  vector suite exercises only indirectly. These guard the "dangerous"
+//  diacritic/word-boundary port against regressions with named, minimal cases.
+//
+
+import XCTest
+
+final class FeedCompilerUnitTests: XCTestCase {
+
+    // MARK: - Date helper
+
+    private func iso(_ s: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: s)!
+    }
+
+    // MARK: - TextMatch.normalize (server normalizeText port)
+
+    func testNormalize_foldsDiacritics_andLowercases() {
+        XCTAssertEqual(TextMatch.normalize("Barça"), "barca")
+        XCTAssertEqual(TextMatch.normalize("Barca"), "barca")
+        XCTAssertEqual(TextMatch.normalize("Vålerenga"), "valerenga")
+        XCTAssertEqual(TextMatch.normalize("LILLESTRØM"), "lillestrøm") // ø has no NFD decomposition — stays, as in JS
+        XCTAssertEqual(TextMatch.normalize(nil), "")
+        XCTAssertEqual(TextMatch.normalize(""), "")
+    }
+
+    // MARK: - TextMatch.containsName (word-boundary, accent-insensitive)
+
+    func testContainsName_wordBoundaryAndDiacritics() {
+        XCTAssertTrue(TextMatch.containsName("Lyn Oslo", "Lyn"))
+        XCTAssertTrue(TextMatch.containsName("Vålerenga – Lyn", "Lyn"))
+        // The pinned false-positive the bell (word boundary) must AVOID —
+        // "Brooklyn" contains "lyn" only as a substring.
+        XCTAssertFalse(TextMatch.containsName("Brooklyn FC", "Lyn"))
+        // Diacritic folding: "Barça" ≡ "Barca".
+        XCTAssertTrue(TextMatch.containsName("FC Barça", "Barca"))
+        XCTAssertTrue(TextMatch.containsName("Barcelona vs Sevilla", "Barcelona"))
+        XCTAssertFalse(TextMatch.containsName("", "Lyn"))
+        XCTAssertFalse(TextMatch.containsName("anything", ""))
+    }
+
+    // MARK: - osloDayKey (Europe/Oslo, summer = UTC+2)
+
+    func testOsloDayKey_crossesMidnightInLocalTime() {
+        // 21:30Z in July is 23:30 Oslo (CEST, +2) → still 13 July.
+        XCTAssertEqual(FeedCompiler.osloDayKey(iso("2026-07-13T21:30:00Z")), "2026-07-13")
+        // 22:30Z is 00:30 Oslo next day → 14 July.
+        XCTAssertEqual(FeedCompiler.osloDayKey(iso("2026-07-13T22:30:00Z")), "2026-07-14")
+    }
+
+    // MARK: - compile: day grouping
+
+    private var followFootballAndGolf: Interests {
+        Interests(
+            followBroadly: ["football", "golf"],
+            alwaysTrack: Interests.AlwaysTrack(
+                teams: [Interests.Entity(name: "Lyn", aliases: ["Lyn Oslo"], sport: "football")]
+            )
+        )
+    }
+
+    func testCompile_groupsByOsloDay_andSortsWithinDay() {
+        let now = iso("2026-07-13T12:00:00Z") // Oslo 14:00, day 2026-07-13
+        let events = [
+            FeedEvent(id: "a", sport: "football", title: "Kamp A", time: iso("2026-07-13T18:00:00Z")),
+            FeedEvent(id: "b", sport: "golf", title: "Runde", time: iso("2026-07-14T06:00:00Z")),
+        ]
+        let feed = FeedCompiler.compile(events: events, interests: followFootballAndGolf, now: now)
+
+        XCTAssertEqual(feed.days.map { $0.key }, ["2026-07-13", "2026-07-14"])
+        XCTAssertEqual(feed.days[0].items.count, 1)
+        XCTAssertEqual(feed.days[1].items.count, 1)
+    }
+
+    func testCompile_multiDayStillRunning_movesUnderToday() {
+        let now = iso("2026-07-13T12:00:00Z")
+        let multiDay = FeedEvent(
+            id: "open", sport: "golf", title: "The Open",
+            time: iso("2026-07-10T06:00:00Z"), endTime: iso("2026-07-15T18:00:00Z")
+        )
+        let feed = FeedCompiler.compile(events: [multiDay], interests: followFootballAndGolf, now: now)
+
+        // Started 10 July but still running → grouped under today (13 July),
+        // not its past start day. Mirrors dashboard.js:352.
+        XCTAssertEqual(feed.days.map { $0.key }, ["2026-07-13"])
+    }
+
+    // MARK: - compile: annotation (bell + accent) is attached to events
+
+    func testCompile_annotatesBellAndAccentForTrackedTeam() {
+        let now = iso("2026-07-13T12:00:00Z")
+        let lyn = FeedEvent(
+            id: "lyn", sport: "football", title: "Lyn – Fram",
+            tournament: "OBOS-ligaen", time: iso("2026-07-13T15:00:00Z"),
+            homeTeam: "Lyn", awayTeam: "Fram"
+        )
+        let feed = FeedCompiler.compile(events: [lyn], interests: followFootballAndGolf, now: now)
+        let item = try? XCTUnwrap(feed.days.first?.items.first)
+        guard case .event(_, let mustWatch, let mustSee) = item else {
+            return XCTFail("expected a single annotated event row")
+        }
+        XCTAssertTrue(mustWatch, "tracked notify-team Lyn should arm the bell")
+        XCTAssertTrue(mustSee, "tracked team Lyn should earn the accent")
+    }
+}

--- a/ios/ZenjiTests/FeedVectorTests.swift
+++ b/ios/ZenjiTests/FeedVectorTests.swift
@@ -1,0 +1,190 @@
+//
+//  FeedVectorTests.swift
+//  ZenjiTests
+//
+//  WP-13 acceptance — the ONLY criterion for this package: the Swift
+//  FeedCompiler reproduces EVERY expectation in EVERY golden feed-vector
+//  bit-for-bit. These tests decode the SAME files the JS reference
+//  (tests/feed-vectors.test.js) replays — referenced directly from the repo
+//  root via project.yml (a bundled `feed-vectors` folder reference), never
+//  copied — so the Swift port is proven against exactly the frozen fixtures,
+//  with no possibility of a drifted copy.
+//
+//  Each vector is a self-contained { input, expected }. A vector declares only
+//  the expectation keys it cares about; each key is asserted against the
+//  matching FeedCompiler predicate as an UNORDERED id set (README §"Fixture
+//  schema"). The four pinned server/client divergences (DIVERGENCES.md) are
+//  part of the fixtures and are expected to pass here unchanged.
+//
+//  If a vector ever fails: DO NOT touch the fixture (it is frozen). The
+//  failure message names the file + predicate; leave it red and escalate.
+//
+
+import XCTest
+
+/// Anchors `Bundle(for:)` at the ZenjiTests bundle, where project.yml's
+/// `../tests/fixtures/feed-vectors` folder reference lands as the bundled
+/// subdirectory "feed-vectors".
+private final class FeedVectorBundleMarker {}
+
+final class FeedVectorTests: XCTestCase {
+
+    // MARK: - Fixture model (mirrors README §"Fixture schema")
+
+    struct Vector: Decodable {
+        struct Window: Decodable {
+            let start: Date
+            let end: Date
+        }
+        struct Input: Decodable {
+            let now: Date?
+            let window: Window?
+            let interests: Interests
+            let events: [FeedEvent]
+        }
+        struct ExpectedSeries: Decodable {
+            let isSeries: Bool
+            let id: String
+            let tournament: String?
+            let stageCount: Int?
+            let nextStageId: String?
+        }
+        struct Expected: Decodable {
+            let relevant: [String]?
+            let mustWatch: [String]?
+            let mustSee: [String]?
+            let inWindow: [String]?
+            let series: [ExpectedSeries]?
+        }
+        let name: String
+        let description: String
+        let input: Input
+        let expected: Expected
+    }
+
+    // MARK: - Loading
+
+    private static let vectors: [(file: String, vector: Vector)] = {
+        let bundle = Bundle(for: FeedVectorBundleMarker.self)
+        let urls = (bundle.urls(forResourcesWithExtension: "json", subdirectory: "feed-vectors") ?? [])
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        precondition(!urls.isEmpty, "No feed-vector JSON found in the test bundle — check project.yml's ../tests/fixtures/feed-vectors folder reference.")
+        return urls.map { url in
+            do {
+                let data = try Data(contentsOf: url)
+                let vector = try ZenjiJSON.decoder.decode(Vector.self, from: data)
+                return (url.lastPathComponent, vector)
+            } catch {
+                fatalError("Failed to decode feed-vector \(url.lastPathComponent): \(error)")
+            }
+        }
+    }()
+
+    // MARK: - Helpers
+
+    /// Ids of `events` for which `predicate` holds, sorted (unordered compare).
+    private func ids(_ events: [FeedEvent], where predicate: (FeedEvent) -> Bool) -> [String] {
+        events.compactMap { predicate($0) ? $0.id : nil }.sorted()
+    }
+
+    private struct SeriesDescriptor: Equatable, Comparable {
+        let isSeries: Bool
+        let id: String
+        let tournament: String?
+        let stageCount: Int?
+        let nextStageId: String?
+        static func < (lhs: SeriesDescriptor, rhs: SeriesDescriptor) -> Bool { lhs.id < rhs.id }
+    }
+
+    // MARK: - Suite integrity (mirrors the JS "feed-vector suite integrity")
+
+    func testSuiteIntegrity() {
+        let vectors = Self.vectors
+        XCTAssertGreaterThanOrEqual(vectors.count, 10, "WP-06 acceptance: at least 10 vectors ship")
+
+        for (file, v) in vectors {
+            let events = v.input.events
+            let idList = events.map { $0.id }
+            XCTAssertTrue(idList.allSatisfy { ($0?.isEmpty == false) }, "\(file): every event needs a non-empty id")
+            let ids = idList.compactMap { $0 }
+            XCTAssertEqual(Set(ids).count, ids.count, "\(file): duplicate event id")
+            let known = Set(ids)
+            for key in ["relevant", "mustWatch", "mustSee", "inWindow"] {
+                let expectedIds: [String]
+                switch key {
+                case "relevant": expectedIds = v.expected.relevant ?? []
+                case "mustWatch": expectedIds = v.expected.mustWatch ?? []
+                case "mustSee": expectedIds = v.expected.mustSee ?? []
+                default: expectedIds = v.expected.inWindow ?? []
+                }
+                for id in expectedIds {
+                    XCTAssertTrue(known.contains(id), "\(file): expected.\(key) references unknown id \"\(id)\"")
+                }
+            }
+
+            let hasAny = v.expected.relevant != nil || v.expected.mustWatch != nil
+                || v.expected.mustSee != nil || v.expected.inWindow != nil || v.expected.series != nil
+            XCTAssertTrue(hasAny, "\(file): no expectations")
+        }
+    }
+
+    // MARK: - §relevant (SERVER isRelevant + 14-day cutoff)
+
+    func testRelevant() throws {
+        for (file, v) in Self.vectors where v.expected.relevant != nil {
+            let now = try XCTUnwrap(v.input.now, "\(file): expected.relevant requires input.now")
+            let actual = ids(v.input.events) { FeedCompiler.isRelevant($0, interests: v.input.interests, now: now) }
+            XCTAssertEqual(actual, v.expected.relevant!.sorted(), "\(file): §relevant mismatch")
+        }
+    }
+
+    // MARK: - §mustWatch (SERVER mustWatchEntity, sport-scoped)
+
+    func testMustWatch() {
+        for (file, v) in Self.vectors where v.expected.mustWatch != nil {
+            let actual = ids(v.input.events) { FeedCompiler.mustWatch($0, interests: v.input.interests) }
+            XCTAssertEqual(actual, v.expected.mustWatch!.sorted(), "\(file): §mustWatch mismatch")
+        }
+    }
+
+    // MARK: - §mustSee (CLIENT isMustSee, naive substring — pinned)
+
+    func testMustSee() {
+        for (file, v) in Self.vectors where v.expected.mustSee != nil {
+            let actual = ids(v.input.events) { FeedCompiler.isMustSee($0, interests: v.input.interests) }
+            XCTAssertEqual(actual, v.expected.mustSee!.sorted(), "\(file): §mustSee mismatch")
+        }
+    }
+
+    // MARK: - §inWindow (SERVER & CLIENT identical)
+
+    func testInWindow() throws {
+        for (file, v) in Self.vectors where v.expected.inWindow != nil {
+            let window = try XCTUnwrap(v.input.window, "\(file): expected.inWindow requires input.window")
+            let actual = ids(v.input.events) {
+                FeedCompiler.isEventInWindow($0, start: window.start, end: window.end)
+            }
+            XCTAssertEqual(actual, v.expected.inWindow!.sorted(), "\(file): §inWindow mismatch")
+        }
+    }
+
+    // MARK: - §series (CLIENT collapseSeries)
+
+    func testSeries() throws {
+        for (file, v) in Self.vectors where v.expected.series != nil {
+            let now = try XCTUnwrap(v.input.now, "\(file): expected.series requires input.now")
+            let actual = FeedCompiler.collapseSeries(v.input.events, now: now).map { item -> SeriesDescriptor in
+                switch item {
+                case .event(let e):
+                    return SeriesDescriptor(isSeries: false, id: e.id ?? "", tournament: nil, stageCount: nil, nextStageId: nil)
+                case .series(let s):
+                    return SeriesDescriptor(isSeries: true, id: s.id, tournament: s.tournament, stageCount: s.stages.count, nextStageId: s.nextStage.id)
+                }
+            }.sorted()
+            let expected = v.expected.series!.map {
+                SeriesDescriptor(isSeries: $0.isSeries, id: $0.id, tournament: $0.tournament, stageCount: $0.stageCount, nextStageId: $0.nextStageId)
+            }.sorted()
+            XCTAssertEqual(actual, expected, "\(file): §series mismatch")
+        }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -89,7 +89,8 @@ targets:
   # sources directly into the test bundle (same pattern the widget extension
   # already uses for DesignTokens.swift above) rather than linking the app
   # binary, so it needs no `@testable import`. WP-12 adds Zenji/Sync the same
-  # way, for SyncClient/CacheStore/DataStore's own hostless tests.
+  # way, for SyncClient/CacheStore/DataStore's own hostless tests; WP-13 adds
+  # Zenji/Feed for the FeedCompiler predicate + golden-vector tests.
   ZenjiTests:
     type: bundle.unit-test
     platform: iOS
@@ -98,6 +99,19 @@ targets:
       - path: ZenjiTests
       - path: Zenji/Models
       - path: Zenji/Sync
+      - path: Zenji/Feed
+      # WP-13: the SAME golden feed-vector fixtures the JS reference test
+      # (tests/feed-vectors.test.js) replays — referenced directly at the repo
+      # root, never copied, so the two runners can never drift. XcodeGen
+      # resolves this relative to project.yml (ios/) and supports source paths
+      # outside it; `buildPhase: resources` bundles the *.json (and the README/
+      # DIVERGENCES docs) so FeedVectorTests can load them from the test bundle
+      # at runtime. `type: folder` keeps the folder as a bundle subdirectory
+      # ("feed-vectors") so the vector JSONs never collide with the WP-11
+      # Fixtures JSONs already flattened into the bundle root.
+      - path: ../tests/fixtures/feed-vectors
+        buildPhase: resources
+        type: folder
     resources:
       - path: ZenjiTests/Fixtures
     info:


### PR DESCRIPTION
## WP-13 · FeedCompiler (Swift)

Porter personaliserings-semantikken som WP-06 frøs som gylne feed-vektorer (`tests/fixtures/feed-vectors/`) til Swift i `ios/Zenji/Feed/`. **Pakkens eneste akseptkriterium:** Swift-porten består ALLE de 13 gylne feed-vektorene bit-likt.

**Vektor-status: 13/13 bestått.**

### De fem predikatene — tro mot RIKTIG side per side

Det finnes ikke ett «special?»-predikat; det er fem, hver med sitt produktspørsmål, portet tro mot siden som eier det:

| Predikat | Spørsmål | Kilde | Semantikk bevart |
|---|---|---|---|
| `isRelevant` | I feeden i det hele tatt? | **server** `build-events.js` + 14-dagers cutoff | `sport ∈ followBroadly` ELLER norwegian/isFavorite/importance≥4/ai-research ELLER en tracked entitet matcher — matchen er **IKKE sport-scoped**. Cutoff på `endTime ?? time`; grense inklusiv. |
| `mustWatch` | Bjelle 🔔? | **server** `helpers.js` `mustWatchEntity` | Kun fra `interests.json` notify-entiteter; **sport-scoped**; ord-grense + diakritika-folding. |
| `isMustSee` | Stille aksent? | **klient** `dashboard.js` `isMustSee` | isFavorite/importance≥4/(norsk+spillere), landslags-regex, så **naiv lowercase-substring** lag/utøver-match — den PINNEDE substring-oppførselen (`"Brooklyn".contains("lyn")`) beholdt. |
| `isEventInWindow` | Overlapper agenda-vinduet? | **server & klient, byte-identisk** | `s = time`, `e = endTime ?? time`; overlapper `[start,end)` hviss `s < end && e >= start`; ingen tid → false. |
| `collapseSeries` | Hvordan kollapser etappeløp? | **klient** `dashboard.js` `collapseSeries` | Grupperer titler `/\betappe\b|\bstage\s*\d/i` på `sport||tournament`; **4 eller flere** kollapser; neste etappe = første med `endTime ?? time >= now`, ellers siste. |

### Divergensene (DIVERGENCES.md) er REPRODUSERT, ikke «fikset»

Alle fire pinnede server/klient-avvik reproduseres: relevans uscopet vs. bjelle sport-scoped (fotball-«Barcelona» drar en tennis-«Barcelona Open» inn på tavla, uten bjelle); aksentens naive substring vs. bjellens ord-grense (`"Brooklyn FC"` får aksent, ikke bjelle); bjelle ≠ aksent generelt; og `confidence` gater IKKE feed-inklusjon.

### Tekst-normalisering (den farligste delen)

`TextMatch.swift` porter server-matcherne som rene, unit-testede funksjoner: `normalize` (NFD → strip `\p{M}` → lowercase, så «Barça» ≡ «Barca») og `containsName` (ord-grense, diakritika-ufølsom via `(?:^|[^\p{L}\p{N}])navn(?:[^\p{L}\p{N}]|$)`). Klient-aksentens NAIVE `lowercased()` + substring `contains` går bevisst IKKE gjennom denne fila — den bor inline i `isMustSee` fordi manglende folding/grenser er pinnet oppførsel.

### Typer

- `FeedEvent` — liten ren-data input. `time: Date?` (ikke WP-11 `Event`s ikke-valgfrie `Date`) slik at den pinnede `"time": null`-vektoren dekodes; `init(from: Event)` bygger bro fra cachede `Event` for WP-14.
- `Interests` — vektorenes innbakte interesse-config.
- `FeedCompiler` — de fem predikatene + `compile(events:interests:now:)`-fasade (relevans → bjelle/aksent-annotering → serie-kollaps → Europe/Oslo dag-gruppering). Dag-grupperingen er IKKE vektordekket — holdt enkel, unit-testet separat.

### Vektor-kjøring uten drift

`FeedVectorTests` leser de SAMME fil­ene som JS-referansen (`tests/feed-vectors.test.js`): repo-rot-mappa `tests/fixtures/feed-vectors` refereres direkte fra `project.yml` som en bundlet mappe-referanse (`buildPhase: resources`, `type: folder` — en sti utenfor `ios/` som XcodeGen løser relativt til `project.yml`), aldri kopiert. **Fixture-ene er fredet** — en rød vektor står rød og eskaleres, aldri «løst» ved å endre fixturen.

### Verifisering

- `xcodebuild test` grønt på iOS 26.5-simulator: **49 tester** (37 WP-10/11/12-baseline + 12 WP-13: 6 `FeedVectorTests` over alle 13 vektorer + 6 `FeedCompilerUnitTests`).
- App-schemet (`Zenji`) bygger.
- `npm test` fra roten urørt grønt (369 tester).

### Scope / ikke-mål

Kun `ios/` + WP-13-raden i PLAN.md. Ingen UI/rendering (WP-14), varsler (WP-15) eller sync-endringer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)