### PR TITLE
WP-16: FM-lekegrind — samtale→profil

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -45,7 +45,7 @@ mennesket, aldri av en agent.
 | WP-13 | FeedCompiler (Swift) | 0B | WP-06, WP-11 | ✅ merget (#243) — 13/13 vektorer bit-likt |
 | WP-14 | Agenda-UI + widget | 0B | WP-13 | ✅ merget (#245) — 102/102 tester + screenshot-bevis |
 | WP-15 | NotificationPlanner | 0B | WP-13 | ✅ merget (#244) — 69/69 tester |
-| WP-16 | FM-lekegrind (samtale→profil) | 0B | WP-10 | todo |
+| WP-16 | FM-lekegrind (samtale→profil) | 0B | WP-10 | ✅ implementert — 152/152 iOS-tester (mot mock; FM kjøres ikke i CI) + DeviceDev bygget/signert/installert på fysisk iPhone (launch krever engangs manuell utvikler-trust på enheten) |
 | WP-17 | 💰 TestFlight-oppsett | 0B | WP-14 | venter på beslutning |
 | WP-26 | Nytt navn | 0C | – | ✅ valgt + domene sikret — formell sjekk gjenstår |
 | WP-27 | 💰 Domene + DNS-cutover | 0C | WP-26 | ✅ zenji.app live 13.07 (cert + enforce-https + rot-paths) |

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,4 +1,4 @@
-# Zenji — iOS app (WP-10 scaffold → WP-11 models → WP-12 sync → WP-13 feed → WP-14 agenda/widget → WP-15 notifications)
+# Zenji — iOS app (WP-10 scaffold → WP-11 models → WP-12 sync → WP-13 feed → WP-14 agenda/widget → WP-15 notifications → WP-16 assistant)
 
 SwiftUI app **Zenji** + WidgetKit extension **ZenjiWidget**, generated with
 [XcodeGen](https://github.com/yonaskolb/XcodeGen) from `project.yml`. WP-10
@@ -768,15 +768,122 @@ last real fetch was, which is precisely the "how stale is this" signal gate
 `.task`, not on `AgendaView`'s pull-to-refresh (WP-14) — a manual refresh
 re-syncs and recompiles the agenda but doesn't re-run the notification diff.
 
+## Assistent — FM-lekegrind (WP-16)
+
+`Zenji/Assistant/` is a conversational way to edit *what the app follows*:
+type a Norwegian utterance ("Følg Ruud bare i Grand Slams", "slutt med
+tennis", "mer sykkel i juli"), and the on-device model turns it into
+structured rule mutations you review as a DIFF and confirm or reject. Reached
+from a discreet speech-bubble glyph in the Tekst-TV header (`ContentView`).
+
+### The model is behind a protocol (vendor surface = one file)
+
+`InterestAssistant` (`Assistant/InterestAssistant.swift`) is the whole model
+API the UI and pipeline see — everything else is FoundationModels-free:
+
+- **`FoundationModelsInterestAssistant`** — the real one, Apple Intelligence
+  via **FoundationModels** (iOS 26+). The **only** file that
+  `import FoundationModels`. It defines the `@Generable` output schema
+  (`GeneratedMutation` — `action`/`entityId`/`entityQuery`/`scope`/`weight`/
+  `reason`) and a `searchEntities` **`Tool`** over the entity index, checks
+  `SystemLanguageModel.default.availability`, and runs one
+  `LanguageModelSession.respond(to:generating:)`. On the Simulator/CI the
+  model reports `.unavailable`, mapped to a calm Norwegian message — so it
+  compiles and links everywhere but only *runs* on the device.
+- **`MockInterestAssistant`** — a deterministic Norwegian keyword parser used
+  by every test (Apple Intelligence can't run in CI) and by SwiftUI previews.
+  It is **not** a silent fallback: when Apple Intelligence is off the shipping
+  app shows the honest "unavailable" banner rather than degrading to keywords.
+
+### Entity grounding is the hard rule
+
+A proposal is applied **only** if its `entityId` resolves in the WP-05 entity
+index (`docs/data/entities.json`, via `DataStore.loadEntities()`).
+`MutationGrounder.ground(_:index:profile:)` re-checks every id the model
+returns — a hallucinated or free-text entity ("cricket") is **rejected**, never
+applied, with a Norwegian explanation and up to three nearest-match suggestions
+("Fant ikke «X» i indeksen — mente du …?"). This holds identically whether the
+raw proposal came from FoundationModels or the mock.
+
+### Pieces (all pure + unit-tested except the two UI/FM shells)
+
+| File | What |
+|---|---|
+| `AssistantModels.swift` | `MutationKind`, `ProposedMutation` (raw), `GroundedMutation`/`RejectedMutation`, `AssistantAvailability`/`AssistantError` |
+| `InterestProfile.swift` | `InterestRule` + `InterestProfile.applying(_:)` — the pure add/update (upsert) / remove diff; every rule keeps a Norwegian `reason` |
+| `EntityIndex.swift` | exact lookup (grounding gate), tool search (Norwegian sport-word expansion), fuzzy nearest-match, the mock's utterance→entity detection |
+| `MutationGrounder.swift` | the hard grounding rule, as one pure function |
+| `ProfileStore.swift` | JSON persistence in Application Support (no App Group needed — works on the free-account device build); `load()` never throws |
+| `MockInterestAssistant.swift` | the deterministic parser (`MockInterestParser`) |
+| `FoundationModelsInterestAssistant.swift` | the real on-device model (only `import FoundationModels`) |
+| `AssistantViewModel.swift` | `@MainActor @Observable` coordinator: submit → ground → confirm/reject → persist |
+| `AssistantView.swift` | the one calm Tekst-TV screen (DIFF in green/amber/red tokens, "Hva jeg følger" list) |
+
+`ProfileStore` writes `interest-profile.json` to Application Support (a
+throwaway temp dir in tests). The profile is device-local — CloudKit sync is
+later work (PLAN.md WP-22).
+
+### Tests
+
+`ZenjiTests/{MockInterestAssistant,MutationGrounder,InterestProfile,ProfileStore,EntityIndex,AssistantViewModel}Tests.swift`
+(+ `AssistantTestSupport.swift`) drive the mock, never FoundationModels. They
+cover the ten canonical utterances → correct mutations, entity lookup +
+free-text rejection with nearest match, the diff application, persistence
+round-trip, and the end-to-end view-model flow. `xcodebuild test` on the
+Simulator passes **152 tests** (the 102 WP-10…15 baseline + 50 new).
+
+### Device build (free personal account)
+
+WP-16 needs a **physical device** with Apple Intelligence to exercise the real
+model. Two free-account limits are handled by a dedicated **`ZenjiDeviceDev`**
+target/scheme (added to `project.yml`) — the Simulator `Zenji` target, its
+schemes and all tests are unchanged:
+
+- **No App Groups** (unavailable on a free team): `ZenjiDeviceDev` uses an empty
+  entitlements file (`ZenjiDeviceDev/ZenjiDeviceDev.entitlements`); `CacheStore`
+  falls back to Application Support (its built-in fallback), `ProfileStore` uses
+  it unconditionally.
+- **No embedded widget** (a prior attempt failed with *"Embedded binary is not
+  signed with the same certificate as the parent app"*): `ZenjiDeviceDev` has
+  **no** `ZenjiWidgetExtension` dependency. The widget stays Simulator-only
+  until a paid account (WP-17).
+- It reuses bundle id `app.zenji.ios` (the free team already has a matching
+  provisioning profile covering the device) and a distinct `PRODUCT_NAME`
+  (`ZenjiDeviceDev.app`) so its product never collides with `Zenji.app`. The
+  home-screen name stays "Zenji" via `CFBundleDisplayName`.
+
+```sh
+cd ios && xcodegen generate
+
+# Build for the connected iPhone (free personal team, automatic signing):
+xcodebuild -project Zenji.xcodeproj -scheme ZenjiDeviceDev \
+  -destination 'platform=iOS,id=<device-id from `xcrun devicectl list devices`>' \
+  -allowProvisioningUpdates CODE_SIGNING_ALLOWED=YES CODE_SIGN_STYLE=Automatic \
+  DEVELOPMENT_TEAM=<team> build
+
+# Install + launch on the device (hardware UDID):
+APP=~/Library/Developer/Xcode/DerivedData/Zenji-*/Build/Products/Debug-iphoneos/ZenjiDeviceDev.app
+xcrun devicectl device install app --device <hardware-udid> "$APP"
+xcrun devicectl device process launch --device <hardware-udid> app.zenji.ios
+```
+
+**One-time on-device trust step:** the first launch of a free-team development
+build is blocked by iOS until the developer certificate is trusted manually —
+*Innstillinger → Generelt → VPN og enhetsadministrering → Utviklerapp → Stol
+på "Apple Development: …"*. This cannot be scripted (`devicectl launch` returns
+a `Security`/"profile has not been explicitly trusted" error until it's done).
+After trusting once, the app launches normally and the FM conversations can be
+verified by hand (see the WP-16 PR's manual checklist).
+
 ## Architecture (what plugs in next)
 
 WP-10 was the shell, WP-11 added the Codable models, WP-12 added sync + cache
 + background refresh, WP-13 added the FeedCompiler, WP-14 added the real
-agenda UI + widget, WP-15 added the NotificationPlanner. The pieces below are
-still separate work packages — **not implemented here**:
+agenda UI + widget, WP-15 added the NotificationPlanner, WP-16 added the FM
+assistant. Still separate, later work packages — **not implemented here**:
 
-- **FM playground (WP-16)** — conversational interest-rule editing via Apple
-  Intelligence `@Generable`, gated on a physical device.
+- **TestFlight (WP-17)** — a paid Apple Developer account, real signing, and
+  re-enabling the App Group + embedded widget on device.
 
 ## Data contract
 

--- a/ios/Zenji/Assistant/AssistantModels.swift
+++ b/ios/Zenji/Assistant/AssistantModels.swift
@@ -1,0 +1,143 @@
+//
+//  AssistantModels.swift
+//  Zenji
+//
+//  WP-16 — the FM-lekegrind's plain, FoundationModels-FREE value types. Every
+//  type in this file is ordinary Swift (Codable/Equatable/Sendable) with no
+//  dependency on the FoundationModels framework, so the whole conversation →
+//  profile pipeline — entity grounding, diff-application, persistence — and
+//  all of its unit tests run on the Simulator (and in CI) without ever needing
+//  Apple Intelligence. Only `FoundationModelsInterestAssistant.swift` imports
+//  FoundationModels; it converts its `@Generable` output into the
+//  `ProposedMutation`s below, and the mock (`MockInterestAssistant`) produces
+//  them directly.
+//
+//  The three layers a proposal passes through:
+//
+//    ProposedMutation   what the model claims (UNTRUSTED entityId + the raw
+//                       phrase the user used) — from FM or the mock
+//         │  MutationGrounder.ground(_:index:profile:)   ← the HARD RULE
+//         ▼
+//    GroundedMutation   entityId verified to exist in the entity index; carries
+//                       the resolved Entity + the rule it would replace/remove
+//    RejectedMutation   entityId NOT in the index → rejected, with a Norwegian
+//                       explanation + nearest-match suggestions ("mente du …?")
+//         │  user taps Bekreft
+//         ▼
+//    InterestProfile.applying(_:now:)                    ← the diff applied
+//
+
+import Foundation
+
+/// What a single proposal does to the interest profile. The UI colours these:
+/// `.add` green, `.update` amber, `.remove` red (the DIFF view).
+enum MutationKind: String, Codable, Equatable, Sendable {
+    /// Follow an entity (upsert — a new rule, or replaces an existing one).
+    case add
+    /// Change an existing rule's weight/scope (upsert if it doesn't exist yet).
+    case update
+    /// Stop following an entity (no-op if there is no such rule).
+    case remove
+}
+
+/// The model's RAW proposal, BEFORE entity-grounding.
+///
+/// `entityId` is deliberately treated as untrusted: the model is instructed to
+/// only ever use ids returned by the `searchEntities` tool, but grounding still
+/// re-checks every id against the live index (defence-in-depth — a model can
+/// hallucinate). `entityQuery` is the natural-language phrase the user actually
+/// used ("Ruud", "tennis", "cricket"); it exists only so a failed lookup can
+/// suggest the nearest real entity.
+struct ProposedMutation: Equatable, Sendable {
+    var kind: MutationKind
+    var entityId: String
+    var entityQuery: String
+    /// Optional Norwegian scope, e.g. "bare i Grand Slams", "i juli".
+    var scope: String?
+    /// Relative weight 0…1; nil = "keep whatever the existing rule has, else
+    /// the default".
+    var weight: Double?
+    /// Always-filled Norwegian rationale (the transparency contract).
+    var reason: String
+
+    init(kind: MutationKind, entityId: String, entityQuery: String, scope: String? = nil, weight: Double? = nil, reason: String) {
+        self.kind = kind
+        self.entityId = entityId
+        self.entityQuery = entityQuery
+        self.scope = scope
+        self.weight = weight
+        self.reason = reason
+    }
+}
+
+/// A proposal whose `entityId` was verified against the index — safe to apply.
+struct GroundedMutation: Equatable, Identifiable, Sendable {
+    var kind: MutationKind
+    var entity: Entity
+    var scope: String?
+    var weight: Double
+    var reason: String
+    /// The rule this would replace/remove, if one already exists — lets the
+    /// DIFF view show a real before/after instead of guessing.
+    var previousRule: InterestRule?
+
+    /// Stable, deterministic id (entity + kind) — no random UUID, so the type
+    /// stays value-equal for tests and SwiftUI diffing.
+    var id: String { "\(entity.id):\(kind.rawValue)" }
+}
+
+/// A proposal that failed the hard grounding rule: it referred to something not
+/// in the index. Never applied — shown to the user as an honest explanation.
+struct RejectedMutation: Equatable, Identifiable, Sendable {
+    /// The phrase the user used that couldn't be grounded.
+    var query: String
+    /// Norwegian explanation, including "mente du …?" when there is a near miss.
+    var explanation: String
+    /// Nearest real entities (may be empty) — offered as tappable alternatives.
+    var suggestions: [Entity]
+
+    var id: String { query }
+}
+
+/// The outcome of grounding a batch of proposals.
+struct GroundingResult: Equatable, Sendable {
+    var grounded: [GroundedMutation]
+    var rejected: [RejectedMutation]
+
+    init(grounded: [GroundedMutation] = [], rejected: [RejectedMutation] = []) {
+        self.grounded = grounded
+        self.rejected = rejected
+    }
+
+    var isEmpty: Bool { grounded.isEmpty && rejected.isEmpty }
+}
+
+/// Whether the on-device model can actually be used right now. Mirrors
+/// `SystemLanguageModel.Availability` but is FM-free so the UI/tests can reason
+/// about it without importing FoundationModels.
+enum AssistantAvailability: Equatable, Sendable {
+    case available
+    /// Not usable — carries a calm, honest Norwegian message for the UI.
+    case unavailable(message: String)
+
+    var isAvailable: Bool { self == .available }
+
+    var message: String? {
+        if case let .unavailable(message) = self { return message }
+        return nil
+    }
+}
+
+/// Errors the assistant layer can surface. All carry Norwegian, user-facing
+/// text (they are shown verbatim in the calm UI).
+enum AssistantError: LocalizedError, Equatable {
+    case unavailable(message: String)
+    case generationFailed(message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unavailable(message): return message
+        case let .generationFailed(message): return message
+        }
+    }
+}

--- a/ios/Zenji/Assistant/AssistantView.swift
+++ b/ios/Zenji/Assistant/AssistantView.swift
@@ -1,0 +1,366 @@
+//
+//  AssistantView.swift
+//  Zenji
+//
+//  WP-16 — the one FM-lekegrind screen, reached from a discreet "Assistent"
+//  glyph in the Tekst-TV header (ContentView). Calm, Norwegian, monospace: a
+//  text field for the utterance; the model's proposed changes shown as a DIFF
+//  (green add / amber change / red remove, in the design tokens) with
+//  Bekreft/Avvis per mutation; honest "fant ikke …" notes for anything that
+//  couldn't be grounded; and the current profile listed below as "Hva jeg
+//  følger", each rule with its Norwegian reason. When Apple Intelligence is off
+//  or the model isn't loaded, a quiet banner says so plainly rather than
+//  pretending to work.
+//
+//  All logic lives in AssistantViewModel + the pure pipeline it calls; this
+//  file is presentation only.
+//
+
+import SwiftUI
+
+struct AssistantView: View {
+    @State private var viewModel: AssistantViewModel
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var inputFocused: Bool
+
+    /// Canonical example utterances (the WP-16 spirit) — tappable to fill the
+    /// field, so the playground is discoverable without a keyboard tour.
+    private static let examples = [
+        "Følg Casper Ruud bare i Grand Slams",
+        "Slutt med tennis",
+        "Mer sykkel i juli",
+        "Følg Magnus Carlsen",
+        "Prioriter 100 Thieves høyere"
+    ]
+
+    init(viewModel: AssistantViewModel = AssistantViewModel()) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                header
+                if let message = viewModel.availability.message {
+                    unavailableBanner(message)
+                }
+                inputSection
+                statusSection
+                if !viewModel.pending.isEmpty { proposalsSection }
+                if !viewModel.rejected.isEmpty { rejectionsSection }
+                profileSection
+                examplesSection
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(ZenjiTokens.background.ignoresSafeArea())
+        .foregroundStyle(ZenjiTokens.foreground)
+        .task { viewModel.refreshAvailability() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("ASSISTENT")
+                .font(.zenjiMono(size: 20, weight: .bold))
+                .foregroundStyle(ZenjiTokens.accent)
+                .tracking(2)
+            Spacer()
+            Button("Lukk") { dismiss() }
+                .font(.zenjiMono(size: 14))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.7))
+        }
+    }
+
+    // MARK: - Availability banner
+
+    private func unavailableBanner(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("APPLE INTELLIGENCE")
+                .font(.zenjiMono(size: 11, weight: .bold))
+                .foregroundStyle(ZenjiTokens.accent.opacity(0.8))
+                .tracking(1.5)
+            Text(message)
+                .font(.zenjiMono(size: 13))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.8))
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(ZenjiTokens.accent.opacity(0.10))
+        .overlay(Rectangle().stroke(ZenjiTokens.accent.opacity(0.35), lineWidth: 1))
+    }
+
+    // MARK: - Input
+
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Skriv hva du vil følge, på vanlig norsk:")
+                .font(.zenjiMono(size: 13))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.7))
+
+            TextField("f.eks. følg Ruud bare i Grand Slams", text: $viewModel.utterance, axis: .vertical)
+                .font(.zenjiMono(size: 15))
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .focused($inputFocused)
+                .padding(12)
+                .background(ZenjiTokens.foreground.opacity(0.06))
+                .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.2), lineWidth: 1))
+                .submitLabel(.send)
+                .onSubmit(runSubmit)
+
+            Button(action: runSubmit) {
+                Text(viewModel.isThinking ? "TOLKER …" : "TOLK")
+                    .font(.zenjiMono(size: 14, weight: .bold))
+                    .tracking(1.5)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(ZenjiTokens.accent.opacity(canSubmit ? 0.85 : 0.25))
+                    .foregroundStyle(ZenjiTokens.background)
+            }
+            .disabled(!canSubmit)
+        }
+    }
+
+    private var canSubmit: Bool {
+        !viewModel.isThinking && !viewModel.utterance.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func runSubmit() {
+        inputFocused = false
+        Task { await viewModel.submit() }
+    }
+
+    // MARK: - Status (thinking / error / notice)
+
+    @ViewBuilder
+    private var statusSection: some View {
+        if viewModel.isThinking {
+            HStack(spacing: 8) {
+                ProgressView().tint(ZenjiTokens.accent)
+                Text("Tenker …")
+                    .font(.zenjiMono(size: 13))
+                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.7))
+            }
+        }
+        if let error = viewModel.errorMessage {
+            Text(error)
+                .font(.zenjiMono(size: 13))
+                .foregroundStyle(ZenjiTokens.diffRemove)
+        }
+        if let notice = viewModel.notice {
+            Text(notice)
+                .font(.zenjiMono(size: 13))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+        }
+    }
+
+    // MARK: - Proposed mutations (the DIFF)
+
+    private var proposalsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                sectionTitle("FORESLÅTTE ENDRINGER")
+                Spacer()
+                if viewModel.pending.count > 1 {
+                    Button("Bekreft alle") { viewModel.confirmAll() }
+                        .font(.zenjiMono(size: 12, weight: .bold))
+                        .foregroundStyle(ZenjiTokens.diffAdd)
+                }
+            }
+            ForEach(viewModel.pending) { mutation in
+                proposalRow(mutation)
+            }
+        }
+    }
+
+    private func proposalRow(_ mutation: GroundedMutation) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(sign(for: mutation.kind))
+                    .font(.zenjiMono(size: 16, weight: .bold))
+                    .foregroundStyle(color(for: mutation.kind))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(mutation.entity.name)
+                        .font(.zenjiMono(size: 15, weight: .bold))
+                    Text(subtitle(for: mutation))
+                        .font(.zenjiMono(size: 12))
+                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                }
+            }
+            Text(mutation.reason)
+                .font(.zenjiMono(size: 12))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.75))
+            HStack(spacing: 10) {
+                Button("Bekreft") { viewModel.confirm(mutation) }
+                    .font(.zenjiMono(size: 13, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.diffAdd)
+                Button("Avvis") { viewModel.reject(mutation) }
+                    .font(.zenjiMono(size: 13))
+                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color(for: mutation.kind).opacity(0.08))
+        .overlay(Rectangle().stroke(color(for: mutation.kind).opacity(0.4), lineWidth: 1))
+    }
+
+    private func subtitle(for mutation: GroundedMutation) -> String {
+        var parts = [SportVocabulary.display(for: mutation.entity.sport)]
+        if let scope = mutation.scope, !scope.isEmpty { parts.append(scope) }
+        if mutation.kind != .remove { parts.append("vekt \(weightLabel(mutation.weight))") }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Rejections (grounding failures)
+
+    private var rejectionsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionTitle("IKKE FUNNET")
+            ForEach(viewModel.rejected) { rejection in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(rejection.explanation)
+                        .font(.zenjiMono(size: 13))
+                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                    if !rejection.suggestions.isEmpty {
+                        FlowRow(rejection.suggestions.map(\.name))
+                    }
+                    Button("OK") { viewModel.dismissRejection(rejection) }
+                        .font(.zenjiMono(size: 12))
+                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(ZenjiTokens.diffRemove.opacity(0.06))
+                .overlay(Rectangle().stroke(ZenjiTokens.diffRemove.opacity(0.3), lineWidth: 1))
+            }
+        }
+    }
+
+    // MARK: - Profile ("Hva jeg følger")
+
+    private var profileSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionTitle("HVA JEG FØLGER")
+            if viewModel.profile.isEmpty {
+                Text("Ingenting ennå. Skriv en ytring over for å begynne.")
+                    .font(.zenjiMono(size: 13))
+                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.55))
+            } else {
+                ForEach(viewModel.profile.rules) { rule in
+                    ruleRow(rule)
+                }
+            }
+        }
+    }
+
+    private func ruleRow(_ rule: InterestRule) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(rule.entityName)
+                    .font(.zenjiMono(size: 14, weight: .bold))
+                Spacer()
+                Button("Fjern") { viewModel.removeRule(rule) }
+                    .font(.zenjiMono(size: 12))
+                    .foregroundStyle(ZenjiTokens.diffRemove.opacity(0.8))
+            }
+            Text(ruleSubtitle(rule))
+                .font(.zenjiMono(size: 12))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+            Text(rule.reason)
+                .font(.zenjiMono(size: 11))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+        }
+        .padding(.vertical, 8)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(ZenjiTokens.foreground.opacity(0.1)).frame(height: 1)
+        }
+    }
+
+    private func ruleSubtitle(_ rule: InterestRule) -> String {
+        var parts = [SportVocabulary.display(for: rule.sport)]
+        if let scope = rule.scope, !scope.isEmpty { parts.append(scope) }
+        parts.append("vekt \(weightLabel(rule.weight))")
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Examples
+
+    private var examplesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionTitle("PRØV")
+            ForEach(Self.examples, id: \.self) { example in
+                Button {
+                    viewModel.utterance = example
+                    inputFocused = true
+                } label: {
+                    Text("› \(example)")
+                        .font(.zenjiMono(size: 12))
+                        .foregroundStyle(ZenjiTokens.accent.opacity(0.8))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    // MARK: - Small helpers
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(text)
+            .font(.zenjiMono(size: 12, weight: .bold))
+            .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+            .tracking(1.5)
+    }
+
+    private func sign(for kind: MutationKind) -> String {
+        switch kind {
+        case .add: return "+"
+        case .update: return "±"
+        case .remove: return "−"
+        }
+    }
+
+    private func color(for kind: MutationKind) -> Color {
+        switch kind {
+        case .add: return ZenjiTokens.diffAdd
+        case .update: return ZenjiTokens.accent
+        case .remove: return ZenjiTokens.diffRemove
+        }
+    }
+
+    private func weightLabel(_ weight: Double) -> String {
+        String(format: "%.1f", weight)
+    }
+}
+
+/// A tiny wrapping row of quiet suggestion chips (the "mente du …?" names).
+private struct FlowRow: View {
+    let items: [String]
+    init(_ items: [String]) { self.items = items }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(items, id: \.self) { item in
+                Text("· \(item)")
+                    .font(.zenjiMono(size: 12))
+                    .foregroundStyle(ZenjiTokens.accent.opacity(0.85))
+            }
+        }
+    }
+}
+
+#Preview {
+    // Preview uses the deterministic mock so it renders without Apple Intelligence.
+    let index = EntityIndex([
+        Entity(id: "casper-ruud", name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis", type: "athlete"),
+        Entity(id: "magnus-carlsen", name: "Magnus Carlsen", aliases: [], sport: "chess", type: "athlete")
+    ])
+    return AssistantView(viewModel: AssistantViewModel(
+        assistant: MockInterestAssistant(),
+        profileStore: ProfileStore(directory: FileManager.default.temporaryDirectory.appendingPathComponent("zenji-preview")),
+        index: index
+    ))
+}

