### PR TITLE
WP-40: felles merge-gate for selvfiks-løkkene

### DIFF
--- a/.github/workflows/improve-agent.yml
+++ b/.github/workflows/improve-agent.yml
@@ -1,9 +1,11 @@
 name: Improve agent
 
-# Evolution, proposal-only. Weekly, the system reviews its own logs and proposes
-# ONE evidenced improvement as a PR for a human to review — never auto-merged,
-# because "what should we do better" is a judgment call. Biased toward sharpening
-# what exists over adding machinery (the v1 complexity lesson).
+# Evolution. Weekly, the system reviews its own logs and proposes ONE evidenced
+# improvement as a PR. The workflow then re-runs the tests AND checks the PR
+# stays out of protected paths before auto-merging (scripts/merge-gate.js —
+# shared with ui-fix and self-repair); a protected-path change is left open for
+# a human. Biased toward sharpening what exists over adding machinery (the v1
+# complexity lesson).
 
 on:
   schedule:
@@ -49,35 +51,35 @@ jobs:
             evidenced improvement, make it on a branch, open a PR. Do not merge
             (the workflow re-gates tests and auto-merges it).
 
-      # Re-gate tests + auto-merge, except protected paths (workflows/hooks/
-      # interests) which are left open for review.
-      - name: Re-gate + auto-merge
+      # Persist the run log to main — the prompt writes docs/data/improve-log.json
+      # on EVERY run (including action:"none" weeks), but the agent never pushes
+      # to main itself, so on no-op runs the log used to be discarded with the
+      # workspace. Runs before the merge gate so the log survives a failed gate.
+      - name: Commit run log
+        if: steps.usage.outputs.run == 'true'
+        run: |
+          LOG=docs/data/improve-log.json
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log unchanged — nothing to commit."; exit 0; }
+          cp "$LOG" "$RUNNER_TEMP/run-log.json"
+          git checkout -f main # the agent may have left the workspace on its fix branch
+          cp "$RUNNER_TEMP/run-log.json" "$LOG"
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log matches main — nothing to commit."; exit 0; }
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add "$LOG"
+          git commit -m "improve: run log"
+          git push || (git pull --rebase -X theirs origin main && git push)
+
+      # Re-gate tests + auto-merge via the shared merge gate (scripts/merge-gate.js,
+      # same invariant for ui-fix/self-repair/improve): protected paths (workflows,
+      # actions, hooks, interests.json, .claude/settings.json) are never auto-merged
+      # — the PR is left open + labelled needs-review.
+      - name: Merge gate (re-test + protected paths + auto-merge)
         id: automerge
         if: steps.usage.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          PR=$(gh pr list --state open --json number,headRefName \
-                --jq '[.[] | select(.headRefName | startswith("improve/"))] | sort_by(.number) | last | .number // empty')
-          if [ -z "$PR" ]; then
-            echo "No improve PR this run."; echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          BLOCK='^(\.github/workflows/|scripts/hooks/|scripts/config/interests\.json$)'
-          BLOCKED=0
-          for f in $(gh pr view "$PR" --json files --jq '.files[].path'); do
-            echo "$f" | grep -qE "$BLOCK" && { echo "protected path: $f"; BLOCKED=1; }
-          done
-          if [ "$BLOCKED" = "1" ]; then
-            echo "PR #$PR touches a protected path — leaving OPEN for review."
-            gh pr edit "$PR" --add-label needs-review 2>/dev/null || true
-            echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          echo "Re-gating PR #$PR with fresh tests…"
-          gh pr checkout "$PR"
-          npm ci
-          npm test
-          gh pr merge "$PR" --merge --delete-branch
-          echo "Auto-merged PR #$PR."; echo "merged=true" >> "$GITHUB_OUTPUT"
+        run: node scripts/merge-gate.js improve/
 
   deploy:
     needs: improve

