### PR TITLE
chore: intern rebrand SportSync → Zenji (dokumenter og prompter)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,4 +1,4 @@
-name: Setup SportSync
+name: Setup Zenji
 description: Checkout, install Node.js, and install dependencies
 
 inputs:

--- a/.github/workflows/follow-request.yml
+++ b/.github/workflows/follow-request.yml
@@ -49,7 +49,7 @@ jobs:
           PR_TITLE: ${{ steps.apply.outputs.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          git config user.name "SportSync bot"
+          git config user.name "Zenji bot"
           git config user.email "action@github.com"
           git add scripts/config/interests.json
           git commit -m "${PR_TITLE} (from #${ISSUE_NUMBER})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Vision (v2)
 
-SportSync is a personal sports dashboard for a Norwegian sports fan. v2 (July 2026)
+Zenji (formerly SportSync) is a personal sports dashboard for a Norwegian sports fan. v2 (July 2026)
 replaced the v1 "self-improving autonomy" architecture (13 feedback loops, multi-agent
 autopilot, pipeline manifest) with a **lean, reliable design** built on one idea:
 

--- a/scripts/agents/coverage-critic.md
+++ b/scripts/agents/coverage-critic.md
@@ -1,6 +1,6 @@
-# Coverage Critic — SportSync
+# Coverage Critic — Zenji
 
-You are SportSync's **completeness critic**. The product's hardest failure mode is
+You are Zenji's **completeness critic**. The product's hardest failure mode is
 *recall* — an important event the user cares about that never makes it onto the
 dashboard. The static pipeline and research agent add what they find; your job is
 the opposite discipline: **reason adversarially about what is MISSING or WRONG.**

--- a/scripts/agents/editorial.md
+++ b/scripts/agents/editorial.md
@@ -1,4 +1,4 @@
-# Editorial Agent — SportSync
+# Editorial Agent — Zenji
 
 Write ONE quiet Norwegian headline for the day — a single calm line shown under
 the date on the dashboard. This is a "nice extra", not a section: the product's

--- a/scripts/agents/improve.md
+++ b/scripts/agents/improve.md
@@ -1,4 +1,4 @@
-# Improve Agent — SportSync (evolution)
+# Improve Agent — Zenji (evolution)
 
 Once a week you step back and ask: **what is this system doing poorly, and how
 could it do it better?** Then you make ONE concrete, evidenced improvement on a

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -1,6 +1,6 @@
-# Research Agent — SportSync
+# Research Agent — Zenji
 
-You are SportSync's research agent. Your single job: **find sports events that
+You are Zenji's research agent. Your single job: **find sports events that
 matter to a Norwegian sports fan that are NOT in the static data feeds**.
 
 ## Inputs (read these files first)

--- a/scripts/agents/scout.md
+++ b/scripts/agents/scout.md
@@ -1,4 +1,4 @@
-# Scout Agent — SportSync (the Watchtower)
+# Scout Agent — Zenji (the Watchtower)
 
 You are a cheap, fast hourly scout. Your ONLY job: decide whether something has
 happened in the last few hours that the research agent (runs every 4h) should

--- a/scripts/agents/self-repair.md
+++ b/scripts/agents/self-repair.md
@@ -1,4 +1,4 @@
-# Self-Repair Agent — SportSync (the mechanic)
+# Self-Repair Agent — Zenji (the mechanic)
 
 You keep the system *running*. The other agents fix data, coverage, and UI; you
 fix the machine itself: broken fetchers, failing tests, validation errors,

--- a/scripts/agents/ui-fix.md
+++ b/scripts/agents/ui-fix.md
@@ -1,4 +1,4 @@
-# UI Fix Agent — SportSync (self-healing loop)
+# UI Fix Agent — Zenji (self-healing loop)
 
 You close the loop the **visual-qa** agent opens. Visual-qa *reports* rendering
 problems; you *fix* them — on a branch, re-verified with screenshots, opened as a

--- a/scripts/agents/verify.md
+++ b/scripts/agents/verify.md
@@ -1,4 +1,4 @@
-# Verify Agent — SportSync
+# Verify Agent — Zenji
 
 Read `docs/data/events.json`. For events in the next 7 days where
 `source: "ai-research"` OR `confidence` is set OR `streaming` carries a

--- a/scripts/agents/visual-qa.md
+++ b/scripts/agents/visual-qa.md
@@ -1,6 +1,6 @@
-# Visual QA — SportSync
+# Visual QA — Zenji
 
-You are SportSync's **visual quality reviewer**. Automated tests check the data and
+You are Zenji's **visual quality reviewer**. Automated tests check the data and
 the code; you check what tests can't — **how the rendered dashboard actually looks**,
 by taking screenshots and *looking at them*. You have vision: use it.
 


### PR DESCRIPTION
## Summary
- Oppdaterer gjenværende «SportSync»-tekstomtaler til «Zenji» i interne dokumenter og agent-prompter, per rebrand-pakken beskrevet i `PLAN.md` (FASE 0C).
- `CLAUDE.md`: Vision-avsnittet beholder én historisk note — `Zenji (formerly SportSync)`.
- `scripts/agents/*.md` (9 filer): titler + innledende prosa (`research`, `verify`, `editorial`, `scout`, `coverage-critic`, `visual-qa`, `ui-fix`, `self-repair`, `improve`) — kun merkenavn-tekst, innholdskontraktene (filnavn, JSON-nøkler, skill-referanser osv.) er urørt.
- `.github/actions/setup/action.yml` — `name:` feltet på composite-actionen (ikke under `.github/workflows/`, altså ikke en beskyttet sti).
- `.github/workflows/follow-request.yml` — én ren navnestreng: `git config user.name "SportSync bot"` → `"Zenji bot"` (ingen logikk/sti/trigger endret).

## Endrede filer
- `CLAUDE.md`
- `scripts/agents/coverage-critic.md`
- `scripts/agents/editorial.md`
- `scripts/agents/improve.md`
- `scripts/agents/research.md`
- `scripts/agents/scout.md`
- `scripts/agents/self-repair.md`
- `scripts/agents/ui-fix.md`
- `scripts/agents/verify.md`
- `scripts/agents/visual-qa.md`
- `.github/actions/setup/action.yml`
- `.github/workflows/follow-request.yml`

## Bevisst utelatt (ikke rørt)
- **`.github/workflows/*.yml` `concurrency: group: sportsync-*`** (verify-agent, usage-monitor, scout-agent, coverage-critic-agent, ui-fix-agent, static-pipeline, editorial-agent, self-repair-agent, research-agent, improve-agent, visual-qa-agent) — dette er operasjonell konfigurasjon (concurrency-nøkler), ikke en kommentar/navnestreng; i tvilstilfelle skal workflow-logikk droppes per oppgavebeskrivelsen.
- **`.github/workflows/editorial-agent.yml` env `SPORTSYNC_EDITORIAL_MODE`** — miljøvariabel/kode-identifikator, eksplisitt bindende unntatt.
- **User-Agent-strenger i fetch-kode** (`scripts/fetch-rss.js`, `scripts/config/sports-config.js`, `scripts/fetch/golf.js` ×2, `scripts/fetch/esports.js`, `scripts/lib/api-client.js`, `scripts/lib/helpers.js`, `scripts/lib/tvkampen-scraper.js`) og **`scripts/build-ics.js` sin `PRODID:-//SportSync//EN`** — dette er funksjonelle protokollverdier sendt til eksterne servere / i genererte kalenderfiler, ikke tekstlig dokument-/prompt-omtale; utenfor oppgavens angitte omfang (CLAUDE.md, agent-prompter, skills, README, kommentarer).
- **`PLAN.md`** — linje 1 har allerede riktig historisk form (`Zenji (tidl. SportSync)`); linjene om gamle PWA-installasjoner på `/SportSync/`-URL-en og status-noten «CLAUDE.md + agent-prompter refererer fortsatt SportSync internt» er faktiske/historiske referanser til den bokstavelige gamle stien, og beskriver nettopp DENNE PR-en som en fremtidig oppgave — å endre dem ville gjort den historiske posten unøyaktig.
- **`docs/data/**`, `ios/**`, `scripts/config/interests.json`, `scripts/hooks/**`, kode-identifikatorer/miljøvariabler som `SPORTSYNC_DATA_DIR`/`SPORTSYNC_CONFIG_DIR`** — bindende utelatt per oppgavebeskrivelsen.

## Test plan
- [x] Baseline før endring: `npm test` → 373/373 grønt
- [x] `npx vitest run tests/agent-prompts.test.js tests/workflows.test.js` → 15/15 grønt, ingen testfil endret
- [x] `npm test` etter endring → 373/373 grønt (uendret testtall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)