--- a/ios/Zenji/Assistant/AssistantViewModel.swift
+++ b/ios/Zenji/Assistant/AssistantViewModel.swift
@@ -1,0 +1,150 @@
+//
+//  AssistantViewModel.swift
+//  Zenji
+//
+//  WP-16 — the FM-lekegrind's view model. Orchestrates the one flow the screen
+//  needs: utterance → model proposal → HARD grounding → a reviewable DIFF the
+//  user confirms/rejects per mutation → persisted profile. Follows the app's
+//  usual @MainActor @Observable pattern (AgendaViewModel); the genuinely
+//  logic-bearing steps it calls are all pure and separately tested
+//  (`MockInterestParser`, `MutationGrounder`, `InterestProfile.applying`,
+//  `ProfileStore`), so this type is a thin, testable coordinator rather than a
+//  place logic hides.
+//
+//  It depends only on the `InterestAssistant` PROTOCOL, so AssistantViewModel
+//  Tests inject `MockInterestAssistant` (FM can't run in CI) and the shipping
+//  app injects `FoundationModelsInterestAssistant` — the code path is identical.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AssistantViewModel {
+    /// Whether the on-device model can be used — drives the honest "off" banner.
+    private(set) var availability: AssistantAvailability
+    /// The current, persisted profile ("Hva jeg følger").
+    private(set) var profile: InterestProfile
+    /// Grounded mutations awaiting the user's Bekreft/Avvis.
+    private(set) var pending: [GroundedMutation] = []
+    /// Proposals rejected by grounding — shown as honest "fant ikke …" notes.
+    private(set) var rejected: [RejectedMutation] = []
+
+    /// Bound to the text field.
+    var utterance: String = ""
+    private(set) var isThinking = false
+    /// A blocking error (model unavailable / generation failed) shown verbatim.
+    private(set) var errorMessage: String?
+    /// A calm, non-error note, e.g. "Fant ingen endringer i det du skrev."
+    private(set) var notice: String?
+
+    private let assistant: any InterestAssistant
+    private let profileStore: ProfileStore
+    private let index: EntityIndex
+
+    /// Designated initializer — everything injected, for tests + previews.
+    init(assistant: any InterestAssistant, profileStore: ProfileStore, index: EntityIndex) {
+        self.assistant = assistant
+        self.profileStore = profileStore
+        self.index = index
+        self.profile = profileStore.load()
+        self.availability = assistant.availability()
+    }
+
+    /// App wiring: the real FM assistant + the on-disk profile + the synced
+    /// entity index from the WP-12 cache.
+    convenience init(
+        dataStore: DataStore = DataStore(),
+        assistant: any InterestAssistant = FoundationModelsInterestAssistant(),
+        profileStore: ProfileStore = ProfileStore()
+    ) {
+        self.init(assistant: assistant, profileStore: profileStore, index: EntityIndex(dataStore.loadEntities()))
+    }
+
+    /// The entity index arrived (has been synced)? Used to warn honestly when
+    /// nothing can be grounded because the index hasn't downloaded yet.
+    var hasEntities: Bool { !index.isEmpty }
+
+    /// Re-reads availability (the model can become ready after app start, or the
+    /// user can toggle Apple Intelligence in Settings while the sheet is open).
+    func refreshAvailability() {
+        availability = assistant.availability()
+    }
+
+    /// Runs one utterance through the model + grounding. Never throws — a
+    /// failure lands in `errorMessage`, an empty result in `notice`.
+    func submit() async {
+        let text = utterance.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        errorMessage = nil
+        notice = nil
+        pending = []
+        rejected = []
+        isThinking = true
+        defer { isThinking = false }
+
+        do {
+            let proposals = try await assistant.propose(utterance: text, profile: profile, index: index)
+            let result = MutationGrounder.ground(proposals, index: index, profile: profile)
+            pending = result.grounded
+            rejected = result.rejected
+            if result.isEmpty {
+                notice = hasEntities
+                    ? "Fant ingen endringer i det du skrev."
+                    : "Har ikke lastet ned hva du kan følge ennå — prøv igjen om litt."
+            }
+        } catch let error as AssistantError {
+            errorMessage = error.errorDescription
+        } catch {
+            errorMessage = "Noe gikk galt: \(error.localizedDescription)"
+        }
+    }
+
+    /// Confirms a single mutation — applies it to the profile and persists.
+    func confirm(_ mutation: GroundedMutation) {
+        profile = profile.applying(mutation)
+        persist()
+        pending.removeAll { $0.id == mutation.id }
+    }
+
+    /// Confirms every pending mutation at once.
+    func confirmAll() {
+        guard !pending.isEmpty else { return }
+        profile = profile.applying(pending)
+        persist()
+        pending = []
+    }
+
+    /// Discards a proposed mutation without touching the profile.
+    func reject(_ mutation: GroundedMutation) {
+        pending.removeAll { $0.id == mutation.id }
+    }
+
+    func dismissRejection(_ rejection: RejectedMutation) {
+        rejected.removeAll { $0.id == rejection.id }
+    }
+
+    /// Directly unfollow an existing rule from the "Hva jeg følger" list.
+    func removeRule(_ rule: InterestRule) {
+        if let entity = index.entity(id: rule.entityId) {
+            profile = profile.applying(GroundedMutation(
+                kind: .remove, entity: entity, scope: nil, weight: rule.weight,
+                reason: "Fjernet manuelt.", previousRule: rule
+            ))
+        } else {
+            // Entity dropped out of the index — remove the rule directly.
+            profile = InterestProfile(rules: profile.rules.filter { $0.entityId != rule.entityId })
+        }
+        persist()
+    }
+
+    private func persist() {
+        do {
+            try profileStore.save(profile)
+        } catch {
+            errorMessage = "Klarte ikke å lagre profilen din."
+        }
+    }
+}