--- a/.github/workflows/self-repair-agent.yml
+++ b/.github/workflows/self-repair-agent.yml
@@ -50,40 +50,39 @@ jobs:
             Read scripts/agents/self-repair.md and execute it — find real breakage,
             fix it on a branch, prove it, open a PR. Do not merge.
 
-      # Re-gate the fix ourselves, then auto-merge ONLY if it stays in safe paths.
-      - name: Re-gate + auto-merge
+      # Persist the run log to main — the prompt writes docs/data/self-repair-log.json
+      # on EVERY run (the improve agent mines it as evidence), but the agent never
+      # pushes to main itself, so on no-op runs the log used to be discarded with
+      # the workspace. Runs before the merge gate so the log survives a failed gate.
+      - name: Commit run log
+        if: steps.usage.outputs.run == 'true'
+        run: |
+          LOG=docs/data/self-repair-log.json
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log unchanged — nothing to commit."; exit 0; }
+          cp "$LOG" "$RUNNER_TEMP/run-log.json"
+          git checkout -f main # the agent may have left the workspace on its fix branch
+          cp "$RUNNER_TEMP/run-log.json" "$LOG"
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log matches main — nothing to commit."; exit 0; }
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add "$LOG"
+          git commit -m "self-repair: run log"
+          git push || (git pull --rebase -X theirs origin main && git push)
+
+      # Re-gate the fix ourselves via the shared merge gate (scripts/merge-gate.js,
+      # same invariant for ui-fix/self-repair/improve): auto-merge everything EXCEPT
+      # protected paths that must never change unattended — the workflows (the
+      # automation's own defs + gates), the composite actions, the safety hooks,
+      # the hook wiring (.claude/settings.json), and the user-owned interests.json.
+      # A change touching any of those is left OPEN + labelled needs-review so the
+      # system can't disable its own recovery or rewrite the user's data.
+      # Everything else is test-gated only (npm test + validate-events).
+      - name: Merge gate (re-test + protected paths + auto-merge)
         id: automerge
         if: steps.usage.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          PR=$(gh pr list --state open --json number,headRefName \
-                --jq '[.[] | select(.headRefName | startswith("self-repair/"))] | sort_by(.number) | last | .number // empty')
-          if [ -z "$PR" ]; then
-            echo "No self-repair PR (nothing broken / abandoned)."; echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          # Auto-merge everything EXCEPT three protected paths that must never be
-          # changed unattended: the workflows (the automation's own defs + gates),
-          # the safety hooks, and the user-owned interests.json. A change touching
-          # any of those is left OPEN for review so the system can't disable its own
-          # recovery or rewrite the user's data. Everything else is test-gated only.
-          BLOCK='^(\.github/workflows/|scripts/hooks/|scripts/config/interests\.json$)'
-          BLOCKED=0
-          for f in $(gh pr view "$PR" --json files --jq '.files[].path'); do
-            echo "$f" | grep -qE "$BLOCK" && { echo "protected path: $f"; BLOCKED=1; }
-          done
-          if [ "$BLOCKED" = "1" ]; then
-            echo "PR #$PR touches a protected path (workflows/hooks/interests) — leaving OPEN for review."
-            gh pr edit "$PR" --add-label needs-review 2>/dev/null || true
-            echo "merged=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          echo "Re-gating PR #$PR with fresh tests…"
-          gh pr checkout "$PR"
-          npm ci
-          npm test
-          node scripts/validate-events.js
-          gh pr merge "$PR" --merge --delete-branch
-          echo "Auto-merged PR #$PR."; echo "merged=true" >> "$GITHUB_OUTPUT"
+        run: node scripts/merge-gate.js self-repair/ --validate-events
 
   deploy:
     needs: self-repair

--- a/.github/workflows/ui-fix-agent.yml
+++ b/.github/workflows/ui-fix-agent.yml
@@ -2,8 +2,11 @@ name: UI fix agent
 
 # Closes the self-healing UI loop: reads the visual-qa findings and, if there are
 # real rendering problems, fixes the frontend ON A BRANCH, re-screenshots to prove
