### PR TITLE
WP-51: tester for rss/standings pure-funksjoner

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -72,7 +72,7 @@ mennesket, aldri av en agent.
 | WP-48 | iOS: Profile/-modul + demo/mock-karantene | 0D | – | ⬜ køet |
 | WP-49 | Repo-vekt: skjermbilde-sanering + policy | 0D | – | ⬜ køet |
 | WP-50 | iOS: README-restrukturering | 0D | WP-48,WP-49 | ⬜ køet |
-| WP-51 | Testdekning: eksporterte pure-funksjoner | 0D | – | 🔬 PR åpnet — 32 nye tester (fetch-rss 23, buildDriverTeamMap 9), 405/405 grønt, kjøretid uendret ~5,3 s |
+| WP-51 | Testdekning: eksporterte pure-funksjoner | 0D | – | 🔬 PR åpnet (#266) — 32 nye tester (fetch-rss 23, buildDriverTeamMap 9), 405/405 grønt, kjøretid uendret ~5,3 s |
 | WP-52 | Dok-resynk (kjøres sist) | 0D | alle 0D | ⬜ køet |
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -72,7 +72,7 @@ mennesket, aldri av en agent.
 | WP-48 | iOS: Profile/-modul + demo/mock-karantene | 0D | – | ⬜ køet |
 | WP-49 | Repo-vekt: skjermbilde-sanering + policy | 0D | – | ⬜ køet |
 | WP-50 | iOS: README-restrukturering | 0D | WP-48,WP-49 | ⬜ køet |
-| WP-51 | Testdekning: eksporterte pure-funksjoner | 0D | – | ⬜ køet |
+| WP-51 | Testdekning: eksporterte pure-funksjoner | 0D | – | 🔬 PR åpnet — 32 nye tester (fetch-rss 23, buildDriverTeamMap 9), 405/405 grønt, kjøretid uendret ~5,3 s |
 | WP-52 | Dok-resynk (kjøres sist) | 0D | alle 0D | ⬜ køet |
 
 ---

--- a/tests/fetch-rss.test.js
+++ b/tests/fetch-rss.test.js
@@ -1,0 +1,185 @@
+// fetch-rss: pure-function coverage — RSS parsing, recency filter, per-sport cap,
+// Norwegian relevance. House style: import the exports, inline fixtures, no network.
+import { describe, it, expect } from "vitest";
+import { parseRssItems, filterRecent, applyPerSportCap, isNorwegianRelevant } from "../scripts/fetch-rss.js";
+
+// --- parseRssItems ---
+
+const RSS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel>
+<title>Feed</title>
+<item>
+  <title><![CDATA[Haaland scorer hat-trick &amp; jubler]]></title>
+  <description><![CDATA[<p>Manchester City vant <b>5-0</b> mot Luton.</p>]]></description>
+  <link>https://example.com/haaland</link>
+  <pubDate>Mon, 13 Jul 2026 18:00:00 GMT</pubDate>
+  <category>Football</category>
+  <category><![CDATA[Premier League]]></category>
+</item>
+<item>
+  <title>Ruud &amp; Alcaraz &#039;klare&#039; for &quot;finale&quot;</title>
+  <link>https://example.com/ruud</link>
+  <dc:date>2026-07-13T12:00:00Z</dc:date>
+</item>
+<item>
+  <title>Long one</title>
+  <description>${"x".repeat(300)}</description>
+</item>
+<item>
+  <description>No title here — should be skipped</description>
+</item>
+</channel>
+</rss>`;
+
+describe("parseRssItems", () => {
+	const items = parseRssItems(RSS_XML);
+
+	it("parses items and skips those without a title", () => {
+		expect(items).toHaveLength(3);
+	});
+
+	it("extracts title (CDATA + entity-decoded), link, pubDate and all categories", () => {
+		const item = items[0];
+		expect(item.title).toBe("Haaland scorer hat-trick & jubler");
+		expect(item.link).toBe("https://example.com/haaland");
+		expect(item.pubDate).toBe("Mon, 13 Jul 2026 18:00:00 GMT");
+		expect(item.categories).toEqual(["Football", "Premier League"]);
+	});
+
+	it("strips HTML tags from descriptions", () => {
+		expect(items[0].description).toBe("Manchester City vant 5-0 mot Luton.");
+	});
+
+	it("decodes entities in plain (non-CDATA) titles", () => {
+		expect(items[1].title).toBe(`Ruud & Alcaraz 'klare' for "finale"`);
+	});
+
+	it("falls back to dc:date when pubDate is missing", () => {
+		expect(items[1].pubDate).toBe("2026-07-13T12:00:00Z");
+	});
+
+	it("truncates descriptions to 200 chars", () => {
+		expect(items[2].description).toHaveLength(200);
+	});
+
+	it("defaults missing optional fields (link, pubDate, categories)", () => {
+		expect(items[2].link).toBe("");
+		expect(items[2].pubDate).toBe("");
+		expect(items[2].categories).toEqual([]);
+	});
+
+	it("returns [] for empty or item-less input", () => {
+		expect(parseRssItems("")).toEqual([]);
+		expect(parseRssItems("<rss><channel><title>tom</title></channel></rss>")).toEqual([]);
+	});
+});
+
+// --- filterRecent ---
+
+describe("filterRecent", () => {
+	const hoursOld = (h) => new Date(Date.now() - h * 60 * 60 * 1000).toUTCString();
+	const items = [
+		{ title: "fresh", pubDate: hoursOld(1) },
+		{ title: "stale", pubDate: hoursOld(48) },
+		{ title: "undated", pubDate: "" },
+		{ title: "garbage", pubDate: "not a date" },
+	];
+
+	it("keeps items inside the default 24h window and drops older ones", () => {
+		const kept = filterRecent(items).map((i) => i.title);
+		expect(kept).toContain("fresh");
+		expect(kept).not.toContain("stale");
+	});
+
+	it("keeps items without a pubDate", () => {
+		expect(filterRecent(items).map((i) => i.title)).toContain("undated");
+	});
+
+	it("drops items with an unparseable pubDate", () => {
+		expect(filterRecent(items).map((i) => i.title)).not.toContain("garbage");
+	});
+
+	it("respects a custom window", () => {
+		expect(filterRecent(items, 72).map((i) => i.title)).toEqual(["fresh", "stale", "undated"]);
+	});
+});
+
+// --- applyPerSportCap ---
+
+describe("applyPerSportCap", () => {
+	// Items must arrive sorted newest-first (the caller's contract).
+	const mkItem = (sport, minutesAgo, tag) => ({
+		sport,
+		title: `${sport || "untagged"}-${tag}`,
+		pubDate: new Date(Date.parse("2026-07-14T12:00:00Z") - minutesAgo * 60 * 1000).toISOString(),
+	});
+	const general = Array.from({ length: 10 }, (_, i) => mkItem("general", i, i));
+	const football = Array.from({ length: 4 }, (_, i) => mkItem("football", 100 + i, i));
+	const golf = Array.from({ length: 3 }, (_, i) => mkItem("golf", 200 + i, i));
+	const sorted = [...general, ...football, ...golf];
+
+	it("guarantees minPerSport items per sport before filling with newest", () => {
+		const result = applyPerSportCap(sorted, 10, 3);
+		const counts = {};
+		for (const item of result) counts[item.sport] = (counts[item.sport] || 0) + 1;
+		// Without the guarantee, pure date-sort would give 10 general and 0 football/golf.
+		expect(counts).toEqual({ general: 4, football: 3, golf: 3 });
+	});
+
+	it("keeps the newest items within each guaranteed sport and caps the total", () => {
+		const result = applyPerSportCap(sorted, 10, 3);
+		expect(result).toHaveLength(10);
+		const footballTitles = result.filter((i) => i.sport === "football").map((i) => i.title);
+		expect(footballTitles.sort()).toEqual(["football-0", "football-1", "football-2"]);
+	});
+
+	it("returns the result sorted newest-first", () => {
+		const result = applyPerSportCap(sorted, 10, 3);
+		const times = result.map((i) => new Date(i.pubDate).getTime());
+		expect(times).toEqual([...times].sort((a, b) => b - a));
+	});
+
+	it("returns everything when there are fewer items than the cap", () => {
+		expect(applyPerSportCap(sorted.slice(0, 5), 40, 3)).toHaveLength(5);
+	});
+
+	it("treats items without a sport as 'general'", () => {
+		const untagged = Array.from({ length: 4 }, (_, i) => mkItem(undefined, i, i));
+		const result = applyPerSportCap([...untagged, ...football], 6, 3);
+		// 3 untagged (general bucket) + 3 football guaranteed = 6; the 4th untagged is cut.
+		expect(result.filter((i) => !i.sport)).toHaveLength(3);
+		expect(result.filter((i) => i.sport === "football")).toHaveLength(3);
+	});
+});
+
+// --- isNorwegianRelevant ---
+
+describe("isNorwegianRelevant", () => {
+	const mk = (title, description = "", categories = []) => ({ title, description, categories });
+
+	it("always keeps Norwegian-language items", () => {
+		expect(isNorwegianRelevant(mk("Lokalfotball i 3. divisjon"), "no")).toBe(true);
+	});
+
+	it("matches a keyword in the title, case-insensitively", () => {
+		expect(isNorwegianRelevant(mk("HAALAND hat-trick sinks Wolves"), "en")).toBe(true);
+	});
+
+	it("matches a keyword in the description", () => {
+		expect(isNorwegianRelevant(mk("Premier League roundup", "Martin Odegaard set up both goals"), "en")).toBe(true);
+	});
+
+	it("matches a keyword in the categories", () => {
+		expect(isNorwegianRelevant(mk("World championship latest", "", ["Magnus Carlsen"]), "en")).toBe(true);
+	});
+
+	it("rejects non-Norwegian-relevant English items", () => {
+		expect(isNorwegianRelevant(mk("Chelsea appoint new manager", "A quiet day at Stamford Bridge", ["Football"]), "en")).toBe(false);
+	});
+
+	it("matches Norwegian characters in keywords (ødegaard, klæbo)", () => {
+		expect(isNorwegianRelevant(mk("Ødegaard tilbake fra skade"), "en")).toBe(true);
+		expect(isNorwegianRelevant(mk("Klæbo dominates sprint"), "en")).toBe(true);
+	});
+});

--- a/tests/fetch-standings.test.js
+++ b/tests/fetch-standings.test.js
@@ -1,0 +1,141 @@
+// fetch-standings: buildDriverTeamMap — infers driver→team from ESPN F1 standings
+// by correlating each constructor's per-race points with pairs of drivers whose
+// per-race points sum to them. No network; fixtures mirror ESPN's entry shape.
+import { describe, it, expect } from "vitest";
+import { buildDriverTeamMap } from "../scripts/fetch-standings.js";
+
+// ESPN marks per-race stats with `played`; season aggregates (rank, points) lack it
+// and must be ignored by the correlation.
+const raceStat = (name, value) => ({ name, value, played: true });
+const driver = (name, races) => ({
+	athlete: { displayName: name },
+	stats: [{ name: "rank", value: 1 }, ...Object.entries(races).map(([r, v]) => raceStat(r, v))],
+});
+const constructorEntry = (team, races) => ({
+	team: team ? { displayName: team } : {},
+	stats: [{ name: "points", value: 999 }, ...Object.entries(races).map(([r, v]) => raceStat(r, v))],
+});
+const group = (entries) => ({ standings: { entries } });
+
+describe("buildDriverTeamMap", () => {
+	it("maps each driver pair to the constructor whose per-race points they sum to", () => {
+		const drivers = [
+			driver("Lando Norris", { bahrain: 25, jeddah: 18 }),
+			driver("Oscar Piastri", { bahrain: 18, jeddah: 25 }),
+			driver("Max Verstappen", { bahrain: 15, jeddah: 12 }),
+			driver("Yuki Tsunoda", { bahrain: 12, jeddah: 10 }),
+		];
+		const constructors = group([
+			constructorEntry("McLaren", { bahrain: 43, jeddah: 43 }),
+			constructorEntry("Red Bull", { bahrain: 27, jeddah: 22 }),
+		]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({
+			"Lando Norris": "McLaren",
+			"Oscar Piastri": "McLaren",
+			"Max Verstappen": "Red Bull",
+			"Yuki Tsunoda": "Red Bull",
+		});
+	});
+
+	it("finds teammate pairs that are not adjacent in the driver standings", () => {
+		const drivers = [
+			driver("A1", { r1: 20 }),
+			driver("B1", { r1: 5 }),
+			driver("A2", { r1: 10 }),
+			driver("B2", { r1: 7 }),
+		];
+		const constructors = group([
+			constructorEntry("Team A", { r1: 30 }),
+			constructorEntry("Team B", { r1: 12 }),
+		]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({
+			A1: "Team A",
+			A2: "Team A",
+			B1: "Team B",
+			B2: "Team B",
+		});
+	});
+
+	it("treats races a driver missed as 0 points", () => {
+		const drivers = [
+			driver("Rookie", { r1: 6 }), // no r2 entry at all
+			driver("Veteran", { r1: 10, r2: 8 }),
+		];
+		const constructors = group([constructorEntry("Backmarker", { r1: 16, r2: 8 })]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({
+			Rookie: "Backmarker",
+			Veteran: "Backmarker",
+		});
+	});
+
+	it("returns an empty map when the constructor group is missing or empty", () => {
+		const drivers = [driver("Solo", { r1: 10 })];
+		expect(buildDriverTeamMap(drivers, undefined)).toEqual({});
+		expect(buildDriverTeamMap(drivers, null)).toEqual({});
+		expect(buildDriverTeamMap(drivers, group([]))).toEqual({});
+		expect(buildDriverTeamMap(drivers, { standings: {} })).toEqual({});
+	});
+
+	it("skips constructors without a team name", () => {
+		const drivers = [
+			driver("D1", { r1: 10 }),
+			driver("D2", { r1: 5 }),
+		];
+		// The nameless constructor's points would match (D1, D2) — it must be skipped,
+		// leaving the drivers unmapped rather than mapped to "".
+		const constructors = group([constructorEntry(null, { r1: 15 })]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({});
+	});
+
+	it("skips constructors with no per-race stats", () => {
+		const drivers = [
+			driver("D1", { r1: 10 }),
+			driver("D2", { r1: 5 }),
+		];
+		const noRaces = { team: { displayName: "Ghost" }, stats: [{ name: "points", value: 15 }] };
+		expect(buildDriverTeamMap(drivers, group([noRaces]))).toEqual({});
+	});
+
+	it("leaves drivers unmapped when no pair sums to the constructor's points", () => {
+		const drivers = [
+			driver("D1", { r1: 25 }),
+			driver("D2", { r1: 18 }),
+		];
+		const constructors = group([constructorEntry("Mismatch", { r1: 100 })]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({});
+	});
+
+	it("leaves the odd driver out when only one pair matches", () => {
+		const drivers = [
+			driver("Paired 1", { r1: 12 }),
+			driver("Paired 2", { r1: 8 }),
+			driver("Odd One", { r1: 3 }),
+		];
+		const constructors = group([constructorEntry("Team", { r1: 20 })]);
+		const map = buildDriverTeamMap(drivers, constructors);
+		expect(map).toEqual({ "Paired 1": "Team", "Paired 2": "Team" });
+		expect(map["Odd One"]).toBeUndefined();
+	});
+
+	it("degrades greedily on ambiguous all-zero (pre-season) data", () => {
+		// Before any race every pair sums to every constructor's 0 — the correlation
+		// cannot distinguish teams. Documents current behavior: greedy first-match
+		// assigns drivers in listing order (arbitrary but harmless pre-season).
+		const drivers = [
+			driver("D1", { r1: 0 }),
+			driver("D2", { r1: 0 }),
+			driver("D3", { r1: 0 }),
+			driver("D4", { r1: 0 }),
+		];
+		const constructors = group([
+			constructorEntry("Team X", { r1: 0 }),
+			constructorEntry("Team Y", { r1: 0 }),
+		]);
+		expect(buildDriverTeamMap(drivers, constructors)).toEqual({
+			D1: "Team X",
+			D2: "Team X",
+			D3: "Team Y",
+			D4: "Team Y",
+		});
+	});
+});


### PR DESCRIPTION
## WP-51 · Testdekning: eksporterte pure-funksjoner (FASE 0D)

32 nye network-frie tester i husstilen (`tests/esports.test.js`-mønsteret: importer eksportene, inline fixtures), i to nye filer. Ingen produksjonskode endret.

### `tests/fetch-rss.test.js` (23 tester)
- **`parseRssItems`** — items med CDATA + entity-dekoding, HTML-stripping i beskrivelser, 200-tegns-trunkering, `dc:date`-fallback, alle `<category>`-tagger, tittel-løse items hoppes over, tomt input → `[]`
- **`filterRecent`** — 24h-default, custom vindu, udaterte items beholdes, uparsebar `pubDate` droppes
- **`applyPerSportCap`** — per-sport-minimumsgarantien (sport-spesifikke feeds trenges ikke ut av general-feeds), cap håndheves, nyeste-først-sortering bevares, `sport`-løse items telles som `general`
- **`isNorwegianRelevant`** — `lang: "no"` alltid relevant, nøkkelord i tittel/beskrivelse/kategorier (case-ufølsomt, æøå), ikke-relevante engelske items avvises

### `tests/fetch-standings.test.js` (9 tester)
- **`buildDriverTeamMap`** — den intrikate par-korrelasjonen: happy path (to constructors, fire førere), ikke-nabo-teammatepar, løp en fører ikke kjørte teller som 0, manglende/tom constructor-gruppe → `{}`, navnløse constructors hoppes over (ikke mappet til `""`), constructors uten `played`-stats hoppes over, umatchbare constructor-poeng lar førere stå umappet (fallback `""` i `fetchF1Standings`), odde fører uten par forblir umappet, og grådig degradering på tvetydig all-null pre-season-data (dokumenterer dagens first-match-atferd)

Ikke-played stats (`rank`/`points`) ligger med i fixtures — korrelasjonen må ignorere dem for at happy path skal gå grønt.

### Aksept
- `npm test`: **405/405 grønt** (31 filer; var 373/29)
- Total kjøretid uendret: ~5,3–5,7 s wall lokalt (baseline før endringen: samme; de nye filene bidrar ~5 ms). NB: baseline lå allerede marginalt over 5 s-budsjettet på denne maskinen under parallell agent-last — ikke innført av denne PR-en.
- Golf bevisst IKKE dekket her (WP-45)
- PLAN.md: WP-51-statusraden oppdatert i samme PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)