--- a/ios/Zenji/Assistant/EntityIndex.swift
+++ b/ios/Zenji/Assistant/EntityIndex.swift
@@ -1,0 +1,248 @@
+//
+//  EntityIndex.swift
+//  Zenji
+//
+//  WP-16 — the grounding substrate. A read-only wrapper around the WP-05
+//  entity list (docs/data/entities.json, loaded via DataStore.loadEntities())
+//  that answers three questions the FM-lekegrind needs:
+//
+//    • entity(id:)          exact lookup — the HARD grounding gate. A mutation
+//                           is accepted ONLY if its entityId resolves here.
+//    • search(_:)           free-text search backing the model's searchEntities
+//                           tool (name/alias/id/sport, with Norwegian sport-word
+//                           expansion so "tennis"/"sykkel" find their entities).
+//    • nearestMatches(to:)  fuzzy lookup for a FAILED grounding — the "mente du
+//                           …?" suggestions. String-similarity only (no sport
+//                           expansion), so a typo ("Hovlan") suggests "Hovland"
+//                           but a genuinely-absent sport ("cricket") suggests
+//                           nothing rather than a misleading near-match.
+//
+//  detectEntities(in:) is the MOCK's utterance→entity matcher (see
+//  MockInterestAssistant); it is deliberately NOT part of grounding — grounding
+//  only ever trusts an exact `entityId`.
+//
+//  All matching routes through TextMatch (WP-13) for diacritic-folded,
+//  word-boundary comparison, so "Barça" ≡ "Barca" and "Lyn" ≠ "Brooklyn" here
+//  exactly as everywhere else in the app.
+//
+
+import Foundation
+
+struct EntityIndex: Sendable {
+    let entities: [Entity]
+    private let byId: [String: Entity]
+
+    init(_ entities: [Entity]) {
+        self.entities = entities
+        self.byId = Dictionary(entities.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    // MARK: - Exact lookup (the grounding gate)
+
+    func entity(id: String) -> Entity? { byId[id] }
+
+    var isEmpty: Bool { entities.isEmpty }
+
+    // MARK: - Tool-facing search
+
+    /// Free-text search for the `searchEntities` tool. Ranks by name/alias/id
+    /// containment, with Norwegian sport-keyword expansion (a bare "tennis" or
+    /// "sykkel" returns that sport's entities). Deterministic order so the tool
+    /// output — and therefore the model's grounding — is reproducible.
+    func search(_ query: String, limit: Int = 8) -> [Entity] {
+        let q = TextMatch.normalize(query)
+        guard !q.isEmpty else { return [] }
+        let sportFromQuery = Self.sportKeyword(in: query)
+
+        var scored: [(Entity, Int)] = []
+        for e in entities {
+            var score = 0
+            if e.id == q { score = 100 }
+            for term in [e.name] + e.aliases {
+                if TextMatch.containsName(query, term) { score = max(score, 75) }
+                if TextMatch.containsName(term, query) { score = max(score, 70) }
+                if TextMatch.normalize(term).contains(q) { score = max(score, 45) }
+            }
+            if let sport = sportFromQuery, e.sport == sport { score = max(score, 50) }
+            if score > 0 { scored.append((e, score)) }
+        }
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+                return lhs.0.name < rhs.0.name
+            }
+            .prefix(limit)
+            .map { $0.0 }
+    }
+
+    // MARK: - Fuzzy nearest (failed-grounding suggestions)
+
+    /// Nearest real entities for a phrase that did NOT ground — string
+    /// similarity only, so it never fabricates a sport-level suggestion. Empty
+    /// when nothing is genuinely close (the correct answer for "cricket").
+    func nearestMatches(to query: String, limit: Int = 3) -> [Entity] {
+        let q = TextMatch.normalize(query)
+        guard !q.isEmpty else { return [] }
+
+        var scored: [(Entity, Int)] = []
+        for e in entities {
+            var best = 0
+            let terms = [e.name] + e.aliases + [e.id.replacingOccurrences(of: "-", with: " ")]
+            for term in terms {
+                best = max(best, Self.similarity(q, TextMatch.normalize(term)))
+            }
+            if best >= 55 { scored.append((e, best)) }
+        }
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+                return lhs.0.name < rhs.0.name
+            }
+            .prefix(limit)
+            .map { $0.0 }
+    }
+
+    // MARK: - Mock utterance detection (NOT grounding)
+
+    /// Entities an utterance mentions, for the mock parser. Two signals:
+    /// (3) the whole name/alias appears as words in the utterance
+    /// (`containsName`), or (2) every significant token of the name (years and
+    /// parenthetical qualifiers dropped) is present — so a year-suffixed
+    /// tournament name like "Tour de France 2026" still matches "Tour de
+    /// France". Only the highest-confidence tier is returned, so a scope phrase
+    /// ("i OBOS-ligaen") never competes with the real target ("Lyn").
+    func detectEntities(in utterance: String) -> [Entity] {
+        let hayTokens = Set(Self.tokens(utterance))
+        var scored: [(Entity, Int)] = []
+        for e in entities {
+            var score = 0
+            for term in [e.name] + e.aliases {
+                if TextMatch.containsName(utterance, term) { score = max(score, 3) }
+                let sig = Set(Self.significantTokens(term))
+                if !sig.isEmpty, sig.isSubset(of: hayTokens) { score = max(score, 2) }
+            }
+            if score > 0 { scored.append((e, score)) }
+        }
+        guard let best = scored.map(\.1).max() else { return [] }
+        var seen = Set<String>()
+        return scored
+            .filter { $0.1 == best }
+            .map { $0.0 }
+            .filter { seen.insert($0.id).inserted }
+            .sorted { $0.name < $1.name }
+    }
+
+    /// A representative entity for a whole-sport command ("mer sykkel", "slutt
+    /// med tennis"). Prefers one already in the profile; otherwise the most
+    /// "headline" entity of that sport (tournament > team > athlete > league).
+    func representativeEntity(forSport sport: String, preferredIn profile: InterestProfile) -> Entity? {
+        if let rule = profile.rules.first(where: { $0.sport == sport }), let e = entity(id: rule.entityId) {
+            return e
+        }
+        let rank: [String: Int] = ["tournament": 0, "team": 1, "athlete": 2, "league": 3]
+        return entities
+            .filter { $0.sport == sport }
+            .sorted { lhs, rhs in
+                let a = rank[lhs.type] ?? 9, b = rank[rhs.type] ?? 9
+                if a != b { return a < b }
+                return lhs.name < rhs.name
+            }
+            .first
+    }
+
+    // MARK: - Tokenisation helpers
+
+    /// Diacritic-folded, lower-cased alphanumeric tokens.
+    static func tokens(_ s: String) -> [String] {
+        TextMatch.normalize(s)
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+    }
+
+    /// Tokens of a name with parenthetical qualifiers and 4-digit years dropped
+    /// — the "meaningful" words to require for a token-overlap match.
+    static func significantTokens(_ s: String) -> [String] {
+        let noParens = s.replacingOccurrences(of: "\\([^)]*\\)", with: " ", options: .regularExpression)
+        return tokens(noParens).filter { !isYear($0) }
+    }
+
+    static func isYear(_ t: String) -> Bool { t.count == 4 && t.allSatisfy(\.isNumber) }
+
+    /// Canonical sport tag for a Norwegian/English keyword found in the query,
+    /// if any (e.g. "sykkel" → "cycling", "sjakk" → "chess").
+    static func sportKeyword(in query: String) -> String? {
+        for token in tokens(query) {
+            if let sport = SportVocabulary.keywordToSport[token] { return sport }
+        }
+        return nil
+    }
+
+    // MARK: - Similarity
+
+    /// 0…100 similarity used only by `nearestMatches`. Cheap, deterministic:
+    /// exact / prefix / substring shortcuts, else a length-normalised
+    /// Levenshtein score.
+    static func similarity(_ a: String, _ b: String) -> Int {
+        if a.isEmpty || b.isEmpty { return 0 }
+        if a == b { return 100 }
+        if b.hasPrefix(a) || a.hasPrefix(b) { return 85 }
+        if b.contains(a) || a.contains(b) { return 70 }
+        let dist = levenshtein(Array(a), Array(b))
+        let maxLen = max(a.count, b.count)
+        let sim = 1.0 - Double(dist) / Double(maxLen)
+        return Int((sim * 100).rounded())
+    }
+
+    private static func levenshtein(_ a: [Character], _ b: [Character]) -> Int {
+        if a.isEmpty { return b.count }
+        if b.isEmpty { return a.count }
+        var prev = Array(0...b.count)
+        var curr = [Int](repeating: 0, count: b.count + 1)
+        for i in 1...a.count {
+            curr[0] = i
+            for j in 1...b.count {
+                let cost = a[i - 1] == b[j - 1] ? 0 : 1
+                curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+            }
+            swap(&prev, &curr)
+        }
+        return prev[b.count]
+    }
+}
+
+extension Entity {
+    /// Memberwise initializer. `Entity` (WP-11) declares a custom `init(from:)`,
+    /// which suppresses Swift's synthesised memberwise init — this restores a
+    /// direct constructor so tests and previews can build entities without
+    /// round-tripping through JSON.
+    init(id: String, name: String, aliases: [String] = [], sport: String, type: String) {
+        self.id = id
+        self.name = name
+        self.aliases = aliases
+        self.sport = sport
+        self.type = type
+    }
+}
+
+/// Norwegian (and English) sport vocabulary — maps free-text keywords to the
+/// canonical English sport tag entities carry, and back to a Norwegian display
+/// word for the assistant's reasons.
+enum SportVocabulary {
+    static let keywordToSport: [String: String] = [
+        "fotball": "football", "football": "football", "soccer": "football",
+        "golf": "golf",
+        "tennis": "tennis",
+        "sjakk": "chess", "chess": "chess",
+        "sykkel": "cycling", "sykling": "cycling", "landeveissykling": "cycling", "cycling": "cycling",
+        "friidrett": "athletics", "athletics": "athletics", "løping": "athletics",
+        "f1": "f1", "formel1": "f1", "formel": "f1", "formula1": "f1", "formula": "f1",
+        "esport": "esports", "esports": "esports", "cs2": "esports", "cs": "esports", "counterstrike": "esports"
+    ]
+
+    static let sportDisplay: [String: String] = [
+        "football": "fotball", "golf": "golf", "tennis": "tennis", "chess": "sjakk",
+        "cycling": "sykkel", "athletics": "friidrett", "f1": "Formel 1", "esports": "CS2/esport"
+    ]
+
+    static func display(for sport: String) -> String { sportDisplay[sport] ?? sport }
+}

