### PR TITLE
WP-16.1: linse i mutasjons-skjemaet + assistenten forklarer seg alltid

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -176,6 +176,7 @@ diff-visning, bekreft/avvis. Krever fysisk enhet med Apple Intelligence (norsk: 
 **Aksept:** 10 norske testytringer («følg Ruud bare i Grand Slams», «slutt med tennis»)
 gir riktige strukturerte mutasjoner; ingen fritekst-entiteter (kun oppslag mot
 entities.json fra WP-05).
+**WP-16.1 (etter første brukertest):** la til LINSE i mutasjons-skjemaet («med fokus på norske utøvere» → `.throughNorwegians`, grounet som en entitet) + regelen om at assistenten ALLTID forklarer seg (aldri «fant ingen endringer») — 166/166 iOS-tester, DeviceDev re-installert på iPhone.
 
 ### WP-17 · 💰 TestFlight (BESLUTNING: 99 USD/år)
 Apple Developer-konto, signering, 15–20 eksterne testere fra nisjemiljøene.

--- a/ios/README.md
+++ b/ios/README.md
@@ -805,11 +805,45 @@ applied, with a Norwegian explanation and up to three nearest-match suggestions
 ("Fant ikke «X» i indeksen — mente du …?"). This holds identically whether the
 raw proposal came from FoundationModels or the mock.
 
+### Lens — the perspective a follow-rule is seen through (WP-16.1)
+
+The entity says *what* is followed; the **lens** says *how*. Without it, an
+utterance like *"Følg Tour de France med fokus på norske utøvere"* had nowhere
+to put "med fokus på norske" — the model produced no mutation and the UI
+collapsed that to a dead-end "fant ingen endringer". `Lens` gives that intent a
+home, on both `ProposedMutation`/`GroundedMutation` and the persisted
+`InterestRule`:
+
+- **`.sportAsSuch`** — the whole thing, every participant (the DEFAULT; existing
+  behaviour is unchanged).
+- **`.throughNorwegians`** — "med fokus på norske utøvere" / "bare de norske".
+- **`.throughAthletes([LensAthlete])`** — specific athletes, carrying their
+  entity ids. Those ids are **grounded exactly like the top-level `entityId`**:
+  `MutationGrounder` re-checks each against the index, drops any that don't
+  resolve (normalising the survivors' display names), and if none survive the
+  lens degrades back to `.sportAsSuch`. A `.remove` never carries a lens; an
+  `.update` with no explicit lens inherits the existing rule's, just as
+  scope/weight carry over. Shown in the DIFF and "Hva jeg følger" as a quiet
+  "gjennom norske utøvere" subtitle segment.
+
+### Always-explain — no dead-end "fant ingen endringer" (WP-16.1)
+
+The assistant **always** accounts for itself. Whenever a submitted utterance
+produces no confirmable change, `AssistantExplanation.make(…)` (pure, unit-
+tested) builds an honest, structured note the UI shows verbatim — `understood`
+(a paraphrase of what it took the utterance to mean) + `reason` (WHY nothing
+changed): the named things weren't in the index (with the "mente du …?"
+suggestions below), the entity data hasn't synced yet, or the intent couldn't
+be expressed as a rule change at all. The forbidden bare "fant ingen endringer"
+string is gone. `MockInterestAssistant.Behavior.producesNothing` simulates the
+usable-model-but-empty-output case so this path is testable without Apple
+Intelligence.
+
 ### Pieces (all pure + unit-tested except the two UI/FM shells)
 
 | File | What |
 |---|---|
-| `AssistantModels.swift` | `MutationKind`, `ProposedMutation` (raw), `GroundedMutation`/`RejectedMutation`, `AssistantAvailability`/`AssistantError` |
+| `AssistantModels.swift` | `MutationKind`, `Lens` (+ `LensAthlete`), `ProposedMutation` (raw), `GroundedMutation`/`RejectedMutation`, `AssistantExplanation`, `AssistantAvailability`/`AssistantError` |
 | `InterestProfile.swift` | `InterestRule` + `InterestProfile.applying(_:)` — the pure add/update (upsert) / remove diff; every rule keeps a Norwegian `reason` |
 | `EntityIndex.swift` | exact lookup (grounding gate), tool search (Norwegian sport-word expansion), fuzzy nearest-match, the mock's utterance→entity detection |
 | `MutationGrounder.swift` | the hard grounding rule, as one pure function |
@@ -830,7 +864,10 @@ later work (PLAN.md WP-22).
 cover the ten canonical utterances → correct mutations, entity lookup +
 free-text rejection with nearest match, the diff application, persistence
 round-trip, and the end-to-end view-model flow. `xcodebuild test` on the
-Simulator passes **152 tests** (the 102 WP-10…15 baseline + 50 new).
+Simulator passes **166 tests** (the 102 WP-10…15 baseline + 50 WP-16 + 14
+WP-16.1: lens detection/grounding/persistence + the always-explain contract,
+incl. the exact first-user-test utterance *"Følg Tour de France med fokus på
+norske utøvere"* → `add(tour-de-france-2026, lens: .throughNorwegians)`).
 
 ### Device build (free personal account)
 
@@ -874,6 +911,15 @@ på "Apple Development: …"*. This cannot be scripted (`devicectl launch` retur
 a `Security`/"profile has not been explicitly trusted" error until it's done).
 After trusting once, the app launches normally and the FM conversations can be
 verified by hand (see the WP-16 PR's manual checklist).
+
+**Update (WP-16.1):** the `ZenjiDeviceDev` scheme was rebuilt for the connected
+iPhone 16 Pro (`-allowProvisioningUpdates CODE_SIGNING_ALLOWED=YES
+CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=9LVCB72DT8`, **BUILD SUCCEEDED**) and
+re-installed with `xcrun devicectl device install app` — the new lens +
+always-explain build now carries `app.zenji.ios` on the device. The on-device
+Apple Intelligence check of *"Følg Tour de France med fokus på norske utøvere"*
+(the utterance that first failed) is the manual step to confirm by hand after
+the one-time trust.
 
 ## Architecture (what plugs in next)
 

--- a/ios/Zenji/Assistant/AssistantModels.swift
+++ b/ios/Zenji/Assistant/AssistantModels.swift
@@ -40,6 +40,58 @@ enum MutationKind: String, Codable, Equatable, Sendable {
     case remove
 }
 
+/// The PERSPECTIVE a follow-rule is seen through (WP-16.1). The entity says
+/// *what* is followed (a tournament, a team, a sport's headline event); the lens
+/// says *how*. Without it, an utterance like "Følg Tour de France med fokus på
+/// norske utøvere" simply could not be represented — the model had nowhere to
+/// put "med fokus på norske", produced no mutation, and the UI collapsed that to
+/// a bare "fant ingen endringer". The lens gives that intent a home.
+///
+///   • `.sportAsSuch`       the whole thing — every participant (the DEFAULT).
+///   • `.throughNorwegians` focus on the Norwegian athletes/teams in the
+///                          entity's events ("med fokus på norske utøvere").
+///   • `.throughAthletes`   focus on specific athletes; carries their entity ids
+///                          — GROUNDED against the index exactly like every other
+///                          id (an athlete not in the index is dropped, and an
+///                          empty result degrades back to `.sportAsSuch`).
+enum Lens: Codable, Equatable, Sendable {
+    case sportAsSuch
+    case throughNorwegians
+    case throughAthletes([LensAthlete])
+
+    /// The neutral default — a rule with no explicit perspective.
+    var isDefault: Bool { self == .sportAsSuch }
+
+    /// Human-readable Norwegian label for the DIFF / "Hva jeg følger" list, e.g.
+    /// "gjennom norske utøvere" or "gjennom Casper Ruud, Viktor Hovland".
+    var label: String {
+        switch self {
+        case .sportAsSuch:
+            return "hele sporten"
+        case .throughNorwegians:
+            return "gjennom norske utøvere"
+        case let .throughAthletes(athletes):
+            let names = athletes.map(\.name).joined(separator: ", ")
+            return names.isEmpty ? "gjennom utvalgte utøvere" : "gjennom \(names)"
+        }
+    }
+}
+
+/// One athlete a `.throughAthletes` lens focuses on. `entityId` is the WP-05
+/// stable id; `name` is cached for display (mirroring `InterestRule.entityName`)
+/// so the DIFF/profile render without a second index lookup. In a RAW proposal
+/// these ids are UNTRUSTED (the grounder re-checks them); in a grounded mutation
+/// or a persisted rule every one has been verified to exist.
+struct LensAthlete: Codable, Equatable, Sendable {
+    var entityId: String
+    var name: String
+
+    init(entityId: String, name: String) {
+        self.entityId = entityId
+        self.name = name
+    }
+}
+
 /// The model's RAW proposal, BEFORE entity-grounding.
 ///
 /// `entityId` is deliberately treated as untrusted: the model is instructed to
@@ -59,14 +111,20 @@ struct ProposedMutation: Equatable, Sendable {
     var weight: Double?
     /// Always-filled Norwegian rationale (the transparency contract).
     var reason: String
+    /// The perspective the user wants this followed through. For a `.throughAthletes`
+    /// lens the athlete ids here are UNTRUSTED (grounding re-checks them, exactly
+    /// like `entityId`). Defaults to `.sportAsSuch` so existing callers and any
+    /// utterance without a focus phrase are unaffected.
+    var lens: Lens
 
-    init(kind: MutationKind, entityId: String, entityQuery: String, scope: String? = nil, weight: Double? = nil, reason: String) {
+    init(kind: MutationKind, entityId: String, entityQuery: String, scope: String? = nil, weight: Double? = nil, reason: String, lens: Lens = .sportAsSuch) {
         self.kind = kind
         self.entityId = entityId
         self.entityQuery = entityQuery
         self.scope = scope
         self.weight = weight
         self.reason = reason
+        self.lens = lens
     }
 }
 
@@ -80,6 +138,11 @@ struct GroundedMutation: Equatable, Identifiable, Sendable {
     /// The rule this would replace/remove, if one already exists — lets the
     /// DIFF view show a real before/after instead of guessing.
     var previousRule: InterestRule?
+    /// The perspective this rule is followed through — GROUNDED (any
+    /// `.throughAthletes` ids have been verified to exist). Defaults to
+    /// `.sportAsSuch`, declared last so the synthesised memberwise initialiser
+    /// stays backward-compatible with callers that omit it.
+    var lens: Lens = .sportAsSuch
 
     /// Stable, deterministic id (entity + kind) — no random UUID, so the type
     /// stays value-equal for tests and SwiftUI diffing.
@@ -110,6 +173,89 @@ struct GroundingResult: Equatable, Sendable {
     }
 
     var isEmpty: Bool { grounded.isEmpty && rejected.isEmpty }
+}
+
+/// The HARD UX RULE, made a value (WP-16.1): the assistant ALWAYS explains
+/// itself. Whenever a submitted utterance produces no confirmable change, this
+/// replaces the old dead-end "fant ingen endringer" note with an honest,
+/// structured account the UI shows verbatim:
+///
+///   • `understood` — a short paraphrase of what the assistant took the
+///     utterance to mean.
+///   • `reason` — WHY nothing changed: the named things weren't in the index
+///     (see the "mente du …?" suggestions), the entity data hasn't synced yet,
+///     or the intent couldn't be expressed as a rule change at all ("jeg kan
+///     ikke uttrykke X ennå" — the case that produced the original bug).
+///
+/// Both fields are always non-empty Norwegian text — the UI must never show a
+/// blank or a bare "no changes".
+struct AssistantExplanation: Equatable, Sendable {
+    var understood: String
+    var reason: String
+
+    init(understood: String, reason: String) {
+        self.understood = understood
+        self.reason = reason
+    }
+
+    /// Builds the honest account shown WHENEVER a submitted utterance produced no
+    /// confirmable change (no grounded mutation). Pure — no clock, no I/O — so
+    /// the always-explain contract is unit-tested directly. The four honest
+    /// endings, in priority order:
+    ///
+    ///   1. the entity index hasn't synced yet → nothing could be looked up;
+    ///   2. the model produced no proposal at all → the intent couldn't be
+    ///      expressed as a rule change (the case that produced the original
+    ///      "fant ingen endringer" bug);
+    ///   3. every proposal named something not in the index → rejected, with the
+    ///      "mente du …?" suggestions shown separately;
+    ///   4. (defensive) proposals resolved but changed nothing net.
+    ///
+    /// `understood` always paraphrases the utterance so the UI never shows a bare
+    /// blank; `reason` always says WHY, in Norwegian.
+    static func make(
+        utterance: String,
+        proposals: [ProposedMutation],
+        result: GroundingResult,
+        hasEntities: Bool
+    ) -> AssistantExplanation {
+        let understood = understoodText(utterance: utterance, proposals: proposals)
+        let reason: String
+        if !hasEntities {
+            reason = "Jeg har ikke lastet ned hva du kan følge ennå, så jeg fikk ikke slått opp noe. Prøv igjen om litt."
+        } else if !result.rejected.isEmpty {
+            let names = result.rejected.map { "«\($0.query)»" }.joined(separator: ", ")
+            reason = "Jeg fant ikke \(names) i indeksen over det du kan følge, så jeg endret ingenting. Se forslagene under."
+        } else if proposals.isEmpty {
+            reason = "Jeg klarte ikke å uttrykke dette som en endring i en følge-regel ennå, så jeg lot profilen stå urørt. Prøv å skrive hvem eller hva du vil følge, f.eks. «Følg Tour de France med fokus på norske utøvere»."
+        } else {
+            reason = "Det du beskrev endrer ikke det du allerede følger, så jeg gjorde ingenting."
+        }
+        return AssistantExplanation(understood: understood, reason: reason)
+    }
+
+    /// A short Norwegian paraphrase of what the assistant took the utterance to
+    /// mean — from the proposals when there are any, else an honest echo of the
+    /// raw text so the field is never empty.
+    private static func understoodText(utterance: String, proposals: [ProposedMutation]) -> String {
+        guard !proposals.isEmpty else {
+            let text = utterance.trimmingCharacters(in: .whitespacesAndNewlines)
+            return "Jeg leste ytringen din som «\(text)», men fant ingen konkret utøver, lag eller turnering å endre."
+        }
+        var seen = Set<String>()
+        let phrases = proposals.map(phrase(for:)).filter { seen.insert($0).inserted }
+        return phrases.joined(separator: " ")
+    }
+
+    private static func phrase(for proposal: ProposedMutation) -> String {
+        let q = proposal.entityQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let subject = q.isEmpty ? "det du skrev" : "«\(q)»"
+        switch proposal.kind {
+        case .add: return "Du vil følge \(subject)."
+        case .update: return "Du vil justere hvordan du følger \(subject)."
+        case .remove: return "Du vil slutte å følge \(subject)."
+        }
+    }
 }
 
 /// Whether the on-device model can actually be used right now. Mirrors

--- a/ios/Zenji/Assistant/AssistantView.swift
+++ b/ios/Zenji/Assistant/AssistantView.swift
@@ -46,6 +46,7 @@ struct AssistantView: View {
                 }
                 inputSection
                 statusSection
+                if let explanation = viewModel.explanation { explanationSection(explanation) }
                 if !viewModel.pending.isEmpty { proposalsSection }
                 if !viewModel.rejected.isEmpty { rejectionsSection }
                 profileSection
@@ -150,11 +151,27 @@ struct AssistantView: View {
                 .font(.zenjiMono(size: 13))
                 .foregroundStyle(ZenjiTokens.diffRemove)
         }
-        if let notice = viewModel.notice {
-            Text(notice)
+    }
+
+    // MARK: - Always-explain (no confirmable change → an honest account)
+
+    /// The WP-16.1 contract, on screen: never a bare "fant ingen endringer".
+    /// Shows what the assistant understood and WHY nothing changed; any
+    /// "mente du …?" suggestions render just below in the rejections section.
+    private func explanationSection(_ explanation: AssistantExplanation) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionTitle("INGEN ENDRING")
+            Text(explanation.understood)
                 .font(.zenjiMono(size: 13))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+            Text(explanation.reason)
+                .font(.zenjiMono(size: 12))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.65))
         }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(ZenjiTokens.foreground.opacity(0.05))
+        .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.2), lineWidth: 1))
     }
 
     // MARK: - Proposed mutations (the DIFF)
