### PR TITLE
WP-43: konvensjons-konvergens (isEventInWindow, datohjelpere, main-guards)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -68,7 +68,7 @@ mennesket, aldri av en agent.
 | WP-40 | Autonomi-herding: felles merge-gate | 0D | – | ⬜ køet — beskyttet sti, menneskelig merge |
 | WP-41 | Web: død kode ut av shippet flate | 0D | – | ✅ merget (#265) — sport-config.js + asset-maps.js slettet (406 linjer, null kallsteder) + døde shared-constants-eksporter; sw-shell synket (+activity.html, cache v2-18); 373/373, begge temaer verifisert |
 | WP-42 | Pipeline: dødkode-sanering | 0D | – | ✅ merget (#268) — sjakk-stier (fetchChessStandings + curated-gren), filters trimmet til de 2 brukte, buildURL/fetchWithDates, `_leagueMeta`, døde norsk-klubb-helpere, cycling-configlesing, pr-body.md, `.github/actions/setup/` slettet; 373/373 grønt, build+validate rent |
-| WP-43 | Pipeline: konvensjons-konvergens | 0D | WP-42 | ⬜ køet |
+| WP-43 | Pipeline: konvensjons-konvergens | 0D | WP-42 | 🔬 PR åpnet — coverage-gaps/fotball-no rutet gjennom `isEventInWindow` (endTime-blindheten fikset + regresjonstester: pågående flerdagsevent ⇒ ingen entity/sport-gap), delt `yyyymmdd`/`espnDateRange` i lib/helpers, én main-guard-form (`pathToFileURL`) i alle scripts, fetch/index `{name, fn}`-array; 411/411 grønt |
 | WP-44 | fetch-results: intern dedupe | 0D | WP-43 | ⬜ køet |
 | WP-45 | Golf: skraper-ekstraksjon | 0D | WP-43 | ⬜ køet |
 | WP-46 | Web: felles theme.js + side-småplukk | 0D | WP-41 | ⬜ køet |

--- a/scripts/aggregate-calibration.js
+++ b/scripts/aggregate-calibration.js
@@ -15,6 +15,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import { rootDataPath, writeJsonPretty, iso, MS_PER_DAY } from "./lib/helpers.js";
 
 const WINDOW_DAYS = 180; // old lessons decay out of the stats
@@ -106,6 +107,6 @@ function main() {
 	);
 }
 
-if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main();
 }

--- a/scripts/build-entities.js
+++ b/scripts/build-entities.js
@@ -51,6 +51,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import { readJsonIfExists, rootDataPath, normalizeText, containsName } from "./lib/helpers.js";
 import { sportsConfig as defaultSportsConfig } from "./config/sports-config.js";
 
@@ -300,6 +301,6 @@ function main() {
 	console.log(`entities.json: ${entities.length} entit${entities.length === 1 ? "y" : "ies"}.`);
 }
 
-if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main();
 }

--- a/scripts/build-manifest.js
+++ b/scripts/build-manifest.js
@@ -19,6 +19,7 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
+import { pathToFileURL } from "url";
 import { rootDataPath, iso } from "./lib/helpers.js";
 
 export const MANIFEST_NAME = "manifest.json";
@@ -85,6 +86,6 @@ function main() {
 	console.log(`manifest.json: ${Object.keys(manifest.files).length} file(s) covered.`);
 }
 
-if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main();
 }

--- a/scripts/check-usage.js
+++ b/scripts/check-usage.js
@@ -16,6 +16,7 @@
  */
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import { rootDataPath, iso, MS_PER_DAY } from "./lib/helpers.js";
 
 // Utilization thresholds (0..1):