--- a/ios/Zenji/Assistant/FoundationModelsInterestAssistant.swift
+++ b/ios/Zenji/Assistant/FoundationModelsInterestAssistant.swift
@@ -1,0 +1,212 @@
+//
+//  FoundationModelsInterestAssistant.swift
+//  Zenji
+//
+//  WP-16 — the REAL model, on-device Apple Intelligence via the FoundationModels
+//  framework (iOS 26+). This is the ONLY file in the app that imports
+//  FoundationModels; everything else (grounding, diff, persistence, UI, tests)
+//  depends solely on the FM-free `InterestAssistant` protocol, so the vendor
+//  surface is confined to one layer (CLAUDE.md's portability principle applied
+//  to the client).
+//
+//  It runs, in practice, only on the physical device (the DeviceDev build): the
+//  Simulator and CI report `SystemLanguageModel.default.availability ==
+//  .unavailable`, which this maps to a calm, honest Norwegian message rather
+//  than a crash or an empty result. The on-device conversations themselves are
+//  verified by a human against the manual checklist in the PR — the automated
+//  tests all run against `MockInterestAssistant`.
+//
+//  How grounding stays airtight even with a free-generating model: the model is
+//  given a `searchEntities` tool over the real index and instructed to only
+//  ever cite ids it returned — but its output is STILL passed through
+//  `MutationGrounder` downstream (AssistantViewModel), which re-checks every id.
+//  A hallucinated id is rejected there, identically to the mock's path.
+//
+
+#if canImport(FoundationModels)
+import Foundation
+import FoundationModels
+
+// MARK: - @Generable output schema
+
+/// One structured mutation the model emits. `action`/`entityId`/`entityQuery`/
+/// `scope`/`weight`/`reason` map straight onto `ProposedMutation`. Kept as
+/// plain `String`/`Double` (no closed enums, no optionals) to keep the generated
+/// schema simple and robust; the conversion below normalises them.
+@Generable
+struct GeneratedMutation {
+    @Guide(description: "Handlingen: 'add' for å begynne å følge, 'remove' for å slutte å følge, 'update' for å endre vekt eller omfang på noe du allerede følger.")
+    var action: String
+
+    @Guide(description: "entityId fra searchEntities-verktøyet. MÅ være en id verktøyet faktisk returnerte — aldri finn på en id. Tom streng hvis du ikke fant noe.")
+    var entityId: String
+
+    @Guide(description: "Ordet eller navnet brukeren brukte, ordrett (f.eks. 'Ruud', 'tennis', 'sykkel').")
+    var entityQuery: String
+
+    @Guide(description: "Valgfri norsk avgrensning, f.eks. 'bare i Grand Slams' eller 'i juli'. Tom streng hvis ingen avgrensning.")
+    var scope: String
+
+    @Guide(description: "Hvor viktig dette er, fra 0 til 1. Bruk 0.5 som standard, høyere hvis brukeren vil prioritere det.")
+    var weight: Double
+
+    @Guide(description: "Kort begrunnelse på norsk for hvorfor denne endringen foreslås. Skal alltid fylles ut.")
+    var reason: String
+}
+
+/// The top-level structure the session generates for a single utterance.
+@Generable
+struct GeneratedMutationList {
+    @Guide(description: "Alle foreslåtte endringer utledet fra ytringen. Tom liste hvis ingenting kan utledes.")
+    var mutations: [GeneratedMutation]
+}
+
+// MARK: - searchEntities tool
+
+/// The grounding tool the model calls to look up real entities. It reads the
+/// live `EntityIndex`, so the model can only ever surface ids that exist —
+/// the first line of defence for the hard grounding rule (the second being
+/// `MutationGrounder`, which re-checks the model's output regardless).
+struct EntitySearchTool: Tool {
+    let name = "searchEntities"
+    let description = "Søk i indeksen over utøvere, lag og turneringer brukeren kan følge. Returnerer ekte entityId-er. Bruk dette FØR du foreslår en mutasjon, og bruk kun id-er herfra."
+
+    let index: EntityIndex
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Navn, lag, turnering eller idrett å søke etter, f.eks. 'Ruud', 'Lyn', 'tennis', 'sykkel'.")
+        var query: String
+    }
+
+    func call(arguments: Arguments) async throws -> String {
+        let hits = index.search(arguments.query, limit: 8)
+        guard !hits.isEmpty else {
+            return "Ingen treff for «\(arguments.query)». Ikke foreslå en mutasjon for dette."
+        }
+        let lines = hits.map { "\($0.id) | \($0.name) | \($0.sport) | \($0.type)" }
+        return "Treff (bruk kolonne 1 som entityId):\n" + lines.joined(separator: "\n")
+    }
+}
+
+// MARK: - The assistant
+
+struct FoundationModelsInterestAssistant: InterestAssistant {
+
+    func availability() -> AssistantAvailability {
+        Self.map(SystemLanguageModel.default.availability)
+    }
+
+    func propose(utterance: String, profile: InterestProfile, index: EntityIndex) async throws -> [ProposedMutation] {
+        let model = SystemLanguageModel.default
+        guard case .available = model.availability else {
+            throw AssistantError.unavailable(message: Self.map(model.availability).message ?? Self.genericUnavailable)
+        }
+
+        let session = LanguageModelSession(
+            model: model,
+            tools: [EntitySearchTool(index: index)],
+            instructions: Self.instructions(profile: profile)
+        )
+
+        do {
+            let response = try await session.respond(to: utterance, generating: GeneratedMutationList.self)
+            return response.content.mutations.compactMap(Self.convert)
+        } catch {
+            throw AssistantError.generationFailed(message: "Klarte ikke å tolke ytringen akkurat nå. Prøv å formulere den enklere.")
+        }
+    }
+
+    // MARK: - Mapping
+
+    static func map(_ availability: SystemLanguageModel.Availability) -> AssistantAvailability {
+        switch availability {
+        case .available:
+            return .available
+        case let .unavailable(reason):
+            return .unavailable(message: message(for: reason))
+        }
+    }
+
+    static func message(for reason: SystemLanguageModel.Availability.UnavailableReason) -> String {
+        switch reason {
+        case .appleIntelligenceNotEnabled:
+            return "Apple Intelligence er slått av. Slå det på i Innstillinger for å bruke assistenten."
+        case .modelNotReady:
+            return "Språkmodellen er ikke lastet ned ennå. Prøv igjen om litt."
+        case .deviceNotEligible:
+            return "Denne enheten støtter ikke Apple Intelligence, så assistenten er ikke tilgjengelig her."
+        @unknown default:
+            return genericUnavailable
+        }
+    }
+
+    static let genericUnavailable = "Assistenten er ikke tilgjengelig akkurat nå."
+
+    /// GeneratedMutation → ProposedMutation. Defensive: an unrecognised action
+    /// falls back to `.add`, an empty scope becomes nil, a non-positive weight
+    /// becomes nil (grounder default). A hallucinated/empty entityId is left as
+    /// is — grounding rejects it downstream with a suggestion.
+    static func convert(_ g: GeneratedMutation) -> ProposedMutation? {
+        let kind: MutationKind
+        switch g.action.lowercased().trimmingCharacters(in: .whitespaces) {
+        case "remove", "fjern", "slutt": kind = .remove
+        case "update", "endre", "oppdater": kind = .update
+        default: kind = .add
+        }
+        let scope = g.scope.trimmingCharacters(in: .whitespacesAndNewlines)
+        let reason = g.reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ProposedMutation(
+            kind: kind,
+            entityId: g.entityId.trimmingCharacters(in: .whitespacesAndNewlines),
+            entityQuery: g.entityQuery.trimmingCharacters(in: .whitespacesAndNewlines),
+            scope: scope.isEmpty ? nil : scope,
+            weight: g.weight > 0 ? min(g.weight, 1.0) : nil,
+            reason: reason.isEmpty ? "Foreslått fra ytringen din." : reason
+        )
+    }
+
+    static func instructions(profile: InterestProfile) -> String {
+        let following: String
+        if profile.rules.isEmpty {
+            following = "Brukeren følger ingenting ennå."
+        } else {
+            following = "Brukeren følger allerede: " + profile.rules.map { rule in
+                rule.scope.map { "\(rule.entityName) (\($0))" } ?? rule.entityName
+            }.joined(separator: ", ") + "."
+        }
+
+        return """
+        Du er en rolig, presis assistent som hjelper en norsk sportsfan å styre hva appen følger.
+        Brukeren skriver på norsk. Gjør om ytringen til en liste med strukturerte mutasjoner.
+
+        REGLER:
+        - Bruk ALLTID verktøyet searchEntities for å finne ekte entityId-er før du foreslår noe.
+        - Foreslå KUN mutasjoner med entityId-er verktøyet returnerte. Aldri finn på id-er eller navn.
+        - Hvis du ikke finner noe som passer, ikke foreslå en mutasjon for det.
+        - «slutt med <idrett>» betyr å fjerne det brukeren allerede følger i den idretten.
+        - Sett en kort, ærlig begrunnelse på norsk i reason på hver mutasjon.
+        - Vær konservativ: foreslå bare det ytringen faktisk ber om.
+
+        \(following)
+        """
+    }
+}
+
+#else
+
+// FoundationModels not importable (e.g. an older SDK) — provide the same type
+// so the app still builds and links; it simply reports unavailable.
+import Foundation
+
+struct FoundationModelsInterestAssistant: InterestAssistant {
+    func availability() -> AssistantAvailability {
+        .unavailable(message: "Apple Intelligence er ikke tilgjengelig i denne byggevarianten.")
+    }
+
+    func propose(utterance: String, profile: InterestProfile, index: EntityIndex) async throws -> [ProposedMutation] {
+        throw AssistantError.unavailable(message: "Apple Intelligence er ikke tilgjengelig i denne byggevarianten.")
+    }
+}
+
+#endif

--- a/ios/Zenji/Assistant/InterestAssistant.swift
+++ b/ios/Zenji/Assistant/InterestAssistant.swift
@@ -1,0 +1,37 @@
+//
+//  InterestAssistant.swift
+//  Zenji
+//
+//  WP-16 — the model-layer protocol. The whole point of putting the model
+//  behind this protocol is portability + testability (the same idea as the
+//  rest of the app's pure-core/thin-shell split, and CLAUDE.md's "vendor
+//  lock-in confined to one layer"): the UI and the grounding/diff/persistence
+//  pipeline depend ONLY on this protocol, never on FoundationModels.
+//
+//    • FoundationModelsInterestAssistant — the real one, on-device Apple
+//      Intelligence (FoundationModels). Only that file imports the framework.
+//    • MockInterestAssistant — a deterministic Norwegian keyword parser used by
+//      the tests (FM can't run in CI) and by SwiftUI previews.
+//
+//  `propose` returns RAW `ProposedMutation`s — deliberately BEFORE grounding.
+//  Grounding (the hard rule) is the caller's job (AssistantViewModel →
+//  MutationGrounder), so it is applied uniformly to real-model and mock output
+//  alike and can be unit-tested in isolation.
+//
+
+import Foundation
+
+protocol InterestAssistant: Sendable {
+    /// Whether the model can actually be used right now. Cheap + synchronous so
+    /// the UI can render an honest "unavailable" state before any request.
+    func availability() -> AssistantAvailability
+
+    /// Turns one Norwegian utterance into raw, ungrounded mutation proposals,
+    /// given the current profile (for context — e.g. which rules a "slutt med
+    /// tennis" would target) and the entity index (the model's searchEntities
+    /// tool reads it; the mock matches against it directly).
+    ///
+    /// Throws `AssistantError.unavailable` if the model isn't usable, or
+    /// `.generationFailed` if a usable model still couldn't produce output.
+    func propose(utterance: String, profile: InterestProfile, index: EntityIndex) async throws -> [ProposedMutation]
+}

--- a/ios/Zenji/Assistant/InterestProfile.swift
+++ b/ios/Zenji/Assistant/InterestProfile.swift
@@ -1,0 +1,134 @@
+//
+//  InterestProfile.swift
+//  Zenji
+//
+//  WP-16 — the local interest profile the FM-lekegrind edits: a flat list of
+//  `InterestRule`s, one per entity. This is the on-device, human-owned mirror
+//  of the "Hva jeg følger" idea — every rule carries an always-filled Norwegian
+//  `reason` (the same transparency contract `tracked.json` uses server-side:
+//  CLAUDE.md "AI decides what to track and writes a defensible reason per
+//  entry"). Persisted as JSON in Application Support by `ProfileStore`.
+//
+//  `applying(_:now:)` is the PURE diff-application core — no I/O, no clock read
+//  (the caller passes `now`) — so `InterestProfileTests` can drive add/update/
+//  remove directly. Add and update are BOTH upserts (insert-or-replace, keyed
+//  on `entityId`): a rule is uniquely identified by its entity, so re-adding an
+//  entity you already follow just refreshes its scope/weight/reason rather than
+//  creating a duplicate.
+//
+
+import Foundation
+
+/// One "follow this" rule. `id == entityId` — one rule per entity.
+struct InterestRule: Codable, Equatable, Identifiable, Sendable {
+    /// The WP-05 stable entity id this rule follows. Doubles as `Identifiable`.
+    var entityId: String
+    /// Cached display name so the UI can render the profile without a second
+    /// entity-index lookup (and so an old rule still reads sensibly if the
+    /// entity later drops out of the index).
+    var entityName: String
+    var sport: String
+    /// Optional Norwegian scope, e.g. "bare i Grand Slams", "i juli".
+    var scope: String?
+    /// Relative importance 0…1 used by future personalisation weighting.
+    var weight: Double
+    /// Always-filled Norwegian rationale.
+    var reason: String
+    var addedAt: Date
+
+    var id: String { entityId }
+
+    private enum CodingKeys: String, CodingKey {
+        case entityId, entityName, sport, scope, weight, reason, addedAt
+    }
+
+    init(entityId: String, entityName: String, sport: String, scope: String? = nil, weight: Double, reason: String, addedAt: Date) {
+        self.entityId = entityId
+        self.entityName = entityName
+        self.sport = sport
+        self.scope = scope
+        self.weight = weight
+        self.reason = reason
+        self.addedAt = addedAt
+    }
+
+    /// Forward-compatible decode (same convention as the WP-11 models): unknown
+    /// keys ignored, missing optionals default, so a profile written by a newer
+    /// build still loads on an older one.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        entityId = try c.decode(String.self, forKey: .entityId)
+        entityName = try c.decodeIfPresent(String.self, forKey: .entityName) ?? entityId
+        sport = try c.decodeIfPresent(String.self, forKey: .sport) ?? ""
+        scope = try c.decodeIfPresent(String.self, forKey: .scope)
+        weight = try c.decodeIfPresent(Double.self, forKey: .weight) ?? InterestProfile.defaultWeight
+        reason = try c.decodeIfPresent(String.self, forKey: .reason) ?? ""
+        addedAt = try c.decodeIfPresent(Date.self, forKey: .addedAt) ?? Date(timeIntervalSince1970: 0)
+    }
+}
+
+struct InterestProfile: Codable, Equatable, Sendable {
+    /// Neutral default weight for a freshly added rule with no explicit weight.
+    static let defaultWeight: Double = 0.5
+
+    var rules: [InterestRule]
+
+    init(rules: [InterestRule] = []) {
+        self.rules = rules
+    }
+
+    private enum CodingKeys: String, CodingKey { case rules }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        rules = try c.decodeIfPresent([InterestRule].self, forKey: .rules) ?? []
+    }
+
+    func rule(for entityId: String) -> InterestRule? {
+        rules.first { $0.entityId == entityId }
+    }
+
+    var isEmpty: Bool { rules.isEmpty }
+
+    /// Applies one grounded mutation, returning a NEW profile (value semantics —
+    /// nothing here mutates in place). Add/update upsert; remove drops the rule
+    /// if present and is otherwise a no-op. Rules are kept sorted by
+    /// (sport, entityName) so the "Hva jeg følger" list is stable and the type
+    /// stays value-comparable regardless of insertion order.
+    func applying(_ mutation: GroundedMutation, now: Date = Date()) -> InterestProfile {
+        var next = rules
+        let entityId = mutation.entity.id
+
+        switch mutation.kind {
+        case .remove:
+            next.removeAll { $0.entityId == entityId }
+
+        case .add, .update:
+            let existing = next.first { $0.entityId == entityId }
+            let rule = InterestRule(
+                entityId: entityId,
+                entityName: mutation.entity.name,
+                sport: mutation.entity.sport,
+                scope: mutation.scope,
+                weight: mutation.weight,
+                reason: mutation.reason,
+                // Preserve the original addedAt on an update; stamp now on a
+                // genuine first add.
+                addedAt: existing?.addedAt ?? now
+            )
+            next.removeAll { $0.entityId == entityId }
+            next.append(rule)
+        }
+
+        next.sort { lhs, rhs in
+            if lhs.sport != rhs.sport { return lhs.sport < rhs.sport }
+            return lhs.entityName.localizedCaseInsensitiveCompare(rhs.entityName) == .orderedAscending
+        }
+        return InterestProfile(rules: next)
+    }
+
+    /// Convenience: fold a whole batch of confirmed mutations in one call.
+    func applying(_ mutations: [GroundedMutation], now: Date = Date()) -> InterestProfile {
+        mutations.reduce(self) { $0.applying($1, now: now) }
+    }
+}