-# the fix + no regressions, runs the tests, and opens a PR for a human to merge.
-# It never changes the live site directly.
+# the fix + no regressions, runs the tests, and opens a PR. The workflow then
+# re-runs the tests AND checks the PR stays out of protected paths before
+# auto-merging + deploying (scripts/merge-gate.js — shared with self-repair and
+# improve); a protected-path change is left open for a human. The agent itself
+# never changes the live site directly.
 
 on:
   schedule:
@@ -51,30 +54,38 @@ jobs:
             into a screenshot-verified frontend fix and open a PR (do not merge; the
             workflow re-gates the tests and auto-merges it).
 
-      # Auto-merge the fix the agent just opened — but only after re-running the
-      # tests ourselves (a deterministic hard gate we don't delegate to the agent).
-      # If tests fail, the merge is skipped and the PR stays open + the run fails
-      # loudly, so a bad fix never reaches the live site.
-      - name: Re-gate tests + auto-merge
+      # Persist the run log to main — the prompt writes docs/data/ui-fix-log.json
+      # on EVERY run (the improve agent mines it as evidence), but the agent never
+      # pushes to main itself, so on no-op runs the log used to be discarded with
+      # the workspace. Runs before the merge gate so the log survives a failed gate.
+      - name: Commit run log
+        if: steps.usage.outputs.run == 'true'
+        run: |
+          LOG=docs/data/ui-fix-log.json
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log unchanged — nothing to commit."; exit 0; }
+          cp "$LOG" "$RUNNER_TEMP/run-log.json"
+          git checkout -f main # the agent may have left the workspace on its fix branch
+          cp "$RUNNER_TEMP/run-log.json" "$LOG"
+          [ -n "$(git status --porcelain -- "$LOG")" ] || { echo "Run log matches main — nothing to commit."; exit 0; }
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add "$LOG"
+          git commit -m "ui-fix: run log"
+          git push || (git pull --rebase -X theirs origin main && git push)
+
+      # Auto-merge the fix the agent just opened — via the shared merge gate
+      # (scripts/merge-gate.js, same invariant for ui-fix/self-repair/improve):
+      # re-runs the tests as a deterministic hard gate we don't delegate to the
+      # agent, and NEVER auto-merges a PR touching a protected path (workflows,
+      # actions, hooks, interests.json, .claude/settings.json) — that PR is left
+      # open + labelled needs-review. If tests fail, the merge is skipped and the
+      # run fails loudly, so a bad fix never reaches the live site.
+      - name: Merge gate (re-test + protected paths + auto-merge)
         id: automerge
         if: steps.usage.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          PR=$(gh pr list --state open --json number,headRefName \
-                --jq '[.[] | select(.headRefName | startswith("ui-autofix/"))] | sort_by(.number) | last | .number // empty')
-          if [ -z "$PR" ]; then
-            echo "No ui-autofix PR was opened (nothing to fix / abandoned) — done."
-            echo "merged=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Re-gating PR #$PR with a fresh test run before auto-merge…"
-          gh pr checkout "$PR"
-          npm ci
-          npm test
-          gh pr merge "$PR" --merge --delete-branch
-          echo "Auto-merged PR #$PR."
-          echo "merged=true" >> "$GITHUB_OUTPUT"
+        run: node scripts/merge-gate.js ui-autofix/
 
   # Publish the merged fix. The merge is a GITHUB_TOKEN push (can't trigger the
   # deploy on its own), so we call preview-deploy directly — same pattern as the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,16 @@ Nine workflows run `anthropics/claude-code-action@v1` with a prompt file:
 
 The self-fixing loops (ui-fix, self-repair, improve) each fix on a branch, open a
 PR, and the **workflow re-runs `npm test` as a hard gate and then auto-merges +