@@ -211,6 +228,9 @@ struct AssistantView: View {
     private func subtitle(for mutation: GroundedMutation) -> String {
         var parts = [SportVocabulary.display(for: mutation.entity.sport)]
         if let scope = mutation.scope, !scope.isEmpty { parts.append(scope) }
+        // The lens — "gjennom norske utøvere" — shown only when it isn't the
+        // neutral default, and never on a remove (WP-16.1).
+        if mutation.kind != .remove, !mutation.lens.isDefault { parts.append(mutation.lens.label) }
         if mutation.kind != .remove { parts.append("vekt \(weightLabel(mutation.weight))") }
         return parts.joined(separator: " · ")
     }
@@ -283,6 +303,7 @@ struct AssistantView: View {
     private func ruleSubtitle(_ rule: InterestRule) -> String {
         var parts = [SportVocabulary.display(for: rule.sport)]
         if let scope = rule.scope, !scope.isEmpty { parts.append(scope) }
+        if !rule.lens.isDefault { parts.append(rule.lens.label) }
         parts.append("vekt \(weightLabel(rule.weight))")
         return parts.joined(separator: " · ")
     }

--- a/ios/Zenji/Assistant/AssistantViewModel.swift
+++ b/ios/Zenji/Assistant/AssistantViewModel.swift
@@ -36,8 +36,10 @@ final class AssistantViewModel {
     private(set) var isThinking = false
     /// A blocking error (model unavailable / generation failed) shown verbatim.
     private(set) var errorMessage: String?
-    /// A calm, non-error note, e.g. "Fant ingen endringer i det du skrev."
-    private(set) var notice: String?
+    /// The always-explain account (WP-16.1): set WHENEVER a submitted utterance
+    /// produced no confirmable change, instead of the old dead-end "fant ingen
+    /// endringer" note. Nil when there are pending mutations to review.
+    private(set) var explanation: AssistantExplanation?
 
     private let assistant: any InterestAssistant
     private let profileStore: ProfileStore
@@ -79,7 +81,7 @@ final class AssistantViewModel {
         guard !text.isEmpty else { return }
 
         errorMessage = nil
-        notice = nil
+        explanation = nil
         pending = []
         rejected = []
         isThinking = true
@@ -90,10 +92,12 @@ final class AssistantViewModel {
             let result = MutationGrounder.ground(proposals, index: index, profile: profile)
             pending = result.grounded
             rejected = result.rejected
-            if result.isEmpty {
-                notice = hasEntities
-                    ? "Fant ingen endringer i det du skrev."
-                    : "Har ikke lastet ned hva du kan følge ennå — prøv igjen om litt."
+            // The always-explain rule: no confirmable change is NEVER a bare
+            // "fant ingen endringer" — build an honest, structured account.
+            if pending.isEmpty {
+                explanation = AssistantExplanation.make(
+                    utterance: text, proposals: proposals, result: result, hasEntities: hasEntities
+                )
             }
         } catch let error as AssistantError {
             errorMessage = error.errorDescription

--- a/ios/Zenji/Assistant/FoundationModelsInterestAssistant.swift
+++ b/ios/Zenji/Assistant/FoundationModelsInterestAssistant.swift
@@ -52,6 +52,12 @@ struct GeneratedMutation {
 
     @Guide(description: "Kort begrunnelse på norsk for hvorfor denne endringen foreslås. Skal alltid fylles ut.")
     var reason: String
+
+    @Guide(description: "Linse — hvilket perspektiv brukeren vil følge dette gjennom. Gjelder kun 'add' og 'update'. Bruk 'sport' for hele sporten/turneringen (standard), 'norwegians' når brukeren sier «med fokus på norske», «bare de norske» e.l., eller 'athletes' når brukeren vil følge bestemte utøvere (f.eks. «bare når Ruud spiller») — da MÅ du fylle lensAthleteIds.")
+    var lens: String
+
+    @Guide(description: "Kun når lens = 'athletes': entityId-ene (fra searchEntities) til utøverne brukeren vil følge dette gjennom. Ellers tom liste. Bruk kun ekte id-er fra verktøyet — aldri oppdiktede.")
+    var lensAthleteIds: [String]
 }
 
 /// The top-level structure the session generates for a single utterance.
@@ -162,8 +168,28 @@ struct FoundationModelsInterestAssistant: InterestAssistant {
             entityQuery: g.entityQuery.trimmingCharacters(in: .whitespacesAndNewlines),
             scope: scope.isEmpty ? nil : scope,
             weight: g.weight > 0 ? min(g.weight, 1.0) : nil,
-            reason: reason.isEmpty ? "Foreslått fra ytringen din." : reason
+            reason: reason.isEmpty ? "Foreslått fra ytringen din." : reason,
+            lens: lens(from: g)
         )
+    }
+
+    /// GeneratedMutation → Lens. The raw athlete ids are left UNTRUSTED here —
+    /// `MutationGrounder` re-checks them (and fills the canonical display name),
+    /// exactly like the top-level entityId. An unrecognised lens string, or a
+    /// `.remove`, falls back to `.sportAsSuch`.
+    static func lens(from g: GeneratedMutation) -> Lens {
+        switch g.lens.lowercased().trimmingCharacters(in: .whitespaces) {
+        case "norwegians", "norske", "norsk", "norway", "norge":
+            return .throughNorwegians
+        case "athletes", "athlete", "utovere", "utøvere", "utover", "utøver":
+            let athletes = g.lensAthleteIds
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .map { LensAthlete(entityId: $0, name: $0) }
+            return athletes.isEmpty ? .sportAsSuch : .throughAthletes(athletes)
+        default:
+            return .sportAsSuch
+        }
     }
 
     static func instructions(profile: InterestProfile) -> String {
@@ -187,6 +213,13 @@ struct FoundationModelsInterestAssistant: InterestAssistant {
         - «slutt med <idrett>» betyr å fjerne det brukeren allerede følger i den idretten.
         - Sett en kort, ærlig begrunnelse på norsk i reason på hver mutasjon.
         - Vær konservativ: foreslå bare det ytringen faktisk ber om.
+
+        LINSE (perspektivet brukeren vil følge noe gjennom — felt: lens):
+        - «Følg Tour de France med fokus på norske utøvere» → add på Tour de France med lens = 'norwegians'.
+        - «Følg VM i friidrett, bare de norske» → add på turneringen med lens = 'norwegians'.
+        - «Følg Tour de France bare når Kristoff er med» → add på Tour de France med lens = 'athletes' og lensAthleteIds = [Kristoffs entityId fra searchEntities].
+        - «Følg hele Premier League» / uten noe fokus-uttrykk → lens = 'sport' (standard).
+        - Linse endrer ALDRI hvilken entitet du følger — den sier bare hvordan. Entiteten (turneringen/laget) må fortsatt være en ekte id fra verktøyet, og utøverne i 'athletes' likeså.
 
         \(following)
         """

--- a/ios/Zenji/Assistant/InterestProfile.swift
+++ b/ios/Zenji/Assistant/InterestProfile.swift
@@ -35,14 +35,17 @@ struct InterestRule: Codable, Equatable, Identifiable, Sendable {
     /// Always-filled Norwegian rationale.
     var reason: String
     var addedAt: Date
+    /// The perspective this rule is followed through (WP-16.1). Defaults to
+    /// `.sportAsSuch`; persisted so "med fokus på norske" survives a round-trip.
+    var lens: Lens
 
     var id: String { entityId }
 
     private enum CodingKeys: String, CodingKey {
-        case entityId, entityName, sport, scope, weight, reason, addedAt
+        case entityId, entityName, sport, scope, weight, reason, addedAt, lens
     }
 
-    init(entityId: String, entityName: String, sport: String, scope: String? = nil, weight: Double, reason: String, addedAt: Date) {
+    init(entityId: String, entityName: String, sport: String, scope: String? = nil, weight: Double, reason: String, addedAt: Date, lens: Lens = .sportAsSuch) {
         self.entityId = entityId
         self.entityName = entityName
         self.sport = sport
@@ -50,6 +53,7 @@ struct InterestRule: Codable, Equatable, Identifiable, Sendable {
         self.weight = weight
         self.reason = reason
         self.addedAt = addedAt
+        self.lens = lens
     }
 
     /// Forward-compatible decode (same convention as the WP-11 models): unknown
@@ -64,6 +68,9 @@ struct InterestRule: Codable, Equatable, Identifiable, Sendable {
         weight = try c.decodeIfPresent(Double.self, forKey: .weight) ?? InterestProfile.defaultWeight
         reason = try c.decodeIfPresent(String.self, forKey: .reason) ?? ""
         addedAt = try c.decodeIfPresent(Date.self, forKey: .addedAt) ?? Date(timeIntervalSince1970: 0)
+        // Forward-compatible: a profile written by WP-16 (pre-lens) has no `lens`
+        // key — default it, exactly like the other optionals above.
+        lens = try c.decodeIfPresent(Lens.self, forKey: .lens) ?? .sportAsSuch
     }
 }
 
@@ -114,7 +121,8 @@ struct InterestProfile: Codable, Equatable, Sendable {
                 reason: mutation.reason,
                 // Preserve the original addedAt on an update; stamp now on a
                 // genuine first add.
-                addedAt: existing?.addedAt ?? now
+                addedAt: existing?.addedAt ?? now,
+                lens: mutation.lens
             )
             next.removeAll { $0.entityId == entityId }
             next.append(rule)

--- a/ios/Zenji/Assistant/MockInterestAssistant.swift
+++ b/ios/Zenji/Assistant/MockInterestAssistant.swift
@@ -28,6 +28,12 @@ struct MockInterestAssistant: InterestAssistant {
         /// Simulates Apple Intelligence being off / the model not loaded, so
         /// the UI's honest "unavailable" path can be tested without a device.
         case unavailable(String)
+        /// Simulates a USABLE model that still produced no usable structured
+        /// output for the utterance — an empty mutation list (or output that all
+        /// failed validation/grounding). This is the device bug that made the UI
+        /// collapse to a bare "fant ingen endringer"; the behaviour exists so the
+        /// WP-16.1 honest-explanation path is testable without Apple Intelligence.
+        case producesNothing
     }
 
     let behavior: Behavior
@@ -38,16 +44,20 @@ struct MockInterestAssistant: InterestAssistant {
 
     func availability() -> AssistantAvailability {
         switch behavior {
-        case .available: return .available
+        case .available, .producesNothing: return .available
         case let .unavailable(message): return .unavailable(message: message)
         }
     }
 
     func propose(utterance: String, profile: InterestProfile, index: EntityIndex) async throws -> [ProposedMutation] {
-        if case let .unavailable(message) = behavior {
+        switch behavior {
+        case let .unavailable(message):
             throw AssistantError.unavailable(message: message)
+        case .producesNothing:
+            return []
+        case .available:
+            return MockInterestParser.parse(utterance: utterance, profile: profile, index: index)
         }
-        return MockInterestParser.parse(utterance: utterance, profile: profile, index: index)
     }
 }
 
@@ -73,6 +83,8 @@ enum MockInterestParser {
         // 1) An explicit entity mention always wins.
         let matched = index.detectEntities(in: trimmed)
         if !matched.isEmpty {
+            // A lens only makes sense on add/increase/decrease — never on remove.
+            let lens: Lens = intent == .remove ? .sportAsSuch : detectLens(in: trimmed)
             return matched.map { entity in
                 let effectiveScope = intent == .remove ? nil : scope
                 return ProposedMutation(
@@ -81,14 +93,16 @@ enum MockInterestParser {
                     entityQuery: entity.name,
                     scope: effectiveScope,
                     weight: weight,
-                    reason: entityReason(intent: intent, name: entity.name, scope: effectiveScope)
+                    reason: entityReason(intent: intent, name: entity.name, scope: effectiveScope, lens: lens),
+                    lens: lens
                 )
             }
         }
 
         // 2) A whole-sport command ("mer sykkel", "slutt med tennis").
         if let sport = EntityIndex.sportKeyword(in: trimmed) {
-            return sportProposals(intent: intent, sport: sport, scope: scope, weight: weight, profile: profile, index: index)
+            let lens: Lens = intent == .remove ? .sportAsSuch : detectLens(in: trimmed)
+            return sportProposals(intent: intent, sport: sport, scope: scope, weight: weight, lens: lens, profile: profile, index: index)
         }
 
         // 3) Nothing recognised → one unresolved proposal; grounding rejects it
@@ -108,7 +122,7 @@ enum MockInterestParser {
 
     // MARK: - Sport-level commands
 
-    private static func sportProposals(intent: Intent, sport: String, scope: String?, weight: Double?, profile: InterestProfile, index: EntityIndex) -> [ProposedMutation] {
+    private static func sportProposals(intent: Intent, sport: String, scope: String?, weight: Double?, lens: Lens, profile: InterestProfile, index: EntityIndex) -> [ProposedMutation] {
         let display = SportVocabulary.display(for: sport)
 
         switch intent {
@@ -134,7 +148,8 @@ enum MockInterestParser {
                 entityQuery: display,
                 scope: scope,
                 weight: weight,
-                reason: sportReason(intent: intent, display: display, entityName: entity.name, scope: scope)
+                reason: sportReason(intent: intent, display: display, entityName: entity.name, scope: scope, lens: lens),
+                lens: lens
             )]
         }
     }
@@ -158,6 +173,21 @@ enum MockInterestParser {
         case .increase, .decrease: return .update
         case .remove: return .remove
         }
+    }
+
+    // MARK: - Lens detection (WP-16.1)
+
+    /// Detects the PERSPECTIVE phrase in an utterance — the Norwegian-focus case
+    /// that produced the original bug ("med fokus på norske utøvere", "bare de
+    /// norske"). Everything else is `.sportAsSuch` (the default). The mock only
+    /// needs this one lens to exercise the pipeline; the real FM model also
+    /// emits the richer `.throughAthletes` lens, and `MutationGrounder`
+    /// re-checks every lens regardless of where it came from.
+    static func detectLens(in utterance: String) -> Lens {
+        let n = " " + TextMatch.normalize(utterance) + " "
+        let norwegianFocus = [" norske ", " norsk ", " nordmenn ", " nordmennene "]
+        if norwegianFocus.contains(where: n.contains) { return .throughNorwegians }
+        return .sportAsSuch
     }
 
     static func weight(for intent: Intent) -> Double? {
@@ -210,22 +240,26 @@ enum MockInterestParser {
 
     // MARK: - Norwegian reason text (always filled)
 
-    static func entityReason(intent: Intent, name: String, scope: String?) -> String {
+    static func entityReason(intent: Intent, name: String, scope: String?, lens: Lens) -> String {
         let s = scope.map { " (\($0))" } ?? ""
+        let base: String
         switch intent {
-        case .add: return "Du ba om å følge \(name)\(s)."
-        case .increase: return "Du ba om å prioritere \(name) høyere\(s)."
-        case .decrease: return "Du ba om å nedprioritere \(name)\(s)."
-        case .remove: return "Du ba om å slutte å følge \(name)."
+        case .add: base = "Du ba om å følge \(name)\(s)."
+        case .increase: base = "Du ba om å prioritere \(name) høyere\(s)."
+        case .decrease: base = "Du ba om å nedprioritere \(name)\(s)."
+        case .remove: base = "Du ba om å slutte å følge \(name)."
         }
+        return lens.isDefault ? base : "\(base) Fokus: \(lens.label)."
     }
 
-    static func sportReason(intent: Intent, display: String, entityName: String, scope: String?) -> String {
+    static func sportReason(intent: Intent, display: String, entityName: String, scope: String?, lens: Lens) -> String {
         let s = scope.map { " \($0)" } ?? ""
+        let base: String
         switch intent {
-        case .add, .increase: return "Du vil se mer \(display)\(s). Legger til \(entityName)."
-        case .decrease: return "Du vil se mindre \(display). Nedprioriterer \(entityName)."
-        case .remove: return "Du ba om å slutte med \(display)."
+        case .add, .increase: base = "Du vil se mer \(display)\(s). Legger til \(entityName)."
+        case .decrease: base = "Du vil se mindre \(display). Nedprioriterer \(entityName)."
+        case .remove: base = "Du ba om å slutte med \(display)."
         }
+        return lens.isDefault ? base : "\(base) Fokus: \(lens.label)."
     }
 }

--- a/ios/Zenji/Assistant/MutationGrounder.swift
+++ b/ios/Zenji/Assistant/MutationGrounder.swift
@@ -48,6 +48,7 @@ enum MutationGrounder {
             case .add, .remove:
                 scope = proposal.scope
             }
+            let lens = groundedLens(for: proposal, previous: previous, index: index)
 
             grounded.append(GroundedMutation(
                 kind: proposal.kind,
@@ -55,11 +56,45 @@ enum MutationGrounder {
                 scope: scope,
                 weight: weight,
                 reason: proposal.reason,
-                previousRule: previous
+                previousRule: previous,
+                lens: lens
             ))
         }
 
         return GroundingResult(grounded: grounded, rejected: rejected)
+    }
+
+    // MARK: - Lens grounding
+
+    /// Grounds a proposal's lens the same way the entity id is grounded (WP-16.1):
+    ///   • `.remove` never carries a lens — you don't stop-following "through" a
+    ///     perspective.
+    ///   • `.throughAthletes` ids are re-checked against the index, exactly like
+    ///     the top-level entity id. Ids that don't resolve are dropped (and their
+    ///     display name is normalised to the index's canonical name); if none
+    ///     survive, the lens degrades to `.sportAsSuch`.
+    ///   • An `.update` that specifies no lens (`.sportAsSuch`, the default)
+    ///     inherits the existing rule's lens, mirroring how scope/weight carry
+    ///     over.
+    private static func groundedLens(for proposal: ProposedMutation, previous: InterestRule?, index: EntityIndex) -> Lens {
+        switch proposal.kind {
+        case .remove:
+            return .sportAsSuch
+        case .add:
+            return resolve(proposal.lens, index: index)
+        case .update:
+            return proposal.lens.isDefault ? (previous?.lens ?? .sportAsSuch) : resolve(proposal.lens, index: index)
+        }
+    }
+
+    private static func resolve(_ lens: Lens, index: EntityIndex) -> Lens {
+        guard case let .throughAthletes(athletes) = lens else { return lens }
+        var seen = Set<String>()
+        let grounded = athletes.compactMap { athlete -> LensAthlete? in
+            guard let entity = index.entity(id: athlete.entityId), seen.insert(entity.id).inserted else { return nil }
+            return LensAthlete(entityId: entity.id, name: entity.name)
+        }
+        return grounded.isEmpty ? .sportAsSuch : .throughAthletes(grounded)
     }
 
     // MARK: - Rejection

--- a/ios/ZenjiTests/AssistantViewModelTests.swift
+++ b/ios/ZenjiTests/AssistantViewModelTests.swift
@@ -91,6 +91,58 @@ final class AssistantViewModelTests: XCTestCase {
         XCTAssertTrue(vm.rejected[0].explanation.contains("cricket"))
     }
 
+    // MARK: - Lens end-to-end (WP-16.1) — the original bug utterance
+
+    func test_submit_lensThroughNorwegians_appliesAndPersists() async {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+        vm.utterance = "Følg Tour de France med fokus på norske utøvere"
+        await vm.submit()
+
+        // A confirmable change — NOT the old dead-end "fant ingen endringer".
+        XCTAssertNil(vm.explanation)
+        XCTAssertEqual(vm.pending.map(\.entity.id), ["tour-de-france-2026"])
+        XCTAssertEqual(vm.pending.first?.lens, .throughNorwegians)
+
+        vm.confirm(vm.pending[0])
+        XCTAssertEqual(vm.profile.rule(for: "tour-de-france-2026")?.lens, .throughNorwegians)
+
+        // The perspective survives a persistence round-trip.
+        let reloaded = makeVM(store: store)
+        XCTAssertEqual(reloaded.profile.rule(for: "tour-de-france-2026")?.lens, .throughNorwegians)
+    }
+
+    // MARK: - Always-explain (WP-16.1) — no bare "fant ingen endringer"
+
+    func test_submit_producesNothing_explainsHonestly() async {
+        // A usable model that returned no structured output — the exact device
+        // bug. The UI must get a structured explanation, never a dead end.
+        let vm = makeVM(behavior: .producesNothing)
+        vm.utterance = "gjør noe fint med sporten min"
+        await vm.submit()
+
+        XCTAssertTrue(vm.pending.isEmpty)
+        XCTAssertNil(vm.errorMessage)
+        let explanation = try? XCTUnwrap(vm.explanation)
+        XCTAssertNotNil(explanation)
+        XCTAssertFalse(explanation?.understood.isEmpty ?? true)
+        XCTAssertFalse(explanation?.reason.isEmpty ?? true)
+        XCTAssertNotEqual(explanation?.reason, "Fant ingen endringer i det du skrev.",
+                          "the forbidden dead-end message must never appear")
+    }
+
+    func test_submit_unknownEntity_explainsAndSuggests() async {
+        let vm = makeVM()
+        vm.utterance = "Følg quidditch"
+        await vm.submit()
+
+        XCTAssertTrue(vm.pending.isEmpty)
+        XCTAssertEqual(vm.rejected.count, 1, "the unknown thing is shown as a rejection")
+        XCTAssertNotNil(vm.explanation, "and it is explained, not collapsed to silence")
+        XCTAssertTrue(vm.explanation?.reason.contains("quidditch") ?? false,
+                      "the explanation names what couldn't be found")
+    }
+
     func test_submit_whenUnavailable_setsErrorMessage() async {
         let vm = makeVM(behavior: .unavailable("Apple Intelligence er av."))
         vm.utterance = "Følg Lyn"

--- a/ios/ZenjiTests/MockInterestAssistantTests.swift
+++ b/ios/ZenjiTests/MockInterestAssistantTests.swift
@@ -130,6 +130,41 @@ final class MockInterestAssistantTests: XCTestCase {
         XCTAssertEqual(p[0].entityQuery, "cricket")  // carried for the "mente du …?" suggestion
     }
 
+    // MARK: - 11. Lens — the original bug ("med fokus på norske utøvere")
+
+    func test11_følgTourDeFranceMedFokusPåNorske() {
+        // The exact first-user-test utterance that WP-16 produced no mutation for.
+        let p = parse("Følg Tour de France med fokus på norske utøvere")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .add)
+        XCTAssertEqual(p[0].entityId, "tour-de-france-2026")
+        XCTAssertEqual(p[0].lens, .throughNorwegians, "«med fokus på norske» must become the Norwegian lens")
+        XCTAssertNil(p[0].scope)
+        XCTAssertTrue(p[0].reason.contains("norske"), "the reason names the perspective")
+    }
+
+    func test11b_plainAdd_hasDefaultLens() {
+        // No focus phrase → the neutral default, so existing behaviour is unchanged.
+        let p = parse("Følg Magnus Carlsen")
+        XCTAssertEqual(p[0].lens, .sportAsSuch)
+        XCTAssertTrue(p[0].lens.isDefault)
+    }
+
+    func test11c_wholeSportWithNorwegianFocus_carriesLens() {
+        // "Mer sykkel" is a whole-sport command; "de norske" is its lens.
+        let p = parse("Mer sykkel, bare de norske")
+        XCTAssertEqual(p.count, 1)
+        XCTAssertEqual(p[0].kind, .update)
+        XCTAssertEqual(p[0].lens, .throughNorwegians)
+    }
+
+    func test11d_removeNeverCarriesLens() {
+        // A lens makes no sense on a remove, even if the phrase is present.
+        let p = parse("Slutt med tennis, de norske", profile: profileFollowingRuud())
+        XCTAssertEqual(p.map(\.kind), [.remove])
+        XCTAssertEqual(p[0].lens, .sportAsSuch)
+    }
+
     // MARK: - Availability + async surface
 
     func test_availability_reflectsBehavior() {

--- a/ios/ZenjiTests/MutationGrounderTests.swift
+++ b/ios/ZenjiTests/MutationGrounderTests.swift
@@ -102,4 +102,66 @@ final class MutationGrounderTests: XCTestCase {
         XCTAssertEqual(result.grounded.map(\.entity.id), ["magnus-carlsen"])
         XCTAssertEqual(result.rejected.map(\.query), ["quidditch"])
     }
+
+    // MARK: - Lens grounding (WP-16.1)
+
+    func test_lens_throughNorwegians_survivesGroundingOnAdd() {
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "tour-de-france-2026", entityQuery: "Tour de France",
+            reason: "følg", lens: .throughNorwegians
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+        XCTAssertEqual(result.grounded.count, 1)
+        XCTAssertEqual(result.grounded[0].lens, .throughNorwegians)
+    }
+
+    func test_lens_throughAthletes_isGroundedLikeAnEntityId() {
+        // Valid + hallucinated athlete ids mixed: the bogus one is dropped, the
+        // real one survives with the index's CANONICAL display name.
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "tour-de-france-2026", entityQuery: "Tour de France", reason: "følg",
+            lens: .throughAthletes([
+                LensAthlete(entityId: "jonas-abrahamsen", name: "feil navn"),
+                LensAthlete(entityId: "does-not-exist", name: "spøkelse")
+            ])
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+        XCTAssertEqual(result.grounded.count, 1)
+        guard case let .throughAthletes(athletes) = result.grounded[0].lens else {
+            return XCTFail("expected a throughAthletes lens")
+        }
+        XCTAssertEqual(athletes.map(\.entityId), ["jonas-abrahamsen"], "hallucinated id dropped")
+        XCTAssertEqual(athletes.first?.name, "Jonas Abrahamsen", "display name normalised to the index")
+    }
+
+    func test_lens_throughAthletes_degradesToSportAsSuch_whenNoneResolve() {
+        let proposal = ProposedMutation(
+            kind: .add, entityId: "tour-de-france-2026", entityQuery: "Tour de France", reason: "følg",
+            lens: .throughAthletes([LensAthlete(entityId: "nobody", name: "Nobody")])
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+        XCTAssertEqual(result.grounded[0].lens, .sportAsSuch, "no surviving athlete → neutral default")
+    }
+
+    func test_lens_updateWithoutLens_inheritsPreviousLens() {
+        let tdf = index.entity(id: "tour-de-france-2026")!
+        let profile = InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: tdf, scope: nil, weight: 0.5, reason: "seed",
+            previousRule: nil, lens: .throughNorwegians
+        ))
+        // An update that specifies no lens keeps the existing perspective, exactly
+        // like scope/weight carry over.
+        let proposal = ProposedMutation(kind: .update, entityId: "tour-de-france-2026", entityQuery: "TdF", reason: "endre")
+        let result = MutationGrounder.ground([proposal], index: index, profile: profile)
+        XCTAssertEqual(result.grounded[0].lens, .throughNorwegians)
+    }
+
+    func test_lens_removeNeverCarriesLens() {
+        let proposal = ProposedMutation(
+            kind: .remove, entityId: "tour-de-france-2026", entityQuery: "TdF",
+            reason: "slutt", lens: .throughNorwegians
+        )
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+        XCTAssertEqual(result.grounded[0].lens, .sportAsSuch)
+    }
 }

--- a/ios/ZenjiTests/ProfileStoreTests.swift
+++ b/ios/ZenjiTests/ProfileStoreTests.swift
@@ -60,4 +60,37 @@ final class ProfileStoreTests: XCTestCase {
         XCTAssertEqual(loaded.rule(for: "casper-ruud")?.reason, "fordi Ruud")
         XCTAssertFalse(loaded.rules.contains { $0.reason.isEmpty }, "every rule keeps its Norwegian reason")
     }
+
+    // MARK: - Lens persistence (WP-16.1)
+
+    func test_lensSurvivesRoundTrip() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let profile = InterestProfile()
+            .applying(GroundedMutation(kind: .add, entity: index.entity(id: "tour-de-france-2026")!,
+                                       scope: nil, weight: 0.5, reason: "norsk fokus",
+                                       previousRule: nil, lens: .throughNorwegians), now: now)
+            .applying(GroundedMutation(kind: .add, entity: index.entity(id: "esports-world-cup-2026-chess")!,
+                                       scope: nil, weight: 0.5, reason: "utvalgte",
+                                       previousRule: nil,
+                                       lens: .throughAthletes([LensAthlete(entityId: "magnus-carlsen", name: "Magnus Carlsen")])),
+                      now: now)
+        let store = AssistantTestSupport.tempProfileStore()
+        try store.save(profile)
+        let loaded = store.load()
+        XCTAssertEqual(loaded, profile, "the lens (both cases) round-trips through JSON unchanged")
+        XCTAssertEqual(loaded.rule(for: "tour-de-france-2026")?.lens, .throughNorwegians)
+    }
+
+    func test_papersOverPreLensProfile_defaultsToSportAsSuch() throws {
+        // A profile written by WP-16 (before the lens existed) has no `lens` key.
+        let store = AssistantTestSupport.tempProfileStore()
+        let json = """
+        { "rules": [ { "entityId": "magnus-carlsen", "entityName": "Magnus Carlsen",
+          "sport": "chess", "weight": 0.5, "reason": "sjakk",
+          "addedAt": "2026-01-01T00:00:00Z" } ] }
+        """
+        try Data(json.utf8).write(to: store.directoryURL.appendingPathComponent(ProfileStore.filename))
+        XCTAssertEqual(store.load().rule(for: "magnus-carlsen")?.lens, .sportAsSuch,
+                       "forward-compatible: a pre-lens rule defaults to the neutral lens")
+    }
 }


### PR DESCRIPTION
## Bakgrunn

Første brukertest av FM-assistenten (WP-16, merget #246) på eierens iPhone 16 Pro:
- «Følg Tour de France med fokus på norske utøvere» → **«fant ingen endringer i det du skrev»**
- «følg Magnus Carlsen» → fungerte

Begge entiteter finnes i `entities.json` (`tour-de-france-2026`, `magnus-carlsen`). To underliggende feil: (1) mutasjons-skjemaet manglet LINSE-konseptet, så «med fokus på norske» hadde ingen plass; (2) UI-et kollapset tomme/ugyldige svar til en intetsigende melding.

## Hva som er gjort

### 1. Linse i mutasjons-skjemaet
Entiteten sier *hva* som følges; **linsen** sier *hvordan*. Ny `Lens`:
- `.sportAsSuch` — hele sporten (standard; eksisterende adferd urørt)
- `.throughNorwegians` — «med fokus på norske utøvere» / «bare de norske»
- `.throughAthletes([LensAthlete])` — bestemte utøvere, med entity-id-er som **grounes akkurat som topp-nivå `entityId`** (ukjente droppes, navn normaliseres til indeksen, tom rest degraderer til `.sportAsSuch`)

Bærer gjennom hele røret: `ProposedMutation` → `GroundedMutation` → persistert `InterestRule` (forward-compat decode). `.remove` bærer aldri linse; en `.update` uten eksplisitt linse arver den forrige (som scope/vekt). Speilet i FM-skjemaet (`@Generable` `lens`/`lensAthleteIds` + norske session-eksempler) og synlig som en rolig undertittel i diff-UI-et og «Hva jeg følger» («gjennom norske utøvere»).

### 2. Alltid-forklar-regelen
«Fant ingen endringer» er **forbudt**. Når en ytring ikke gir en bekreftbar endring, bygger `AssistantExplanation.make(…)` (ren, enhetstestet) et ærlig, strukturert svar UI-et viser ordrett — *hva den forsto* + *hvorfor* ingenting endret seg (ikke i indeksen + «mente du …?», ikke synket ennå, eller intensjonen kan ikke uttrykkes som en regelendring). Ny `MockInterestAssistant.Behavior.producesNothing` gjør bug-tilfellet testbart uten Apple Intelligence.

## Testing
- **166/166 iOS-tester** (`iPhone 17 Pro`-simulator): 152 baseline urørt grønne + 14 nye — linse-deteksjon/grounding/persistens + alltid-forklar-kontrakten, inkl. den eksakte ytringen som først feilet: `«Følg Tour de France med fokus på norske utøvere»` → `add(tour-de-france-2026, lens: .throughNorwegians)`.
- **npm test uendret grønt** (369/369).

## Installasjon
`ZenjiDeviceDev` rebygget/signert for tilkoblet iPhone 16 Pro (`-allowProvisioningUpdates CODE_SIGNING_ALLOWED=YES CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=9LVCB72DT8`, **BUILD SUCCEEDED**) og re-installert via `xcrun devicectl device install app` — den nye linse + alltid-forklar-byggingen bærer nå `app.zenji.ios` på enheten. Den on-device Apple Intelligence-bekreftelsen av selve ytringen gjenstår som manuelt steg (krever engangs utvikler-trust på enheten).

## Docs
`ios/README.md` (linse + alltid-forklar + oppdatert testtall + WP-16.1 device-note) og `PLAN.md` (én linje i WP-16-seksjonen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)