--- a/ios/Zenji/Assistant/MockInterestAssistant.swift
+++ b/ios/Zenji/Assistant/MockInterestAssistant.swift
@@ -1,0 +1,231 @@
+//
+//  MockInterestAssistant.swift
+//  Zenji
+//
+//  WP-16 — the FM-free stand-in for the on-device model. Apple Intelligence
+//  cannot run in CI (or on the Simulator), so every test drives THIS instead of
+//  FoundationModels: a deterministic Norwegian keyword parser that turns an
+//  utterance into the same `ProposedMutation`s the real model is asked to
+//  produce. It also backs SwiftUI previews. It is NOT wired in as a silent
+//  fallback for the shipping app — when Apple Intelligence is off the app shows
+//  an honest "unavailable" message rather than quietly degrading to keywords
+//  (per the brief).
+//
+//  The parser is intentionally small and rule-based (verbs → intent, entity
+//  index → targets, a couple of phrase patterns → scope) — enough to exercise
+//  the whole grounding/diff/persistence pipeline against the ten canonical
+//  utterances, not a general NLU. Entity RESOLUTION still goes through the
+//  index (so the mock can only "find" real entities, exactly like the tool-
+//  using model), and grounding re-checks everything downstream regardless.
+//
+
+import Foundation
+
+struct MockInterestAssistant: InterestAssistant {
+
+    enum Behavior: Sendable, Equatable {
+        case available
+        /// Simulates Apple Intelligence being off / the model not loaded, so
+        /// the UI's honest "unavailable" path can be tested without a device.
+        case unavailable(String)
+    }
+
+    let behavior: Behavior
+
+    init(behavior: Behavior = .available) {
+        self.behavior = behavior
+    }
+
+    func availability() -> AssistantAvailability {
+        switch behavior {
+        case .available: return .available
+        case let .unavailable(message): return .unavailable(message: message)
+        }
+    }
+
+    func propose(utterance: String, profile: InterestProfile, index: EntityIndex) async throws -> [ProposedMutation] {
+        if case let .unavailable(message) = behavior {
+            throw AssistantError.unavailable(message: message)
+        }
+        return MockInterestParser.parse(utterance: utterance, profile: profile, index: index)
+    }
+}
+
+/// The deterministic parse, exposed as a static pure function so tests can call
+/// it directly (synchronously) as well as through the async protocol.
+enum MockInterestParser {
+
+    enum Intent: Equatable {
+        case add
+        case increase
+        case decrease
+        case remove
+    }
+
+    static func parse(utterance: String, profile: InterestProfile, index: EntityIndex) -> [ProposedMutation] {
+        let trimmed = utterance.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let intent = detectIntent(trimmed)
+        let scope = extractScope(from: trimmed)
+        let weight = weight(for: intent)
+
+        // 1) An explicit entity mention always wins.
+        let matched = index.detectEntities(in: trimmed)
+        if !matched.isEmpty {
+            return matched.map { entity in
+                let effectiveScope = intent == .remove ? nil : scope
+                return ProposedMutation(
+                    kind: kind(for: intent),
+                    entityId: entity.id,
+                    entityQuery: entity.name,
+                    scope: effectiveScope,
+                    weight: weight,
+                    reason: entityReason(intent: intent, name: entity.name, scope: effectiveScope)
+                )
+            }
+        }
+
+        // 2) A whole-sport command ("mer sykkel", "slutt med tennis").
+        if let sport = EntityIndex.sportKeyword(in: trimmed) {
+            return sportProposals(intent: intent, sport: sport, scope: scope, weight: weight, profile: profile, index: index)
+        }
+
+        // 3) Nothing recognised → one unresolved proposal; grounding rejects it
+        //    with a "mente du …?" suggestion. This is how free-text entities are
+        //    caught rather than invented.
+        let query = residualQuery(trimmed)
+        guard !query.isEmpty else { return [] }
+        return [ProposedMutation(
+            kind: kind(for: intent),
+            entityId: "",
+            entityQuery: query,
+            scope: intent == .remove ? nil : scope,
+            weight: weight,
+            reason: "Klarte ikke å knytte «\(query)» til noe i indeksen."
+        )]
+    }
+
+    // MARK: - Sport-level commands
+
+    private static func sportProposals(intent: Intent, sport: String, scope: String?, weight: Double?, profile: InterestProfile, index: EntityIndex) -> [ProposedMutation] {
+        let display = SportVocabulary.display(for: sport)
+
+        switch intent {
+        case .remove:
+            // Drop every rule the profile currently holds for this sport.
+            return profile.rules
+                .filter { $0.sport == sport }
+                .compactMap { rule in
+                    guard let entity = index.entity(id: rule.entityId) else { return nil }
+                    return ProposedMutation(
+                        kind: .remove,
+                        entityId: entity.id,
+                        entityQuery: display,
+                        reason: "Du ba om å slutte med \(display) — fjerner \(entity.name)."
+                    )
+                }
+
+        case .add, .increase, .decrease:
+            guard let entity = index.representativeEntity(forSport: sport, preferredIn: profile) else { return [] }
+            return [ProposedMutation(
+                kind: kind(for: intent),
+                entityId: entity.id,
+                entityQuery: display,
+                scope: scope,
+                weight: weight,
+                reason: sportReason(intent: intent, display: display, entityName: entity.name, scope: scope)
+            )]
+        }
+    }
+
+    // MARK: - Intent / weight / kind
+
+    static func detectIntent(_ utterance: String) -> Intent {
+        let n = " " + TextMatch.normalize(utterance) + " "
+        func has(_ needles: [String]) -> Bool { needles.contains { n.contains($0) } }
+
+        if has([" slutt", " fjern", " stopp", " dropp", " glem", " avfølg", " ikke følg"]) { return .remove }
+        // Decrease BEFORE increase: "nedprioriter" contains "prioriter".
+        if has([" mindre", " lavere", " nedprioriter", " senk", " sjeldnere"]) { return .decrease }
+        if has([" mer ", " prioriter", " høyere", " viktigere", " øk", " mest ", " oftere"]) { return .increase }
+        return .add
+    }
+
+    static func kind(for intent: Intent) -> MutationKind {
+        switch intent {
+        case .add: return .add
+        case .increase, .decrease: return .update
+        case .remove: return .remove
+        }
+    }
+
+    static func weight(for intent: Intent) -> Double? {
+        switch intent {
+        case .add, .remove: return nil        // grounder applies the default
+        case .increase: return 0.8
+        case .decrease: return 0.3
+        }
+    }
+
+    // MARK: - Scope extraction
+
+    static func extractScope(from utterance: String) -> String? {
+        // "bare …" / "kun …" — from that word to the end, original casing.
+        if let match = firstRegexRange(utterance, "(?i)\\b(bare|kun)\\b.*$") {
+            return match
+        }
+        // "… i <rest>" → keep as "i <rest>".
+        if let match = firstRegexRange(utterance, "(?i)(?:^|\\s)i\\s+\\S.*$") {
+            return match
+        }
+        // "under <rest>".
+        if let match = firstRegexRange(utterance, "(?i)\\bunder\\b.*$") {
+            return match
+        }
+        return nil
+    }
+
+    private static func firstRegexRange(_ s: String, _ pattern: String) -> String? {
+        guard let r = s.range(of: pattern, options: .regularExpression) else { return nil }
+        let out = s[r].trimmingCharacters(in: .whitespacesAndNewlines)
+        return out.isEmpty ? nil : out
+    }
+
+    // MARK: - Residual (unresolved) query
+
+    static let stopwords: Set<String> = [
+        "følg", "følge", "følger", "legg", "til", "vis", "meg", "spor", "start", "begynn", "se",
+        "slutt", "slutte", "slutter", "med", "fjern", "stopp", "dropp", "ikke", "glem", "avfølg",
+        "mer", "mindre", "prioriter", "prioritere", "høyere", "lavere", "øk", "øke", "senk",
+        "viktigere", "mest", "oftere", "sjeldnere", "opp", "ned", "nedprioriter",
+        "bare", "kun", "i", "under", "på", "av", "og", "en", "et", "den", "de", "litt", "mye", "også"
+    ]
+
+    static func residualQuery(_ utterance: String) -> String {
+        EntityIndex.tokens(utterance)
+            .filter { !stopwords.contains($0) && !EntityIndex.isYear($0) }
+            .joined(separator: " ")
+    }
+
+    // MARK: - Norwegian reason text (always filled)
+
+    static func entityReason(intent: Intent, name: String, scope: String?) -> String {
+        let s = scope.map { " (\($0))" } ?? ""
+        switch intent {
+        case .add: return "Du ba om å følge \(name)\(s)."
+        case .increase: return "Du ba om å prioritere \(name) høyere\(s)."
+        case .decrease: return "Du ba om å nedprioritere \(name)\(s)."
+        case .remove: return "Du ba om å slutte å følge \(name)."
+        }
+    }
+
+    static func sportReason(intent: Intent, display: String, entityName: String, scope: String?) -> String {
+        let s = scope.map { " \($0)" } ?? ""
+        switch intent {
+        case .add, .increase: return "Du vil se mer \(display)\(s). Legger til \(entityName)."
+        case .decrease: return "Du vil se mindre \(display). Nedprioriterer \(entityName)."
+        case .remove: return "Du ba om å slutte med \(display)."
+        }
+    }
+}

--- a/ios/Zenji/Assistant/MutationGrounder.swift
+++ b/ios/Zenji/Assistant/MutationGrounder.swift
@@ -1,0 +1,89 @@
+//
+//  MutationGrounder.swift
+//  Zenji
+//
+//  WP-16 — THE HARD RULE, in one pure function. Every proposal the model makes
+//  is checked against the entity index here before it can touch the profile: a
+//  proposal is accepted ONLY if its `entityId` resolves to a real entity. A
+//  free-text entity the model invented (or an id it hallucinated despite the
+//  searchEntities tool) is rejected — never applied — with a calm Norwegian
+//  explanation and up to three nearest-match suggestions ("fant ikke «X» i
+//  indeksen — mente du …?"). This is the guarantee the whole feature rests on:
+//  the model can phrase things freely, but it can only ever change rules about
+//  entities that actually exist.
+//
+//  Pure and side-effect-free (index + profile in, GroundingResult out) so
+//  MutationGrounderTests can prove both the accept and the reject path with no
+//  model, no disk, no UI.
+//
+
+import Foundation
+
+enum MutationGrounder {
+
+    /// Grounds a batch of raw proposals against `index`, using `profile` only to
+    /// attach the existing rule (for the DIFF's before/after) and to inherit a
+    /// weight/scope an update leaves unspecified.
+    static func ground(_ proposals: [ProposedMutation], index: EntityIndex, profile: InterestProfile) -> GroundingResult {
+        var grounded: [GroundedMutation] = []
+        var rejected: [RejectedMutation] = []
+
+        for proposal in proposals {
+            // THE gate: the claimed entityId must exist in the index, verbatim.
+            guard let entity = index.entity(id: proposal.entityId) else {
+                rejected.append(reject(proposal, index: index))
+                continue
+            }
+
+            let previous = profile.rule(for: entity.id)
+            let weight = proposal.weight
+                ?? previous?.weight
+                ?? InterestProfile.defaultWeight
+            // An update with no new scope keeps the existing one; an add uses
+            // whatever it was given (possibly nil = no scope).
+            let scope: String?
+            switch proposal.kind {
+            case .update:
+                scope = proposal.scope ?? previous?.scope
+            case .add, .remove:
+                scope = proposal.scope
+            }
+
+            grounded.append(GroundedMutation(
+                kind: proposal.kind,
+                entity: entity,
+                scope: scope,
+                weight: weight,
+                reason: proposal.reason,
+                previousRule: previous
+            ))
+        }
+
+        return GroundingResult(grounded: grounded, rejected: rejected)
+    }
+
+    // MARK: - Rejection
+
+    private static func reject(_ proposal: ProposedMutation, index: EntityIndex) -> RejectedMutation {
+        let query = proposal.entityQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? proposal.entityId
+            : proposal.entityQuery
+        let suggestions = index.nearestMatches(to: query)
+        return RejectedMutation(
+            query: query,
+            explanation: rejectionText(query: query, suggestions: suggestions),
+            suggestions: suggestions
+        )
+    }
+
+    /// The Norwegian rejection message — with a "mente du …?" tail only when
+    /// there is a genuine near-match to offer.
+    static func rejectionText(query: String, suggestions: [Entity]) -> String {
+        let subject = query.isEmpty ? "det" : "«\(query)»"
+        if suggestions.isEmpty {
+            return "Fant ikke \(subject) i indeksen over det du kan følge. Prøv et navn eller en turnering jeg kjenner."
+        }
+        let names = suggestions.map { $0.name }.joined(separator: ", ")
+        return "Fant ikke \(subject) i indeksen — mente du: \(names)?"
+    }
+}