-deploys** — fully hands-off. The ONLY exception is three **protected paths** that
+deploys** — fully hands-off. The ONLY exception is five **protected paths** that
 are never auto-merged (a change touching them is left open, labelled
-`needs-review`):
+`needs-review`; enforced in one place, `scripts/merge-gate.js`):
 
 - `.github/workflows/**` — the automation's own definitions and gates; auto-merging
   a broken change here could disable the test-gate or break the fixer itself.
+- `.github/actions/**` — composite actions the workflows invoke.
 - `scripts/hooks/**` — the safety hooks (interests protection, post-write validate).
 - `scripts/config/interests.json` — user-owned; "AI never writes here" (also hook-enforced).
+- `.claude/settings.json` — wires the safety hooks into the harness.
 
 Everything else — fetchers, libs, agent prompts, skills, other config, docs, tests,
 `package.json` — auto-merges once tests pass. Every auto-merge is a revertable
@@ -192,7 +194,7 @@ or schema drifts from the code, CI fails.
 
 - **Never modify `scripts/config/interests.json`** — it is user-owned.
 - Agents commit only their contracted outputs (see each prompt's output contract).
-- **Protected paths — never auto-merged** (self-fixing loops leave them as an open PR for review): `.github/workflows/**`, `scripts/hooks/**`, `scripts/config/interests.json`. Everything else the loops touch auto-merges once tests pass (see Autonomy model).
+- **Protected paths — never auto-merged** (self-fixing loops leave them as an open PR for review; enforced by `scripts/merge-gate.js`): `.github/workflows/**`, `.github/actions/**`, `scripts/hooks/**`, `scripts/config/interests.json`, `.claude/settings.json`. Everything else the loops touch auto-merges once tests pass (see Autonomy model).
 - Run `npm test` before committing code changes; run `node scripts/validate-events.js` after writing events.
 - Always `git pull --rebase` before pushing — the static pipeline and agents commit to main on schedules.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -65,7 +65,7 @@ mennesket, aldri av en agent.
 | WP-27 | 💰 Domene + DNS-cutover | 0C | WP-26 | ✅ zenji.app live 13.07 (cert + enforce-https + rot-paths) |
 | WP-28 | Repo-splitt (privat motor / public site) | ~~0C~~ → Fase 1 | trigger | utsatt — trigger-basert (se WP-28) |
 | WP-29 | Self-hosted runner (kun privat repo) | ~~0C~~ → Fase 1 | WP-28 | utsatt — følger WP-28 |
-| WP-40 | Autonomi-herding: felles merge-gate | 0D | – | ⬜ køet — beskyttet sti, menneskelig merge |
+| WP-40 | Autonomi-herding: felles merge-gate | 0D | – | 🔬 PR åpnet — `scripts/merge-gate.js` delt av alle tre løkker (ui-fix-hullet tettet), BLOCK utvidet med `.claude/settings.json` + `.github/actions/**`, run-logger committes også på no-op, toppkommentarer rettet; 382/382 tester. Beskyttet sti → menneskelig merge |
 | WP-41 | Web: død kode ut av shippet flate | 0D | – | ✅ merget (#265) — sport-config.js + asset-maps.js slettet (406 linjer, null kallsteder) + døde shared-constants-eksporter; sw-shell synket (+activity.html, cache v2-18); 373/373, begge temaer verifisert |
 | WP-42 | Pipeline: dødkode-sanering | 0D | – | ✅ merget (#268) — sjakk-stier (fetchChessStandings + curated-gren), filters trimmet til de 2 brukte, buildURL/fetchWithDates, `_leagueMeta`, døde norsk-klubb-helpere, cycling-configlesing, pr-body.md, `.github/actions/setup/` slettet; 373/373 grønt, build+validate rent |
 | WP-43 | Pipeline: konvensjons-konvergens | 0D | WP-42 | ✅ merget (#270) — coverage-gaps/fotball-no rutet gjennom `isEventInWindow` (endTime-blindheten fikset + regresjonstester: pågående flerdagsevent ⇒ ingen entity/sport-gap), delt `yyyymmdd`/`espnDateRange` i lib/helpers, én main-guard-form (`pathToFileURL`) i alle scripts, fetch/index `{name, fn}`-array; 411/411 grønt |

--- a/scripts/merge-gate.js
+++ b/scripts/merge-gate.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Shared merge gate for the three self-fixing loops (ui-fix, self-repair, improve).
+ *   node scripts/merge-gate.js <branch-prefix> [--validate-events]
+ *
+ * ONE place enforces the invariant "protected paths are never auto-merged".
+ * Finds the newest open PR whose head branch starts with <branch-prefix> and:
+ *   1. If it touches a protected path → leave it OPEN, label `needs-review`.
+ *      Protected: the workflows (the automation's own defs + this gate), the
+ *      composite actions, the safety hooks, the hook wiring (.claude/settings.json),
+ *      and the user-owned interests.json.
+ *   2. Otherwise re-run the tests ourselves as a deterministic hard gate
+ *      (npm ci + npm test, plus validate-events for self-repair) and auto-merge.
+ *      A failing gate command throws → the workflow step fails loudly and the
+ *      PR stays open, so a bad fix never reaches the live site.
+ *
+ * Writes `merged=true|false` to $GITHUB_OUTPUT (drives the deploy job).
+ */
+import fs from "fs";
+import { execFileSync } from "child_process";
+import { pathToFileURL } from "url";
+
+// Paths that must never ship unattended. Kept in sync with CLAUDE.md
+// ("Protected paths — never auto-merged") and the agent prompts.
+export const PROTECTED_PATHS = [
+	/^\.github\/workflows\//, // the automation's own definitions and gates
+	/^\.github\/actions\//, // composite actions the workflows invoke
+	/^scripts\/hooks\//, // the safety hooks (interests protection, post-write validate)
+	/^scripts\/config\/interests\.json$/, // user-owned; AI never writes here
+	/^\.claude\/settings\.json$/, // wires the safety hooks into the harness
+];
+
+export function findProtectedPaths(files) {
+	return files.filter((f) => PROTECTED_PATHS.some((re) => re.test(f)));
+}
+
+export function pickLatestPr(prs, prefix) {
+	const matching = (prs || []).filter((pr) => pr.headRefName && pr.headRefName.startsWith(prefix));
+	if (matching.length === 0) return null;
+	return matching.reduce((a, b) => (b.number > a.number ? b : a));
+}
+
+/**
+ * The gate itself, with all side effects behind `io` so tests can drive it.
+ * Returns { merged, reason } and mirrors the decision to io.setOutput("merged", …).
+ */
+export function runMergeGate({ prefix, validateEvents = false }, io) {
+	const pr = pickLatestPr(io.listOpenPrs(), prefix);
+	if (!pr) {
+		io.log(`No open ${prefix}* PR (nothing to fix / abandoned) — done.`);
+		io.setOutput("merged", "false");
+		return { merged: false, reason: "no-pr" };
+	}
+
+	const blocked = findProtectedPaths(io.prFiles(pr.number));
+	if (blocked.length > 0) {
+		for (const f of blocked) io.log(`protected path: ${f}`);
+		io.log(`PR #${pr.number} touches a protected path — leaving OPEN for review.`);
+		io.addLabel(pr.number, "needs-review");
+		io.setOutput("merged", "false");
+		return { merged: false, reason: "protected-path", blocked };
+	}
+
+	io.log(`Re-gating PR #${pr.number} with a fresh test run before auto-merge…`);
+	io.checkoutPr(pr.number);
+	io.run("npm", ["ci"]);
+	io.run("npm", ["test"]);
+	if (validateEvents) io.run("node", ["scripts/validate-events.js"]);
+	io.merge(pr.number);
+	io.log(`Auto-merged PR #${pr.number}.`);
+	io.setOutput("merged", "true");
+	return { merged: true, reason: "merged" };
+}
+
+function realIo() {
+	const sh = (cmd, args) => execFileSync(cmd, args, { stdio: "inherit" });
+	const ghJson = (args) => JSON.parse(execFileSync("gh", args, { encoding: "utf-8" }));
+	return {
+		log: (msg) => console.log(msg),
+		listOpenPrs: () => ghJson(["pr", "list", "--state", "open", "--json", "number,headRefName"]),
+		prFiles: (n) => ghJson(["pr", "view", String(n), "--json", "files"]).files.map((f) => f.path),
+		addLabel: (n, label) => {
+			try {
+				sh("gh", ["pr", "edit", String(n), "--add-label", label]);
+			} catch {
+				console.log(`(could not add label ${label} — leaving the PR open anyway)`);
+			}
+		},
+		checkoutPr: (n) => sh("gh", ["pr", "checkout", String(n)]),
+		run: sh,
+		merge: (n) => sh("gh", ["pr", "merge", String(n), "--merge", "--delete-branch"]),
+		setOutput: (key, value) => {
+			console.log(`${key}=${value}`);
+			if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+		},
+	};
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+	const args = process.argv.slice(2);
+	const prefix = args.find((a) => !a.startsWith("--"));
+	if (!prefix) {
+		console.error("Usage: node scripts/merge-gate.js <branch-prefix> [--validate-events]");
+		process.exit(2);
+	}
+	runMergeGate({ prefix, validateEvents: args.includes("--validate-events") }, realIo());
+}

--- a/tests/merge-gate.test.js
+++ b/tests/merge-gate.test.js
@@ -1,0 +1,113 @@
+// merge-gate.js — the ONE shared enforcement of "protected paths are never
+// auto-merged" for the three self-fixing loops (ui-fix, self-repair, improve).
+import { describe, it, expect } from "vitest";
+import { PROTECTED_PATHS, findProtectedPaths, pickLatestPr, runMergeGate } from "../scripts/merge-gate.js";
+
+// A fake io that records every side effect the gate takes.
+function fakeIo({ prs = [], files = [] } = {}) {
+	const calls = { labels: [], runs: [], merged: [], checkedOut: [], outputs: {} };
+	return {
+		calls,
+		log: () => {},
+		listOpenPrs: () => prs,
+		prFiles: () => files,
+		addLabel: (n, label) => calls.labels.push([n, label]),
+		checkoutPr: (n) => calls.checkedOut.push(n),
+		run: (cmd, args) => calls.runs.push([cmd, ...args].join(" ")),
+		merge: (n) => calls.merged.push(n),
+		setOutput: (k, v) => (calls.outputs[k] = v),
+	};
+}
+
+describe("findProtectedPaths", () => {
+	it("blocks all five protected paths", () => {
+		const blocked = [
+			".github/workflows/static-pipeline.yml",
+			".github/actions/setup/action.yml",
+			"scripts/hooks/protect-interests.js",
+			"scripts/config/interests.json",
+			".claude/settings.json",
+		];
+		expect(findProtectedPaths(blocked)).toEqual(blocked);
+		expect(PROTECTED_PATHS.length).toBe(5);
+	});
+
+	it("does not block safe paths, including near-misses", () => {
+		expect(
+			findProtectedPaths([
+				"docs/css/cards.css",
+				"scripts/fetch/golf.js",
+				"scripts/agents/research.md",
+				"scripts/config/tracked.json", // AI-managed, not interests
+				".claude/skills/norwegian-rights/SKILL.md", // skills are agent-editable
+				"tests/interests-schema.test.js",
+				"package.json",
+			]),
+		).toEqual([]);
+	});
+});
+
+describe("pickLatestPr", () => {
+	it("picks the newest PR matching the branch prefix", () => {
+		const prs = [
+			{ number: 3, headRefName: "ui-autofix/20260701-0900" },
+			{ number: 9, headRefName: "self-repair/20260713-0630" },
+			{ number: 7, headRefName: "ui-autofix/20260713-0900" },
+		];
+		expect(pickLatestPr(prs, "ui-autofix/").number).toBe(7);
+		expect(pickLatestPr(prs, "improve/")).toBeNull();
+		expect(pickLatestPr([], "ui-autofix/")).toBeNull();
+	});
+});
+
+describe("runMergeGate", () => {
+	const pr = [{ number: 42, headRefName: "self-repair/20260714-0630" }];
+
+	it("no matching PR → merged=false, nothing touched", () => {
+		const io = fakeIo({ prs: [] });
+		const res = runMergeGate({ prefix: "ui-autofix/" }, io);
+		expect(res).toMatchObject({ merged: false, reason: "no-pr" });
+		expect(io.calls.outputs.merged).toBe("false");
+		expect(io.calls.merged).toEqual([]);
+		expect(io.calls.runs).toEqual([]);
+	});
+
+	it("a PR touching a protected path stays OPEN with needs-review (never merged)", () => {
+		const io = fakeIo({ prs: pr, files: ["scripts/lib/helpers.js", ".github/workflows/scout-agent.yml"] });
+		const res = runMergeGate({ prefix: "self-repair/" }, io);
+		expect(res.merged).toBe(false);
+		expect(res.reason).toBe("protected-path");
+		expect(res.blocked).toEqual([".github/workflows/scout-agent.yml"]);
+		expect(io.calls.labels).toEqual([[42, "needs-review"]]);
+		expect(io.calls.merged).toEqual([]);
+		expect(io.calls.runs).toEqual([]); // not even test-gated — it simply waits for a human
+		expect(io.calls.outputs.merged).toBe("false");
+	});
+
+	it("a safe PR is re-gated (npm ci + npm test) and auto-merged", () => {
+		const io = fakeIo({ prs: pr, files: ["scripts/fetch/golf.js", "docs/css/cards.css"] });
+		const res = runMergeGate({ prefix: "self-repair/" }, io);
+		expect(res.merged).toBe(true);
+		expect(io.calls.checkedOut).toEqual([42]);
+		expect(io.calls.runs).toEqual(["npm ci", "npm test"]);
+		expect(io.calls.merged).toEqual([42]);
+		expect(io.calls.labels).toEqual([]);
+		expect(io.calls.outputs.merged).toBe("true");
+	});
+
+	it("--validate-events adds the events contract to the gate", () => {
+		const io = fakeIo({ prs: pr, files: ["scripts/build-events.js"] });
+		runMergeGate({ prefix: "self-repair/", validateEvents: true }, io);
+		expect(io.calls.runs).toEqual(["npm ci", "npm test", "node scripts/validate-events.js"]);
+	});
+
+	it("a failing gate command propagates (PR stays open, no merge)", () => {
+		const io = fakeIo({ prs: pr, files: ["scripts/fetch/golf.js"] });
+		io.run = (cmd, args) => {
+			if (args[0] === "test") throw new Error("tests failed");
+		};
+		expect(() => runMergeGate({ prefix: "self-repair/" }, io)).toThrow("tests failed");
+		expect(io.calls.merged).toEqual([]);
+		expect(io.calls.outputs.merged).toBeUndefined(); // step fails loudly instead
+	});
+});

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -61,4 +61,21 @@ describe("v2 workflows", () => {
 			expect(wf(f), f).toContain("concurrency:");
 		}
 	});
+
+	it("all three self-fixing loops use the ONE shared merge gate and commit their run log", () => {
+		expect(fs.existsSync(path.resolve("scripts", "merge-gate.js")), "scripts/merge-gate.js").toBe(true);
+		for (const [file, prefix, log] of [
+			["ui-fix-agent.yml", "ui-autofix/", "docs/data/ui-fix-log.json"],
+			["self-repair-agent.yml", "self-repair/", "docs/data/self-repair-log.json"],
+			["improve-agent.yml", "improve/", "docs/data/improve-log.json"],
+		]) {
+			const content = wf(file);
+			expect(content, `${file} must call the shared gate`).toContain(`node scripts/merge-gate.js ${prefix}`);
+			expect(content, `${file} must not keep an inline protected-path check`).not.toMatch(/BLOCK=/);
+			expect(content, `${file} must not merge inline`).not.toContain("gh pr merge");
+			expect(content, `${file} must persist its run log to main`).toContain(log);
+		}
+		// self-repair additionally gates on the events contract, as before the extraction
+		expect(wf("self-repair-agent.yml")).toContain("--validate-events");
+	});
 });


### PR DESCRIPTION
## Hva

Invarianten **«beskyttede stier auto-merges aldri»** håndheves nå fra ÉN kilde — `scripts/merge-gate.js` — i alle tre selvfiks-løkker (PLAN.md · FASE 0D · WP-40).

**Hullet som tettes:** self-repair og improve hadde hver sin inline BLOCK-sjekk; **ui-fix manglet den helt** og auto-merget enhver `ui-autofix/`-PR som passerte testene.

## Endringer

- **`scripts/merge-gate.js` (ny):** delt re-gate — finner nyeste åpne PR per branch-prefiks → protected-path-sjekk → `npm ci` + `npm test` (+ `--validate-events` for self-repair) → auto-merge, ellers åpen + `needs-review`. Testbar kjerne (`runMergeGate`) med injisert io; gate-feil propagerer så workflow-steget feiler høylytt og PR-en blir stående.
- **BLOCK utvidet** med `.claude/settings.json` (filen som wirer sikkerhetshookene) og `.github/actions/**` — fem beskyttede stier totalt.
- **Workflows:** `ui-fix`/`self-repair`/`improve-agent.yml` kaller gaten (`node scripts/merge-gate.js <prefiks> [--validate-events]`); toppkommentarene i ui-fix («opens a PR for a human to merge») og improve («never auto-merged») rettet — de sa det motsatte av koden.
- **Run-logg persisteres:** nytt «Commit run log»-steg i alle tre committer `docs/data/{ui-fix,self-repair,improve}-log.json` til main også på no-op-kjøringer (promptene krever loggene; improve miner dem som bevis — før ble de skrevet og forkastet med workspacet). Kjøres før gaten så loggen overlever en feilet re-gate.
- **CLAUDE.md:** protected-paths-listelinjene oppdatert (5 stier + referanse til merge-gate.js). Øvrig dok-synk (bl.a. «three protected paths» i agenttabellen og prompt-tekstene) er WP-52/utenfor scope (ikke-mål: prompts røres ikke).
- **Tester:** `tests/merge-gate.test.js` (beskyttet sti ⇒ åpen + `needs-review`, ingen merge; trygg PR ⇒ re-gate + merge; testfeil propagerer) + koherenssjekk i `tests/workflows.test.js` (alle tre kaller samme gate, ingen inline BLOCK igjen, logg-commit til stede).

## Aksept

- ✅ Alle tre workflows kaller samme script
- ✅ PR som rører beskyttet sti ⇒ åpen + `needs-review` (enhetstestet mot gate-kjernen)
- ✅ PR som ikke gjør det ⇒ re-gates + auto-merges (enhetstestet)
- ✅ `npm test` grønt — 30 filer / 382 tester (inkl. `tests/workflows.test.js`)

## NB

Denne PR-en rører `.github/workflows/**` — **beskyttet sti, skal merges av menneske** (PLAN.md-oppføringen er den eksplisitte ordren, jf. regel 3). Ikke sett auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)