@@ -159,7 +160,7 @@ async function fetchUsageHeaders(token) {
 }
 
 // CLI: make the call, write usage-state.json (fail-soft — never overwrite with junk).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	const token = process.env.CLAUDE_CODE_OAUTH_TOKEN;
 	const out = path.join(rootDataPath(), "usage-state.json");
 	(async () => {

--- a/scripts/detect-coverage-gaps.js
+++ b/scripts/detect-coverage-gaps.js
@@ -22,7 +22,8 @@
 
 import fs from "fs";
 import path from "path";
-import { readJsonIfExists, rootDataPath, writeJsonPretty, iso, MS_PER_DAY, containsName, normalizeEntity, entityTerms } from "./lib/helpers.js";
+import { pathToFileURL } from "url";
+import { readJsonIfExists, rootDataPath, writeJsonPretty, iso, MS_PER_DAY, containsName, normalizeEntity, entityTerms, isEventInWindow } from "./lib/helpers.js";
 
 // Re-export so existing importers (tests) keep resolving containsName from here.
 export { containsName };
@@ -95,14 +96,16 @@ function eventMentionsName(event, name) {
 	return containsName(haystack, name);
 }
 
-/** Does any event within `days` (and not already past) mention this name? */
+/**
+ * Does any event within `days` (and not already over) mention this name?
+ * Uses isEventInWindow so an ongoing multi-day event (golf, stage race) that
+ * STARTED days ago still counts as coverage — windowing on start time alone
+ * generated false gaps for exactly those events.
+ */
 export function hasEventWithin(name, events, now, days) {
-	const horizon = now + days * MS_PER_DAY;
-	return events.some((e) => {
-		const t = Date.parse(e.time);
-		if (Number.isNaN(t) || t < now - MS_PER_DAY || t > horizon) return false;
-		return eventMentionsName(e, name);
-	});
+	const windowStart = now - MS_PER_DAY;
+	const windowEnd = now + days * MS_PER_DAY;
+	return events.some((e) => isEventInWindow(e, windowStart, windowEnd) && eventMentionsName(e, name));
 }
 
 /** Back-compat: is there an upcoming (≤14d) event for this name? */
@@ -110,14 +113,11 @@ export function hasUpcomingEvent(name, events, now = Date.now()) {
 	return hasEventWithin(name, events, now, UPCOMING_DAYS);
 }
 
-/** Count events of a given sport within `days` (and not already past). */
+/** Count events of a given sport within `days` (ongoing multi-day events included). */
 export function countSportEventsWithin(events, sport, now, days) {
-	const horizon = now + days * MS_PER_DAY;
-	return events.filter((e) => {
-		if (e.sport !== sport) return false;
-		const t = Date.parse(e.time);
-		return !Number.isNaN(t) && t >= now - MS_PER_DAY && t <= horizon;
-	}).length;
+	const windowStart = now - MS_PER_DAY;
+	const windowEnd = now + days * MS_PER_DAY;
+	return events.filter((e) => e.sport === sport && isEventInWindow(e, windowStart, windowEnd)).length;
 }
 
 export function detectGaps({ rss, events, interests, tracked, now = Date.now() }) {
@@ -199,10 +199,9 @@ export function detectSourceAnomalies({ sources, events, now = Date.now() }) {
 			continue;
 		}
 		const fileEvents = (data.tournaments || []).flatMap((t) => t.events || []);
-		const upcomingInFile = fileEvents.filter((e) => {
-			const t = Date.parse(e.time);
-			return !Number.isNaN(t) && t >= now - MS_PER_DAY && t <= now + UPCOMING_DAYS * MS_PER_DAY;
-		}).length;
+		const upcomingInFile = fileEvents.filter((e) =>
+			isEventInWindow(e, now - MS_PER_DAY, now + UPCOMING_DAYS * MS_PER_DAY)
+		).length;
 		if (upcomingInFile > 0) {
 			anomalies.push({ sport, issue: "dropped-in-build", detail: `${upcomingInFile} upcoming ${sport} event(s) in the source file but 0 on the board — build/normalisation may be dropping them`, severity: "high", detectedAt: iso(now) });
 		} else if (fileEvents.length === 0) {
@@ -245,6 +244,6 @@ function main() {
 	);
 }
 
-if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main();
 }

--- a/scripts/fetch-results.js
+++ b/scripts/fetch-results.js
@@ -13,15 +13,12 @@
  */
 
 import path from "path";
-import { fetchJson, iso, readJsonIfExists, rootDataPath, writeJsonPretty, MS_PER_DAY, matchInterest } from "./lib/helpers.js";
+import { pathToFileURL } from "url";
+import { fetchJson, iso, readJsonIfExists, rootDataPath, writeJsonPretty, MS_PER_DAY, matchInterest, yyyymmdd } from "./lib/helpers.js";
 import { validateESPNScoreboard } from "./lib/response-validator.js";
 
 const ESPN_SITE = "https://site.api.espn.com/apis/site/v2/sports";
 const INTERESTS_PATH = path.resolve(process.cwd(), "scripts", "config", "interests.json");
-
-export function formatDate(d) {
-	return d.toISOString().slice(0, 10).replace(/-/g, "");
-}
 
 function loadUserContext() {
 	const interests = readJsonIfExists(INTERESTS_PATH) || {};
@@ -180,7 +177,7 @@ export async function fetchFootballResults(options = {}) {
 	for (const [leagueCode, leagueName] of Object.entries(LEAGUE_MAP)) {
 		for (let d = 0; d < daysBack; d++) {
 			const date = new Date(now.getTime() - d * MS_PER_DAY);
-			const dateStr = formatDate(date);
+			const dateStr = yyyymmdd(date);
 			const url = `${ESPN_SITE}/soccer/${leagueCode}/scoreboard?dates=${dateStr}`;
 
 			try {
@@ -368,7 +365,7 @@ export async function fetchTennisResults(options = {}) {
 	for (const tour of TENNIS_TOURS) {
 		for (let d = 0; d < daysBack; d++) {
 			const date = new Date(now.getTime() - d * MS_PER_DAY);
-			const dateStr = formatDate(date);
+			const dateStr = yyyymmdd(date);
 			const url = `${tour.url}?dates=${dateStr}`;
 
 			try {
@@ -480,7 +477,7 @@ export async function fetchF1Results(options = {}) {
 
 	for (let d = 0; d < daysBack; d++) {
 		const date = new Date(now.getTime() - d * MS_PER_DAY);
-		const dateStr = formatDate(date);
+		const dateStr = yyyymmdd(date);
 		const url = `${F1_URL}?dates=${dateStr}`;
 
 		try {
@@ -815,7 +812,7 @@ async function main() {
 	console.log(`Results written to ${outPath} (${validation.validResults}/${validation.totalResults} valid)`);
 }
 
-if (process.argv[1]?.includes("fetch-results")) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main().catch((err) => {
 		console.error("Fatal error:", err);
 		process.exit(1);

--- a/scripts/fetch-rss.js
+++ b/scripts/fetch-rss.js
@@ -9,6 +9,7 @@
 import https from "https";
 import http from "http";
 import path from "path";
+import { pathToFileURL } from "url";
 import { iso, rootDataPath, writeJsonPretty } from "./lib/helpers.js";
 
 const FEEDS = [
@@ -244,7 +245,7 @@ async function main() {
 }
 
 // Run if executed directly
-if (process.argv[1]?.includes("fetch-rss")) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main().catch((err) => {
 		console.error("Fatal error:", err);
 		process.exit(1);

--- a/scripts/fetch-standings.js
+++ b/scripts/fetch-standings.js
@@ -9,6 +9,7 @@
  */
 
 import path from "path";
+import { pathToFileURL } from "url";
 import { fetchJson, iso, rootDataPath, readJsonIfExists, writeJsonPretty } from "./lib/helpers.js";
 import { validateESPNStandings, validateESPNScoreboard } from "./lib/response-validator.js";
 
@@ -359,7 +360,7 @@ async function main() {
 }
 
 // Run if executed directly
-if (process.argv[1]?.includes("fetch-standings")) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	main().catch((err) => {
 		console.error("Fatal error:", err);
 		process.exit(1);

--- a/scripts/fetch/fotball-no.js
+++ b/scripts/fetch/fotball-no.js
@@ -1,4 +1,4 @@
-import { fetchJson, iso, normalizeToUTC } from "../lib/helpers.js";
+import { fetchJson, iso, normalizeToUTC, isEventInWindow } from "../lib/helpers.js";
 import https from "https";
 
 // Fetch OBOS-ligaen calendar from fotball.no
@@ -28,10 +28,9 @@ export async function fetchOBOSLigaenFromFotballNo() {
 		const endOfWeek = new Date(startOfWeek);
 		endOfWeek.setDate(startOfWeek.getDate() + 7);
 		
-		const currentWeekMatches = lynMatches.filter(match => {
-			const matchDate = new Date(match.time);
-			return matchDate >= startOfWeek && matchDate < endOfWeek;
-		});
+		const currentWeekMatches = lynMatches.filter(match =>
+			isEventInWindow(match, startOfWeek, endOfWeek)
+		);
 		
 		return {
 			lastUpdated: iso(),

--- a/scripts/fetch/golf.js
+++ b/scripts/fetch/golf.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import https from "https";
+import { pathToFileURL } from "url";
 import { fetchJson, iso, normalizeToUTC } from "../lib/helpers.js";
 import { validateESPNScoreboard } from "../lib/response-validator.js";
 
@@ -737,7 +738,7 @@ export async function fetchGolfESPN() {
 export { playerNameMatches, parseTeeTimeToUTC, tournamentNameMatches, filterNorwegiansAgainstField, buildFeaturedGroups, fetchPGATourPage, fetchPGATourTeeTimes };
 
 // Run if executed directly
-if (process.argv[1]?.includes('golf.js')) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	fetchGolfESPN().then(data => {
 		console.log(JSON.stringify(data, null, 2));
 	}).catch(err => {

--- a/scripts/fetch/index.js
+++ b/scripts/fetch/index.js
@@ -27,18 +27,8 @@ async function main() {
 		fetchers.map(({ fn }) => fn())
 	);
 
-	const mapping = [
-		"football.json",
-		"golf.json",
-		"tennis.json",
-		"f1.json",
-		"chess.json",
-		"esports.json",
-		"cycling.json",
-	];
-
-	for (let i = 0; i < mapping.length; i++) {
-		const file = mapping[i];
+	for (let i = 0; i < fetchers.length; i++) {
+		const file = `${fetchers[i].name}.json`;
 		const result = results[i];
 
 		if (result.status !== "fulfilled" || !result.value) {

--- a/scripts/lib/adapters/espn-adapter.js
+++ b/scripts/lib/adapters/espn-adapter.js
@@ -1,5 +1,6 @@
 import { BaseFetcher } from "../base-fetcher.js";
 import { EventNormalizer } from "../event-normalizer.js";
+import { espnDateRange } from "../helpers.js";
 
 export class ESPNAdapter extends BaseFetcher {
 	async fetchFromSource(source) {
@@ -27,7 +28,7 @@ export class ESPNAdapter extends BaseFetcher {
 	async fetchScoreboardWithLeagues(source) {
 		const allEvents = [];
 		const now = new Date();
-		const days = this.generateDateRange(7);
+		const days = espnDateRange(7);
 		const leagueResults = new Map(); // track per-league success/failure
 
 		for (const league of source.leagues) {
@@ -284,18 +285,6 @@ export class ESPNAdapter extends BaseFetcher {
 		}
 		
 		return streaming;
-	}
-
-	generateDateRange(days) {
-		const dates = [];
-		const now = new Date();
-		
-		for (let i = 0; i < days; i++) {
-			const date = new Date(now.getTime() + i * 86400000);
-			dates.push(date.toISOString().split("T")[0].replace(/-/g, ""));
-		}
-		
-		return dates;
 	}
 
 	applyCustomFilters(events) {

--- a/scripts/lib/helpers.js
+++ b/scripts/lib/helpers.js
@@ -11,6 +11,17 @@ export function iso(d = Date.now()) {
 	return new Date(d).toISOString();
 }
 
+/** UTC calendar date as "YYYYMMDD" — the format ESPN's ?dates= parameter takes. */
+export function yyyymmdd(d = Date.now()) {
+	return new Date(d).toISOString().slice(0, 10).replace(/-/g, "");
+}
+
+/** The next `days` UTC dates (starting today) as yyyymmdd strings for ESPN ?dates=. */
+export function espnDateRange(days) {
+	const now = Date.now();
+	return Array.from({ length: days }, (_, i) => yyyymmdd(now + i * MS_PER_DAY));
+}
+
 /**
  * Check if an event overlaps with a time window.
  * Handles multi-day events (endTime) and single-point events uniformly.

--- a/scripts/update-readme-status.js
+++ b/scripts/update-readme-status.js
@@ -9,6 +9,7 @@
  */
 import fs from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import { rootDataPath, readJsonIfExists, iso } from "./lib/helpers.js";
 
 const START = "<!-- STATUS:START -->";
@@ -67,7 +68,7 @@ export function replaceBetweenMarkers(text, start, end, replacement) {
 	return `${text.slice(0, s + start.length)}\n${replacement}\n${text.slice(e)}`;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
 	const readmePath = path.resolve(process.cwd(), "README.md");
 	const dataDir = rootDataPath();
 	const summary = readJsonIfExists(path.join(dataDir, "usage-summary.json"));

--- a/tests/detect-coverage-gaps.test.js
+++ b/tests/detect-coverage-gaps.test.js
@@ -109,6 +109,38 @@ describe("detectGaps — imminence (entity has a later event but nothing soon)",
 	});
 });
 
+describe("detectGaps — ongoing multi-day events (WP-43 regression)", () => {
+	// A golf tournament that STARTED three days before NOW and is still running.
+	// Windowing on e.time alone read this as "not on the board" and produced
+	// false entity/sport gaps; isEventInWindow must count it as coverage.
+	const ongoingGolf = {
+		sport: "golf",
+		title: "The Open Championship",
+		norwegianPlayers: [{ name: "Viktor Hovland" }],
+		time: "2026-06-30T06:00:00Z", // > 1 day before NOW (2026-07-03)
+		endTime: "2026-07-06T18:00:00Z", // still in progress
+	};
+
+	it("does NOT flag an entity playing an ongoing multi-day event", () => {
+		const rss = { items: [{ title: "Viktor Hovland spiller i dag", link: "https://nrk.no/h" }] };
+		const gaps = detectGaps({ rss, events: [ongoingGolf], interests, tracked, now: NOW });
+		expect(gaps.find((x) => x.entity === "Viktor Hovland")).toBeUndefined();
+	});
+
+	it("does NOT flag a sport gap when the sport has an ongoing multi-day event", () => {
+		const rss = { items: [{ title: "PGA Tour: avgjørelsen faller i dag" }] };
+		const gaps = detectGaps({ rss, events: [ongoingGolf], interests, tracked, now: NOW });
+		expect(gaps.find((x) => x.kind === "sport" && x.sport === "golf")).toBeUndefined();
+	});
+
+	it("still flags when the multi-day event is already over", () => {
+		const finished = { ...ongoingGolf, time: "2026-06-25T06:00:00Z", endTime: "2026-06-28T18:00:00Z" };
+		const rss = { items: [{ title: "Viktor Hovland spiller i dag", link: "https://nrk.no/h" }] };
+		const gaps = detectGaps({ rss, events: [finished], interests, tracked, now: NOW });
+		expect(gaps.find((x) => x.entity === "Viktor Hovland")).toBeTruthy();
+	});
+});
+
 describe("detectGaps — sport-level blind spot (the F1 case)", () => {
 	it("flags a followed sport that is imminent in the news but absent from the board soon", () => {
 		// F1 in the news happening today; board only has a race 14 days out (the real bug).
@@ -175,6 +207,15 @@ describe("detectSourceAnomalies", () => {
 		const board = boardWithAll().filter((e) => e.sport !== "chess");
 		const a = detectSourceAnomalies({ sources: s, events: board, now: NOW });
 		expect(a.find((x) => x.sport === "chess")?.issue).toBe("file-empty");
+	});
+
+	it("counts an ongoing multi-day event in the source file as upcoming (WP-43 regression)", () => {
+		const s = healthy();
+		// Started 3 days before NOW, still running — must register as dropped-in-build, not file-empty.
+		s.golf = { tournaments: [{ events: [{ time: "2026-06-30T06:00:00Z", endTime: "2026-07-06T18:00:00Z" }] }] };
+		const board = boardWithAll().filter((e) => e.sport !== "golf");
+		const a = detectSourceAnomalies({ sources: s, events: board, now: NOW });
+		expect(a.find((x) => x.sport === "golf")?.issue).toBe("dropped-in-build");
 	});
 
 	it("flags (high) events present in the source but dropped from the board", () => {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -5,7 +5,22 @@ import os from "os";
 import path from "path";
 import { isEventInWindow, retainLastGood, hasEvents, normalizeToUTC, MS_PER_DAY,
 	normalizeText, containsName, normalizeEntity, matchInterest, mustWatchEntity,
-	normalizeParticipants, normalizeNorwegianPlayers } from "../scripts/lib/helpers.js";
+	normalizeParticipants, normalizeNorwegianPlayers, yyyymmdd, espnDateRange } from "../scripts/lib/helpers.js";
+
+describe("yyyymmdd / espnDateRange (shared ESPN date helpers)", () => {
+	it("formats a date as YYYYMMDD in UTC", () => {
+		expect(yyyymmdd(new Date("2026-07-03T12:00:00Z"))).toBe("20260703");
+		expect(yyyymmdd(Date.parse("2026-01-09T23:59:59Z"))).toBe("20260109");
+	});
+
+	it("espnDateRange returns `days` consecutive yyyymmdd strings starting today", () => {
+		const range = espnDateRange(3);
+		expect(range).toHaveLength(3);
+		expect(range[0]).toBe(yyyymmdd());
+		expect(range.every((d) => /^\d{8}$/.test(d))).toBe(true);
+		expect(range[1]).toBe(yyyymmdd(Date.now() + MS_PER_DAY));
+	});
+});
 
 describe("isEventInWindow", () => {
 	const day = (n) => new Date(Date.parse("2026-07-02T00:00:00Z") + n * MS_PER_DAY);


### PR DESCRIPTION
## FASE 0D · WP-43

**Fasens ene tilsiktede atferdsendring — endTime-blindheten i coverage-gaps:**
`detect-coverage-gaps.js` vinduet kun på `Date.parse(e.time)`, så en pågående flerdagsevent (golfturnering, etapperitt) som startet for >1 døgn siden ble lest som «ikke på tavla» og kunne generere falske entity-/sport-gaps. `hasEventWithin`, `countSportEventsWithin` og source-anomaly-filteret ruter nå gjennom `isEventInWindow` (`scripts/lib/helpers.js`), med regresjonstester:
- pågående flerdagsevent startet for 3 døgn siden ⇒ **ingen** entity-gap, **ingen** sport-gap, og teller som «upcoming» i source-anomaly-sjekken
- avsluttet flerdagsevent ⇒ gap flagges fortsatt

**Ren konvergens (ingen atferdsendring):**
- `fetch/fotball-no.js` ukesfilter → `isEventInWindow` (konvensjonen er absolutt, jf. CLAUDE.md)
- Én `yyyymmdd()`/`espnDateRange(days)` i `lib/helpers.js`; migrert `fetch-results.js` (`formatDate`) og `espn-adapter.js` (`generateDateRange`) — golfs inline-variant tas i WP-45
- Én CLI-main-guard-form i `scripts/`: `import.meta.url === pathToFileURL(process.argv[1] || "").href` (fire idiomer før; `process.argv[1]?.includes(...)`-varianten kunne false-positive på sti-substrenger). `grep` viser nå kun én form
- `fetch/index.js`: filnavn avledes av `{name, fn}`-arrayen — den posisjonskoblede `mapping`-arrayen er borte

**Ikke-mål respektert:** fetch-results-dedupe (WP-44), golf-skraper (WP-45), nye coverage-gaps-features.

**Verifikasjon:** 411/411 tester grønne (`--maxWorkers=1`; parallelle kjøringer viser kjent 5s-spawn-timeout-støy under maskinlast). `node scripts/detect-coverage-gaps.js` og `node scripts/validate-events.js` kjører rent mot ekte data.

PLAN.md-statusraden for WP-43 oppdatert i samme PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)