--- a/ios/Zenji/Assistant/ProfileStore.swift
+++ b/ios/Zenji/Assistant/ProfileStore.swift
@@ -1,0 +1,71 @@
+//
+//  ProfileStore.swift
+//  Zenji
+//
+//  WP-16 — local persistence for the interest profile. A single JSON file in
+//  Application Support (the "enkleste robuste" option from the brief — no
+//  SwiftData ceremony for one small user-owned document, and no App Group
+//  needed, which matters for the free-account DeviceDev build where App Groups
+//  are unavailable). Same robustness contract as WP-12's DataStore: `load()`
+//  never throws — a missing or corrupt file is an empty profile, not a crash —
+//  while `save(_:)` writes atomically so a crash mid-write can't corrupt it.
+//
+//  The directory is injectable (defaults to Application Support/ZenjiProfile)
+//  so ProfileStoreTests can round-trip through a throwaway temp directory
+//  instead of this process's real container.
+//
+
+import Foundation
+
+struct ProfileStore: Sendable {
+    static let filename = "interest-profile.json"
+
+    let directoryURL: URL
+
+    /// Default location: `Application Support/ZenjiProfile/`. Falls back to the
+    /// temporary directory if Application Support can't be resolved (never nil).
+    init(fileManager: FileManager = .default) {
+        let base = (try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true))
+            ?? fileManager.temporaryDirectory
+        self.init(directory: base.appendingPathComponent("ZenjiProfile", isDirectory: true))
+    }
+
+    /// Explicit-directory initializer — tests use this for an isolated,
+    /// throwaway location.
+    init(directory: URL) {
+        self.directoryURL = directory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    private var fileURL: URL { directoryURL.appendingPathComponent(Self.filename) }
+
+    /// Reads the persisted profile. Never throws — an absent or unreadable file
+    /// is a fresh, empty profile.
+    func load() -> InterestProfile {
+        guard let data = try? Data(contentsOf: fileURL) else { return InterestProfile() }
+        return (try? Self.decoder.decode(InterestProfile.self, from: data)) ?? InterestProfile()
+    }
+
+    /// Persists atomically. Throws only on a genuine write failure (disk full,
+    /// permissions) — callers may surface that, but the in-memory profile is
+    /// unaffected either way.
+    func save(_ profile: InterestProfile) throws {
+        let data = try Self.encoder.encode(profile)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    // MARK: - Codec (ISO 8601 dates, matching the rest of the app)
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+}

--- a/ios/Zenji/ContentView.swift
+++ b/ios/Zenji/ContentView.swift
@@ -27,6 +27,8 @@ struct ContentView: View {
 
     @State private var viewModel: AgendaViewModel
     @State private var now = Date()
+    /// WP-16: the FM-lekegrind, reached from the header glyph below.
+    @State private var showingAssistant = false
 
     /// Ticks once a second — the "tikkende klokke-følelse" in the header,
     /// same idea as the web masthead's clock (dashboard.js `startClock`), just
@@ -77,6 +79,9 @@ struct ContentView: View {
             await refresh()
         }
         .onReceive(clock) { now = $0 }
+        .sheet(isPresented: $showingAssistant) {
+            AssistantView()
+        }
     }
 
     /// Loads whatever is already cached immediately (so the agenda isn't
@@ -112,6 +117,15 @@ struct ContentView: View {
                     .foregroundStyle(ZenjiTokens.foreground.opacity(0.7))
             }
             Spacer()
+            Button {
+                showingAssistant = true
+            } label: {
+                Image(systemName: "text.bubble")
+                    .font(.system(size: 15, design: .monospaced))
+                    .foregroundStyle(ZenjiTokens.accent.opacity(0.8))
+            }
+            .accessibilityLabel("Assistent")
+            .padding(.trailing, 12)
             Text(clockLabel)
                 .font(.zenjiMono(size: 13))
                 .monospacedDigit()

--- a/ios/Zenji/DesignTokens.swift
+++ b/ios/Zenji/DesignTokens.swift
@@ -44,6 +44,13 @@ enum ZenjiTokens {
     static var background: Color { .zenji(dark: Dark.background, light: Light.background) }
     /// Body text, adapted to the current system colour scheme.
     static var foreground: Color { .zenji(dark: Dark.foreground, light: Light.foreground) }
+
+    /// DIFF colours for the FM-lekegrind's proposed-change view (WP-16): green
+    /// for add/keep, red for remove, legible on both the near-black and
+    /// warm-paper pages. "Changed" (update) reuses `accent` (amber) so the
+    /// palette stays the one restrained accent + these two signal colours.
+    static var diffAdd: Color { .zenji(dark: Color(hex: 0x3FB950), light: Color(hex: 0x1A7F37)) }
+    static var diffRemove: Color { .zenji(dark: Color(hex: 0xF85149), light: Color(hex: 0xB3261E)) }
 }
 
 extension Color {

--- a/ios/ZenjiDeviceDev/Info.plist
+++ b/ios/ZenjiDeviceDev/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>app.zenji.refresh</string>
+	</array>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>nb</string>
+	<key>CFBundleDisplayName</key>
+	<string>Zenji</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/ios/ZenjiDeviceDev/ZenjiDeviceDev.entitlements
+++ b/ios/ZenjiDeviceDev/ZenjiDeviceDev.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  WP-16 — DELIBERATELY EMPTY. A free personal Apple Developer team cannot
+	  provision App Groups, so the device build declares no entitlements at all;
+	  CacheStore then uses its Application Support fallback and ProfileStore is
+	  Application-Support-only regardless. Local notifications (UNUserNotification
+	  Center) need no entitlement. Flip App Groups / push back on for WP-17
+	  (paid account) — see the Zenji.entitlements sibling.
+	-->
+</dict>
+</plist>

--- a/ios/ZenjiTests/AssistantTestSupport.swift
+++ b/ios/ZenjiTests/AssistantTestSupport.swift
@@ -1,0 +1,28 @@
+//
+//  AssistantTestSupport.swift
+//  ZenjiTests
+//
+//  WP-16 — shared helpers for the FM-lekegrind tests. The entity index is built
+//  from the SAME checked-in `entities.json` fixture the WP-11 decode tests use
+//  (real production entity ids: casper-ruud, fk-lyn-oslo, tour-de-france-2026,
+//  …), so the parser/grounder are proven against real data, not invented ids.
+//  ProfileStore always points at a throwaway temp directory so persistence
+//  round-trips never touch this process's real Application Support.
+//
+
+import Foundation
+
+enum AssistantTestSupport {
+    /// EntityIndex over the real, checked-in entities fixture.
+    static func liveIndex() -> EntityIndex {
+        // swiftlint:disable:next force_try
+        let entities = try! ZenjiJSON.decoder.decode([Entity].self, from: Fixture.data("entities"))
+        return EntityIndex(entities)
+    }
+
+    /// A ProfileStore in a fresh, unique temp directory.
+    static func tempProfileStore() -> ProfileStore {
+        ProfileStore(directory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("zenji-tests-\(UUID().uuidString)", isDirectory: true))
+    }
+}

--- a/ios/ZenjiTests/AssistantViewModelTests.swift
+++ b/ios/ZenjiTests/AssistantViewModelTests.swift
@@ -1,0 +1,114 @@
+//
+//  AssistantViewModelTests.swift
+//  ZenjiTests
+//
+//  WP-16 — end-to-end through the view model with the deterministic mock in
+//  place of Apple Intelligence: utterance → submit → grounded pending → confirm
+//  → applied + persisted, plus the reject, rejected-free-text, and
+//  model-unavailable paths. Proves the pieces wire together the same way the
+//  shipping app runs them (only the assistant differs).
+//
+
+import XCTest
+
+@MainActor
+final class AssistantViewModelTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func makeVM(
+        behavior: MockInterestAssistant.Behavior = .available,
+        store: ProfileStore? = nil
+    ) -> AssistantViewModel {
+        AssistantViewModel(
+            assistant: MockInterestAssistant(behavior: behavior),
+            profileStore: store ?? AssistantTestSupport.tempProfileStore(),
+            index: index
+        )
+    }
+
+    func test_availability_reflectsAssistant() {
+        XCTAssertEqual(makeVM().availability, .available)
+        XCTAssertEqual(makeVM(behavior: .unavailable("av")).availability, .unavailable(message: "av"))
+    }
+
+    func test_submit_groundsIntoPending_withoutApplying() async {
+        let vm = makeVM()
+        vm.utterance = "Følg Casper Ruud bare i Grand Slams"
+        await vm.submit()
+        XCTAssertEqual(vm.pending.map(\.entity.id), ["casper-ruud"])
+        XCTAssertEqual(vm.pending.first?.scope, "bare i Grand Slams")
+        XCTAssertTrue(vm.profile.isEmpty, "nothing is applied until the user confirms")
+    }
+
+    func test_confirm_appliesAndPersists() async {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+        vm.utterance = "Følg Casper Ruud bare i Grand Slams"
+        await vm.submit()
+        vm.confirm(vm.pending[0])
+
+        XCTAssertEqual(vm.profile.rules.map(\.entityId), ["casper-ruud"])
+        XCTAssertTrue(vm.pending.isEmpty)
+
+        // Persisted — a fresh view model over the same store sees it.
+        let reloaded = makeVM(store: store)
+        XCTAssertEqual(reloaded.profile.rule(for: "casper-ruud")?.scope, "bare i Grand Slams")
+    }
+
+    func test_reject_dropsWithoutApplying() async {
+        let vm = makeVM()
+        vm.utterance = "Følg Magnus Carlsen"
+        await vm.submit()
+        vm.reject(vm.pending[0])
+        XCTAssertTrue(vm.pending.isEmpty)
+        XCTAssertTrue(vm.profile.isEmpty)
+    }
+
+    func test_endToEnd_addThenRemoveWholeSport() async {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+
+        vm.utterance = "Følg Casper Ruud bare i Grand Slams"
+        await vm.submit()
+        vm.confirmAll()
+        XCTAssertEqual(vm.profile.rules.map(\.entityId), ["casper-ruud"])
+
+        vm.utterance = "Slutt med tennis"
+        await vm.submit()
+        XCTAssertEqual(vm.pending.map(\.entity.id), ["casper-ruud"])
+        XCTAssertEqual(vm.pending.first?.kind, .remove)
+        vm.confirmAll()
+        XCTAssertTrue(vm.profile.isEmpty)
+    }
+
+    func test_submit_freeTextEntity_isRejected() async {
+        let vm = makeVM()
+        vm.utterance = "Følg cricket"
+        await vm.submit()
+        XCTAssertTrue(vm.pending.isEmpty)
+        XCTAssertEqual(vm.rejected.count, 1)
+        XCTAssertTrue(vm.rejected[0].explanation.contains("cricket"))
+    }
+
+    func test_submit_whenUnavailable_setsErrorMessage() async {
+        let vm = makeVM(behavior: .unavailable("Apple Intelligence er av."))
+        vm.utterance = "Følg Lyn"
+        await vm.submit()
+        XCTAssertEqual(vm.errorMessage, "Apple Intelligence er av.")
+        XCTAssertTrue(vm.pending.isEmpty)
+    }
+
+    func test_removeRule_directlyUnfollows() async {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+        vm.utterance = "Følg Magnus Carlsen"
+        await vm.submit()
+        vm.confirmAll()
+        XCTAssertEqual(vm.profile.rules.count, 1)
+
+        vm.removeRule(vm.profile.rules[0])
+        XCTAssertTrue(vm.profile.isEmpty)
+        XCTAssertTrue(makeVM(store: store).profile.isEmpty, "removal persisted")
+    }
+}

--- a/ios/ZenjiTests/EntityIndexTests.swift
+++ b/ios/ZenjiTests/EntityIndexTests.swift
@@ -1,0 +1,81 @@
+//
+//  EntityIndexTests.swift
+//  ZenjiTests
+//
+//  WP-16 — the grounding substrate's primitives: exact lookup, tool-facing
+//  search (with Norwegian sport-word expansion), fuzzy nearest-match (the
+//  "mente du …?" source), and the mock's utterance→entity detection. Proven
+//  against the real entities.json fixture.
+//
+
+import XCTest
+
+final class EntityIndexTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    func test_exactLookup() {
+        XCTAssertEqual(index.entity(id: "casper-ruud")?.name, "Casper Ruud")
+        XCTAssertNil(index.entity(id: "no-such-id"))
+    }
+
+    func test_search_byNameAndAlias() {
+        XCTAssertTrue(index.search("Ruud").contains { $0.id == "casper-ruud" })
+        XCTAssertTrue(index.search("Hovland").contains { $0.id == "viktor-hovland" })
+        XCTAssertTrue(index.search("Lyn").contains { $0.id == "fk-lyn-oslo" })
+    }
+
+    func test_search_expandsSportKeyword() {
+        let tennis = index.search("tennis").map(\.id)
+        XCTAssertTrue(tennis.contains("casper-ruud"))
+        let sykkel = index.search("sykkel").map(\.id)
+        XCTAssertTrue(sykkel.contains("tour-de-france-2026"))
+    }
+
+    func test_nearestMatches_typo() {
+        let near = index.nearestMatches(to: "Hovlan")
+        XCTAssertEqual(near.first?.id, "viktor-hovland")
+    }
+
+    func test_nearestMatches_absentSport_isEmpty() {
+        XCTAssertTrue(index.nearestMatches(to: "cricket").isEmpty)
+    }
+
+    func test_detectEntities_prefersHighestConfidenceTarget() {
+        // "Lyn" (alias, whole-word) beats "OBOS-ligaen" (token overlap), which is
+        // the scope, not the target.
+        XCTAssertEqual(index.detectEntities(in: "Følg Lyn i OBOS-ligaen").map(\.id), ["fk-lyn-oslo"])
+    }
+
+    func test_detectEntities_yearSuffixedTournament() {
+        XCTAssertEqual(index.detectEntities(in: "Følg Tour de France").map(\.id), ["tour-de-france-2026"])
+    }
+
+    func test_detectEntities_noFalsePositiveOnParentheticalName() {
+        // The athlete matches; the "(Karsten Warholm)"-qualified tournament does not.
+        XCTAssertEqual(index.detectEntities(in: "Følg Karsten Warholm").map(\.id), ["karsten-warholm"])
+    }
+
+    func test_representativeEntity_prefersTournament() {
+        XCTAssertEqual(
+            index.representativeEntity(forSport: "cycling", preferredIn: InterestProfile())?.id,
+            "tour-de-france-2026"
+        )
+    }
+
+    func test_representativeEntity_prefersProfileMember() {
+        let profile = InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: index.entity(id: "uno-x-mobility")!, scope: nil, weight: 0.5, reason: "seed", previousRule: nil
+        ))
+        XCTAssertEqual(
+            index.representativeEntity(forSport: "cycling", preferredIn: profile)?.id,
+            "uno-x-mobility"
+        )
+    }
+
+    func test_sportKeywordDetection() {
+        XCTAssertEqual(EntityIndex.sportKeyword(in: "mer sykkel i juli"), "cycling")
+        XCTAssertEqual(EntityIndex.sportKeyword(in: "slutt med tennis"), "tennis")
+        XCTAssertNil(EntityIndex.sportKeyword(in: "følg cricket"))
+    }
+}

--- a/ios/ZenjiTests/InterestProfileTests.swift
+++ b/ios/ZenjiTests/InterestProfileTests.swift
@@ -1,0 +1,96 @@
+//
+//  InterestProfileTests.swift
+//  ZenjiTests
+//
+//  WP-16 acceptance — diff application on the profile. Add/update are upserts
+//  keyed on entityId (never a duplicate rule per entity); remove drops or
+//  no-ops; addedAt is preserved across an update but stamped on a first add;
+//  the reason is always retained. Pure — no store, no model.
+//
+
+import XCTest
+
+final class InterestProfileTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func entity(_ id: String) -> Entity { index.entity(id: id)! }
+
+    private func add(_ id: String, scope: String? = nil, weight: Double = 0.5, reason: String = "r", now: Date) -> GroundedMutation {
+        GroundedMutation(kind: .add, entity: entity(id), scope: scope, weight: weight, reason: reason, previousRule: nil)
+    }
+
+    func test_add_createsRuleWithAllFields() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let profile = InterestProfile().applying(
+            add("casper-ruud", scope: "bare i Grand Slams", weight: 0.6, reason: "fordi Ruud", now: now),
+            now: now
+        )
+        XCTAssertEqual(profile.rules.count, 1)
+        let rule = profile.rules[0]
+        XCTAssertEqual(rule.entityId, "casper-ruud")
+        XCTAssertEqual(rule.entityName, "Casper Ruud")
+        XCTAssertEqual(rule.sport, "tennis")
+        XCTAssertEqual(rule.scope, "bare i Grand Slams")
+        XCTAssertEqual(rule.weight, 0.6)
+        XCTAssertEqual(rule.reason, "fordi Ruud")
+        XCTAssertEqual(rule.addedAt, now)
+    }
+
+    func test_addSameEntityTwice_upsertsAndKeepsAddedAt() {
+        let t1 = Date(timeIntervalSince1970: 1_000)
+        let t2 = Date(timeIntervalSince1970: 2_000)
+        var profile = InterestProfile().applying(add("casper-ruud", scope: "gammel", weight: 0.4, now: t1), now: t1)
+        profile = profile.applying(
+            GroundedMutation(kind: .update, entity: entity("casper-ruud"), scope: "ny", weight: 0.9, reason: "endret", previousRule: profile.rules[0]),
+            now: t2
+        )
+        XCTAssertEqual(profile.rules.count, 1, "upsert, not duplicate")
+        XCTAssertEqual(profile.rules[0].scope, "ny")
+        XCTAssertEqual(profile.rules[0].weight, 0.9)
+        XCTAssertEqual(profile.rules[0].addedAt, t1, "original addedAt preserved across update")
+    }
+
+    func test_remove_dropsRule() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        var profile = InterestProfile()
+            .applying(add("casper-ruud", now: now), now: now)
+            .applying(add("magnus-carlsen", now: now), now: now)
+        XCTAssertEqual(profile.rules.count, 2)
+
+        profile = profile.applying(
+            GroundedMutation(kind: .remove, entity: entity("casper-ruud"), scope: nil, weight: 0.5, reason: "slutt", previousRule: nil),
+            now: now
+        )
+        XCTAssertEqual(profile.rules.map(\.entityId), ["magnus-carlsen"])
+    }
+
+    func test_removeMissing_isNoOp() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let profile = InterestProfile().applying(add("casper-ruud", now: now), now: now)
+        let after = profile.applying(
+            GroundedMutation(kind: .remove, entity: entity("magnus-carlsen"), scope: nil, weight: 0.5, reason: "x", previousRule: nil),
+            now: now
+        )
+        XCTAssertEqual(after, profile)
+    }
+
+    func test_rulesSortedBySportThenName() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let profile = InterestProfile()
+            .applying(add("magnus-carlsen", now: now), now: now)   // chess
+            .applying(add("casper-ruud", now: now), now: now)      // tennis
+            .applying(add("viktor-hovland", now: now), now: now)   // golf
+        // chess < golf < tennis alphabetically by sport tag
+        XCTAssertEqual(profile.rules.map(\.sport), ["chess", "golf", "tennis"])
+    }
+
+    func test_batchApply() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let profile = InterestProfile().applying([
+            add("casper-ruud", now: now),
+            add("magnus-carlsen", now: now)
+        ], now: now)
+        XCTAssertEqual(Set(profile.rules.map(\.entityId)), ["casper-ruud", "magnus-carlsen"])
+    }
+}

--- a/ios/ZenjiTests/MockInterestAssistantTests.swift
+++ b/ios/ZenjiTests/MockInterestAssistantTests.swift
@@ -1,0 +1,160 @@
+//
+//  MockInterestAssistantTests.swift
+//  ZenjiTests
+//
+//  WP-16 acceptance — the parsing pipeline. The ten canonical Norwegian
+//  utterances (PLAN.md's spirit) must each produce the RIGHT structured
+//  mutation(s), grounded in real entity ids from the checked-in index. Apple
+//  Intelligence can't run in CI, so this drives the deterministic
+//  `MockInterestParser`/`MockInterestAssistant` — the same code path the app
+//  runs through the FM model, minus the model itself.
+//
+
+import XCTest
+
+final class MockInterestAssistantTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func parse(_ utterance: String, profile: InterestProfile = InterestProfile()) -> [ProposedMutation] {
+        MockInterestParser.parse(utterance: utterance, profile: profile, index: index)
+    }
+
+    /// Convenience: a profile that already follows Casper Ruud (tennis), used by
+    /// the "slutt med tennis" case.
+    private func profileFollowingRuud() -> InterestProfile {
+        let ruud = index.entity(id: "casper-ruud")!
+        return InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: ruud, scope: "bare i Grand Slams", weight: 0.5,
+            reason: "seed", previousRule: nil
+        ))
+    }
+
+    // MARK: - 1. Entity + scope
+
+    func test01_følgRuudBareGrandSlams() {
+        let p = parse("Følg Casper Ruud bare i Grand Slams")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .add)
+        XCTAssertEqual(p[0].entityId, "casper-ruud")
+        XCTAssertEqual(p[0].scope, "bare i Grand Slams")
+        XCTAssertFalse(p[0].reason.isEmpty)
+    }
+
+    // MARK: - 2. Plain entity add
+
+    func test02_følgMagnusCarlsen() {
+        let p = parse("Følg Magnus Carlsen")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .add)
+        XCTAssertEqual(p[0].entityId, "magnus-carlsen")
+        XCTAssertNil(p[0].scope)
+    }
+
+    // MARK: - 3. Entity + tournament scope
+
+    func test03_følgLynIObosligaen() {
+        let p = parse("Følg Lyn i OBOS-ligaen")
+        XCTAssertEqual(p.map(\.entityId), ["fk-lyn-oslo"])
+        XCTAssertEqual(p[0].kind, .add)
+        XCTAssertEqual(p[0].scope, "i OBOS-ligaen")
+    }
+
+    // MARK: - 4. Whole-sport increase + month scope
+
+    func test04_merSykkelIJuli() {
+        let p = parse("Mer sykkel i juli")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .update)              // "mer" = increase
+        XCTAssertEqual(p[0].entityId, "tour-de-france-2026") // representative cycling entity
+        XCTAssertEqual(p[0].scope, "i juli")
+        XCTAssertEqual(p[0].weight, 0.8)
+    }
+
+    // MARK: - 5. Whole-sport removal (needs the profile)
+
+    func test05_sluttMedTennis() {
+        let p = parse("Slutt med tennis", profile: profileFollowingRuud())
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .remove)
+        XCTAssertEqual(p[0].entityId, "casper-ruud")
+    }
+
+    func test05b_sluttMedTennis_emptyProfile_nothingToRemove() {
+        // No tennis rules to remove → no proposals (rather than a spurious one).
+        XCTAssertTrue(parse("Slutt med tennis").isEmpty)
+    }
+
+    // MARK: - 6. Remove a specific entity by alias
+
+    func test06_fjernHovland() {
+        let p = parse("Fjern Hovland")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .remove)
+        XCTAssertEqual(p[0].entityId, "viktor-hovland")  // matched via alias "Hovland"
+    }
+
+    // MARK: - 7. Full-name athlete add
+
+    func test07_følgKarstenWarholm() {
+        let p = parse("Følg Karsten Warholm")
+        XCTAssertEqual(p.map(\.entityId), ["karsten-warholm"])
+        XCTAssertEqual(p[0].kind, .add)
+    }
+
+    // MARK: - 8. Year-suffixed tournament name matched by tokens
+
+    func test08_følgTourDeFrance() {
+        let p = parse("Følg Tour de France")
+        XCTAssertEqual(p.map(\.entityId), ["tour-de-france-2026"])
+        XCTAssertEqual(p[0].kind, .add)
+        XCTAssertNil(p[0].scope)
+    }
+
+    // MARK: - 9. Weight increase for a team
+
+    func test09_prioriter100ThievesHøyere() {
+        let p = parse("Prioriter 100 Thieves høyere")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .update)
+        XCTAssertEqual(p[0].entityId, "100-thieves")
+        XCTAssertEqual(p[0].weight, 0.8)
+    }
+
+    // MARK: - 10. Free-text entity NOT in the index → unresolved (rejected later)
+
+    func test10_følgCricket_isUnresolved() {
+        let p = parse("Følg cricket")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].entityId, "")            // nothing grounded
+        XCTAssertEqual(p[0].entityQuery, "cricket")  // carried for the "mente du …?" suggestion
+    }
+
+    // MARK: - Availability + async surface
+
+    func test_availability_reflectsBehavior() {
+        XCTAssertEqual(MockInterestAssistant().availability(), .available)
+        XCTAssertEqual(
+            MockInterestAssistant(behavior: .unavailable("av")).availability(),
+            .unavailable(message: "av")
+        )
+    }
+
+    func test_asyncPropose_matchesParser() async throws {
+        let assistant = MockInterestAssistant()
+        let out = try await assistant.propose(utterance: "Følg Magnus Carlsen", profile: InterestProfile(), index: index)
+        XCTAssertEqual(out.map(\.entityId), ["magnus-carlsen"])
+    }
+
+    func test_asyncPropose_throwsWhenUnavailable() async {
+        let assistant = MockInterestAssistant(behavior: .unavailable("Apple Intelligence er av."))
+        do {
+            _ = try await assistant.propose(utterance: "Følg Lyn", profile: InterestProfile(), index: index)
+            XCTFail("expected throw")
+        } catch let error as AssistantError {
+            XCTAssertEqual(error, .unavailable(message: "Apple Intelligence er av."))
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+}

--- a/ios/ZenjiTests/MutationGrounderTests.swift
+++ b/ios/ZenjiTests/MutationGrounderTests.swift
@@ -1,0 +1,105 @@
+//
+//  MutationGrounderTests.swift
+//  ZenjiTests
+//
+//  WP-16 acceptance — the HARD grounding rule. A proposal is applied ONLY if its
+//  entityId resolves in the index; anything else is rejected with a Norwegian
+//  explanation and nearest-match suggestions. These prove both branches with no
+//  model in the loop, so grounding is guaranteed regardless of whether the raw
+//  proposal came from FoundationModels or the mock.
+//
+
+import XCTest
+
+final class MutationGrounderTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    // MARK: - Accept path
+
+    func test_groundsValidEntityId() {
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "casper-ruud", entityQuery: "Ruud",
+            scope: "bare i Grand Slams", weight: nil, reason: "fordi"
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+
+        XCTAssertTrue(result.rejected.isEmpty)
+        XCTAssertEqual(result.grounded.count, 1)
+        let g = result.grounded[0]
+        XCTAssertEqual(g.entity.id, "casper-ruud")
+        XCTAssertEqual(g.entity.name, "Casper Ruud")
+        XCTAssertEqual(g.scope, "bare i Grand Slams")
+        XCTAssertEqual(g.weight, InterestProfile.defaultWeight)  // nil → default
+        XCTAssertNil(g.previousRule)
+    }
+
+    func test_update_inheritsExistingScopeAndWeight() {
+        let ruud = index.entity(id: "casper-ruud")!
+        let profile = InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: ruud, scope: "bare i Grand Slams", weight: 0.7,
+            reason: "seed", previousRule: nil
+        ))
+        // An update that specifies neither scope nor weight keeps the old ones.
+        let proposal = ProposedMutation(kind: .update, entityId: "casper-ruud", entityQuery: "Ruud", reason: "endre")
+        let result = MutationGrounder.ground([proposal], index: index, profile: profile)
+
+        XCTAssertEqual(result.grounded.count, 1)
+        XCTAssertEqual(result.grounded[0].scope, "bare i Grand Slams")
+        XCTAssertEqual(result.grounded[0].weight, 0.7)
+        XCTAssertEqual(result.grounded[0].previousRule?.entityId, "casper-ruud")
+    }
+
+    func test_remove_carriesPreviousRule() {
+        let hovland = index.entity(id: "viktor-hovland")!
+        let profile = InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: hovland, scope: nil, weight: 0.5, reason: "seed", previousRule: nil
+        ))
+        let proposal = ProposedMutation(kind: .remove, entityId: "viktor-hovland", entityQuery: "Hovland", reason: "slutt")
+        let result = MutationGrounder.ground([proposal], index: index, profile: profile)
+
+        XCTAssertEqual(result.grounded.count, 1)
+        XCTAssertEqual(result.grounded[0].kind, .remove)
+        XCTAssertEqual(result.grounded[0].previousRule?.entityId, "viktor-hovland")
+    }
+
+    // MARK: - Reject path (the hard rule)
+
+    func test_rejectsHallucinatedEntityId_withNearestMatch() {
+        // A typo'd/hallucinated reference: bogus id, but the phrase is a near
+        // miss for a real alias ("Hovland").
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "hovlan", entityQuery: "Hovlan", reason: "følg"
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+
+        XCTAssertTrue(result.grounded.isEmpty)
+        XCTAssertEqual(result.rejected.count, 1)
+        let r = result.rejected[0]
+        XCTAssertTrue(r.explanation.contains("Fant ikke"))
+        XCTAssertTrue(r.explanation.contains("mente du"))
+        XCTAssertEqual(r.suggestions.first?.id, "viktor-hovland")
+    }
+
+    func test_rejectsFreeTextEntity_notInIndex() {
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "", entityQuery: "cricket", reason: "følg"
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+
+        XCTAssertTrue(result.grounded.isEmpty)
+        XCTAssertEqual(result.rejected.count, 1)
+        XCTAssertTrue(result.rejected[0].explanation.contains("cricket"))
+        XCTAssertTrue(result.rejected[0].explanation.contains("Fant ikke"))
+    }
+
+    func test_mixedBatch_partitionsGroundedAndRejected() {
+        let proposals = [
+            ProposedMutation(kind: .add, entityId: "magnus-carlsen", entityQuery: "Carlsen", reason: "ok"),
+            ProposedMutation(kind: .add, entityId: "does-not-exist", entityQuery: "quidditch", reason: "nope")
+        ]
+        let result = MutationGrounder.ground(proposals, index: index, profile: InterestProfile())
+        XCTAssertEqual(result.grounded.map(\.entity.id), ["magnus-carlsen"])
+        XCTAssertEqual(result.rejected.map(\.query), ["quidditch"])
+    }
+}

--- a/ios/ZenjiTests/ProfileStoreTests.swift
+++ b/ios/ZenjiTests/ProfileStoreTests.swift
@@ -1,0 +1,63 @@
+//
+//  ProfileStoreTests.swift
+//  ZenjiTests
+//
+//  WP-16 acceptance — persistence round-trip. Save → load returns an equal
+//  profile; a missing or corrupt file yields an empty profile (never throws on
+//  read, WP-12 DataStore's robustness contract); writes are atomic. All through
+//  a throwaway temp directory, never this process's real Application Support.
+//
+
+import XCTest
+
+final class ProfileStoreTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func sampleProfile() -> InterestProfile {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return InterestProfile()
+            .applying(GroundedMutation(kind: .add, entity: index.entity(id: "casper-ruud")!, scope: "bare i Grand Slams", weight: 0.6, reason: "fordi Ruud", previousRule: nil), now: now)
+            .applying(GroundedMutation(kind: .add, entity: index.entity(id: "viktor-hovland")!, scope: nil, weight: 0.5, reason: "golf-favoritt", previousRule: nil), now: now)
+    }
+
+    func test_saveThenLoad_roundTripsEqual() throws {
+        let store = AssistantTestSupport.tempProfileStore()
+        let profile = sampleProfile()
+        try store.save(profile)
+        XCTAssertEqual(store.load(), profile)
+    }
+
+    func test_load_fromEmptyDirectory_isEmptyProfile() {
+        let store = AssistantTestSupport.tempProfileStore()
+        XCTAssertTrue(store.load().isEmpty)
+    }
+
+    func test_load_corruptFile_isEmptyProfile() throws {
+        let store = AssistantTestSupport.tempProfileStore()
+        let url = store.directoryURL.appendingPathComponent(ProfileStore.filename)
+        try Data("{ not json".utf8).write(to: url)
+        XCTAssertTrue(store.load().isEmpty, "corrupt cache must degrade to empty, not crash")
+    }
+
+    func test_save_overwritesPreviousProfile() throws {
+        let store = AssistantTestSupport.tempProfileStore()
+        try store.save(sampleProfile())
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let replacement = InterestProfile().applying(
+            GroundedMutation(kind: .add, entity: index.entity(id: "magnus-carlsen")!, scope: nil, weight: 0.5, reason: "sjakk", previousRule: nil),
+            now: now
+        )
+        try store.save(replacement)
+        XCTAssertEqual(store.load().rules.map(\.entityId), ["magnus-carlsen"])
+    }
+
+    func test_reasonSurvivesRoundTrip() throws {
+        let store = AssistantTestSupport.tempProfileStore()
+        try store.save(sampleProfile())
+        let loaded = store.load()
+        XCTAssertEqual(loaded.rule(for: "casper-ruud")?.reason, "fordi Ruud")
+        XCTAssertFalse(loaded.rules.contains { $0.reason.isEmpty }, "every rule keeps its Norwegian reason")
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -128,6 +128,14 @@ targets:
       - path: Zenji/DesignTokens.swift
       - path: Zenji/Agenda
       - path: Zenji/Widget
+      # WP-16: the FM-lekegrind's sources — the pure pipeline (grounding, diff,
+      # persistence, the mock parser) plus the FoundationModels-backed assistant
+      # and its @Generable schema. Compiled directly into the hostless bundle
+      # (same "no @testable import" pattern). FoundationModels is present in the
+      # Simulator SDK so this compiles fine; the tests drive MockInterestAssistant
+      # only (Apple Intelligence can't run in CI/Simulator — see AssistantView's
+      # header and ios/README.md).
+      - path: Zenji/Assistant
       # WP-13: the SAME golden feed-vector fixtures the JS reference test
       # (tests/feed-vectors.test.js) replays — referenced directly at the repo
       # root, never copied, so the two runners can never drift. XcodeGen
@@ -151,6 +159,75 @@ targets:
         PRODUCT_NAME: ZenjiTests
         PRODUCT_BUNDLE_IDENTIFIER: app.zenji.ios.tests
 
+  # WP-16: a device-flavoured build of the SAME app sources (path: Zenji — so it
+  # includes Assistant/ and its on-device FoundationModels code) for running on
+  # a PHYSICAL iPhone under a FREE personal Apple Developer team. It handles two
+  # free-account constraints WITHOUT touching the Simulator setup:
+  #   (a) App Groups are unavailable on a free team, so this target uses an EMPTY
+  #       entitlements file (no com.apple.security.application-groups). CacheStore
+  #       then falls back to its Application Support directory (its built-in
+  #       fallback, see CacheStore.swift), and ProfileStore (WP-16) already uses
+  #       Application Support unconditionally.
+  #   (b) A previous device attempt failed with "Embedded binary is not signed
+  #       with the same certificate as the parent app" — so this target does NOT
+  #       depend on / embed ZenjiWidgetExtension. The widget stays Simulator-only
+  #       until a paid account (WP-17).
+  # The Simulator `Zenji` target + scheme and every existing test are unchanged;
+  # this target is purely additive and lives in its own `ZenjiDeviceDev` scheme.
+  ZenjiDeviceDev:
+    type: application
+    platform: iOS
+    deploymentTarget: "26.0"
+    sources:
+      - path: Zenji
+        # This target's own Info.plist lives at ZenjiDeviceDev/Info.plist (below),
+        # so XcodeGen would otherwise treat the app's Zenji/Info.plist as an
+        # ordinary resource and copy it into the bundle — colliding with the
+        # processed Info.plist ("Multiple commands produce …/Info.plist"). The
+        # Simulator `Zenji` target doesn't hit this because its info.path IS
+        # Zenji/Info.plist (auto-excluded). Exclude it explicitly here.
+        excludes:
+          - Info.plist
+    info:
+      path: ZenjiDeviceDev/Info.plist
+      properties:
+        CFBundleDevelopmentRegion: nb
+        CFBundleDisplayName: Zenji
+        CFBundlePackageType: APPL
+        LSRequiresIPhoneOS: true
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        BGTaskSchedulerPermittedIdentifiers:
+          - app.zenji.refresh
+        UIBackgroundModes:
+          - fetch
+    settings:
+      base:
+        # Distinct PRODUCT_NAME → distinct `ZenjiDeviceDev.app` output, so it
+        # never collides with the Simulator `Zenji` target's `Zenji.app` (the new
+        # build system flags a shared output path project-wide, even across
+        # schemes). The home-screen name stays "Zenji" via CFBundleDisplayName
+        # above; only the on-disk product bundle name differs.
+        PRODUCT_NAME: ZenjiDeviceDev
+        # Reuses the app's own bundle id (NOT a distinct one): the free personal
+        # team already has a valid "iOS Team Provisioning Profile: app.zenji.ios"
+        # covering this device, and a free account can't provision an unlimited
+        # number of new App IDs — so the device build signs against the existing
+        # profile. The Simulator `Zenji` target shares this id but never signs
+        # (CODE_SIGNING_ALLOWED=NO), so the two don't collide at install time
+        # (only one is ever installed per destination). Xcode may warn about the
+        # shared id; that's expected and harmless here.
+        PRODUCT_BUNDLE_IDENTIFIER: app.zenji.ios
+        CODE_SIGN_ENTITLEMENTS: ZenjiDeviceDev/ZenjiDeviceDev.entitlements
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGNING_ALLOWED: YES
+        CODE_SIGNING_REQUIRED: YES
+        CODE_SIGN_IDENTITY: "Apple Development"
+        DEVELOPMENT_TEAM: "9LVCB72DT8"
+
 schemes:
   Zenji:
     build:
@@ -170,6 +247,16 @@ schemes:
     build:
       targets:
         ZenjiWidgetExtension: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  # WP-16: builds only the widget-free, App-Group-free device app (see the
+  # ZenjiDeviceDev target above). Used for the physical-iPhone build/install.
+  ZenjiDeviceDev:
+    build:
+      targets:
+        ZenjiDeviceDev: all
     run:
       config: Debug
     archive:


### PR DESCRIPTION
## WP-16 · FM-lekegrind — samtale→profil

Conversational interest-rule editing behind Apple Intelligence (FoundationModels),
all in `ios/Zenji/Assistant/`. Type a Norwegian utterance → the on-device model
proposes structured rule mutations → you review them as a DIFF and confirm/reject.
Reached from a discreet speech-bubble glyph in the Tekst-TV header.

### What's here

- **Model behind a protocol** (`InterestAssistant`). `FoundationModelsInterestAssistant`
  is the *only* file that `import FoundationModels`: a `@Generable` mutation schema
  (`action`/`entityId`/`entityQuery`/`scope`/`weight`/norsk `reason`) + a
  `searchEntities` **`Tool`** over the entity index, one
  `LanguageModelSession.respond(to:generating:)`. It checks
  `SystemLanguageModel.default.availability` and renders a calm, honest Norwegian
  message when Apple Intelligence is off / the model isn't loaded.
  `MockInterestAssistant` is a deterministic Norwegian parser for the tests
  (FM can't run in CI) and previews — **not** a silent fallback.
- **Entity grounding is the hard rule.** `MutationGrounder` re-checks every
  `entityId` against the WP-05 index (`entities.json`); free-text entities are
  **rejected**, never applied, with *"Fant ikke «X» i indeksen — mente du …?"* +
  nearest matches.
- **Local profile** persisted as JSON in Application Support (`ProfileStore`, no
  App Group needed); every `InterestRule` keeps a norsk `reason`.
- **One calm Tekst-TV screen** (`AssistantView`): utterance field, proposed
  mutations as a green (add) / amber (change) / red (remove) DIFF with Bekreft/Avvis
  per mutation, and the current **"Hva jeg følger"** list with reasons.

### Test status

`xcodebuild test -scheme Zenji -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
→ **152 tests, 0 failures** (102 WP-10…15 baseline + 50 new; all drive the mock).
`npm test` → **369/369** (untouched — this PR is `ios/` only). New coverage:
the ten canonical utterances → correct mutations, entity lookup + free-text
rejection with nearest match, diff application (add/update upsert, remove),
persistence round-trip, and the end-to-end view-model flow.

### Device build (free personal team) — proven

A dedicated **`ZenjiDeviceDev`** target/scheme handles two free-account limits
without touching the Simulator setup (its target, schemes and all tests are
unchanged, still green):

- **No App Groups** (unavailable on a free team) → empty entitlements; `CacheStore`
  uses its Application Support fallback, `ProfileStore` uses it unconditionally.
- **No embedded widget** → avoids the earlier *"Embedded binary is not signed with
  the same certificate as the parent app"* failure. Widget stays Simulator-only
  until WP-17 (paid account).
- Reuses bundle id `app.zenji.ios` (matches the free team's existing provisioning
  profile for the device); distinct `PRODUCT_NAME` (`ZenjiDeviceDev.app`) avoids a
  product collision; home-screen name stays "Zenji".

Confirmed in this environment (Xcode 26.6 / iOS 26.5 SDK, iPhone 16 Pro):

- ✅ **Built** for the device — `BUILD SUCCEEDED`, signed *"Apple Development:
  chris.haerem@gmail.com"* with *"iOS Team Provisioning Profile: app.zenji.ios"*.
- ✅ **Installed** — `xcrun devicectl device install app` → `bundleID: app.zenji.ios`;
  `devicectl device info apps` lists **Zenji** on the phone.
- ⚠️ **Launch** is blocked by iOS's one-time developer-trust gate (expected for a
  free team, cannot be scripted): *Innstillinger → Generelt → VPN og
  enhetsadministrering → Utviklerapp → Stol på "Apple Development: …"*. After
  trusting once, the app launches and the FM conversations can be verified by hand.

### Manual test checklist (FM on device — human verifies)

Prereqs: trust the developer profile (above); Apple Intelligence on; Norwegian
(nb-NO) enabled. Open the app → tap the speech-bubble glyph in the header. For
each utterance, check the proposed mutation(s) and the "Hva jeg følger" list:

1. **"Følg Casper Ruud bare i Grand Slams"** → add `casper-ruud`, scope "bare i Grand Slams".
2. **"Følg Magnus Carlsen"** → add `magnus-carlsen`, no scope.
3. **"Følg Lyn i OBOS-ligaen"** → add `fk-lyn-oslo`, scope "i OBOS-ligaen" (not the tournament).
4. **"Mer sykkel i juli"** → increase a cycling rule (e.g. Tour de France), scope "i juli".
5. **"Slutt med tennis"** → remove the tennis rule(s) you follow (e.g. Casper Ruud).
6. **"Fjern Hovland"** → remove `viktor-hovland` (matched via alias).
7. **"Følg Karsten Warholm"** → add `karsten-warholm` (athlete, not the parenthetical tournament).
8. **"Følg Tour de France"** → add `tour-de-france-2026` (year-suffixed name still matches).
9. **"Prioriter 100 Thieves høyere"** → increase weight on `100-thieves`.
10. **"Følg cricket"** → **rejected**: "Fant ikke «cricket» i indeksen …" (no cricket entity).

Then confirm a couple, reopen the sheet / relaunch → the profile persisted; toggle
Apple Intelligence off → the honest "unavailable" banner appears.

### Non-goals respected

No chat over the feed/brief, no PCC/escalation, no changes to the Simulator setup,
widget functionality, or anything outside `ios/` except the WP-16 row in `PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
