### PR TITLE
WP-46: felles theme.js + side-småplukk

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -71,7 +71,7 @@ mennesket, aldri av en agent.
 | WP-43 | Pipeline: konvensjons-konvergens | 0D | WP-42 | ⬜ køet |
 | WP-44 | fetch-results: intern dedupe | 0D | WP-43 | ⬜ køet |
 | WP-45 | Golf: skraper-ekstraksjon | 0D | WP-43 | ⬜ køet |
-| WP-46 | Web: felles theme.js + side-småplukk | 0D | WP-41 | ⬜ køet |
+| WP-46 | Web: felles theme.js + side-småplukk | 0D | WP-41 | 🔬 PR åpnet — ny `docs/js/theme.js` (3-stegs system→mørk→lys, ◐/●/○) på alle tre sider + pre-paint-snutt overalt; 2-stegs-variantene i activity/edit fjernet; theme-color/manifest → tokens (#0A0A0C/#F5F1E6); IBM Plex Mono-taggene ut (null eksterne requests); `SS_REPO` + `ssShortReason` i shared-constants; sw-cache `zenji-v2-19`; syklus verifisert identisk på alle sider, begge temaer screenshottet |
 | WP-47 | Web: dashboard.js-splitt | 0D | WP-46 | ⬜ køet |
 | WP-48 | iOS: Profile/-modul + demo/mock-karantene | 0D | – | ✅ merget (#269) — 12 filer `git mv` → `Zenji/Profile/` + profil-sync-extension ut av AssistantViewModel; `Zenji/Demo/` (LensDemoSeed/MemoryDemoSeed) strukturelt utenfor widget/test-targets; Mock* i `#if DEBUG` (også MockMemoryDistiller — `endOfOsloDay` → ny `MemoryFreshness`, siden FM-distillasjonen bruker den); `nm`: 0 Mock*-symboler i Release (193 i Debug-kontroll); 376/376 iOS-tester (uendret antall), 373/373 JS, begge schemes + ZenjiDeviceDev bygger |
 | WP-49 | Repo-vekt: skjermbilde-sanering + policy | 0D | – | ✅ merget (#264) — 57 PNG-er slettet (docs-design/, ios/docs/variants/, enso-grids; alle ureferert), enso-icon.swift beholdt med header for valgt variant v3-grov-contig (hash-bevist = shippet ikon), regel 8 (bevis-policy) lagt til; sporede PNG-er 12 MB → 8,3 MB |

--- a/docs/activity.html
+++ b/docs/activity.html
@@ -4,13 +4,12 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 	<meta name="description" content="Hva automatikken bak Zenji har gjort — forbedringer, reparasjoner og research, med lenke til hver endring.">
-	<meta name="theme-color" content="#0c0e11" media="(prefers-color-scheme: dark)">
-	<meta name="theme-color" content="#f6f3ec" media="(prefers-color-scheme: light)">
+	<meta name="theme-color" content="#0A0A0C" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F5F1E6" media="(prefers-color-scheme: light)">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>Zenji · Aktivitet</title>
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
+	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
 	<link rel="stylesheet" href="css/base.css">
 	<link rel="stylesheet" href="css/layout.css">
 	<style>
@@ -92,29 +91,13 @@
 		<a class="back-link" href="./">← oversikten</a>
 	</footer>
 
+	<script src="js/shared-constants.js"></script>
+	<script src="js/theme.js"></script>
 	<script>
-		// Theme — share the dashboard's key so the choice carries across pages.
-		(function () {
-			try {
-				const stored = localStorage.getItem('ss-theme');
-				if (stored) document.documentElement.setAttribute('data-theme', stored);
-			} catch { /* ignore */ }
-			document.getElementById('theme-toggle')?.addEventListener('click', () => {
-				const cur = document.documentElement.getAttribute('data-theme')
-					|| (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-				const next = cur === 'light' ? 'dark' : 'light';
-				document.documentElement.setAttribute('data-theme', next);
-				try { localStorage.setItem('ss-theme', next); } catch { /* ignore */ }
-			});
-		})();
+		// Repo slug (SS_REPO) and escapeHtml come from shared-constants.js; theme
+		// (glyph + system → dark → light cycle) lives in js/theme.js.
+		const REPO = SS_REPO;
 
-		const REPO = 'CHaerem/Zenji';
-
-		function escapeHtml(s) {
-			return String(s ?? '').replace(/[&<>"']/g, c => (
-				{ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
-			));
-		}
 		function timeAgo(iso) {
 			const t = Date.parse(iso);
 			if (!Number.isFinite(t)) return '';

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,8 @@
 	<link rel="apple-touch-icon" href="icons/icon-180x180.png">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>Zenji</title>
+	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
+	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
 	<link rel="stylesheet" href="css/base.css">
 	<link rel="stylesheet" href="css/layout.css">
 	<link rel="stylesheet" href="css/cards.css">
@@ -55,6 +57,7 @@
 	</footer>
 
 	<script src="js/shared-constants.js"></script>
+	<script src="js/theme.js"></script>
 	<script src="js/dashboard.js"></script>
 	<script>
 		if ('serviceWorker' in navigator) {

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -17,7 +17,7 @@ class Dashboard {
 	}
 
 	async init() {
-		this.initTheme();
+		// Theme is owned by js/theme.js (shared across pages).
 		this.renderDate();
 		this.startClock();
 		await this.loadData();
@@ -657,21 +657,13 @@ class Dashboard {
 		else if (tourn) why = `Del av <strong>${escapeHtml(tourn)}</strong>, som du følger`;
 		else if (e.source === 'ai-research') {
 			const r = this.trackedReasonFor(e);
-			why = r ? `AI valgte dette: ${escapeHtml(this.shortReason(r))}` : 'AI-research fant dette for deg';
+			why = r ? `AI valgte dette: ${escapeHtml(ssShortReason(r, 95))}` : 'AI-research fant dette for deg';
 		}
 		else if (e.norwegian) why = 'Norsk deltakelse';
 		else if (SPORT[e.sport]) why = `Du følger ${escapeHtml(SPORT[e.sport])}`;
 		else why = 'Passer interessene dine';
 		if (e.mustWatch) why += ` · varsel ${this.notifyLead()} min før`;
 		return why;
-	}
-
-	/** Trim an agent reason to a one-line gist (drops the provenance prefix). */
-	shortReason(r) {
-		if (!r) return '';
-		let s = String(r).replace(/^\s*(alwaysTrack\.\w+\.?|interests\.json#\S+)\s*/i, '').replace(/^[,.\s]+/, '').trim();
-		if (s.length > 95) s = s.slice(0, 93).replace(/\s+\S*$/, '') + '…';
-		return s;
 	}
 
 	/** The research agent's reason for tracking the thing this ai-research event belongs to. */
@@ -710,7 +702,7 @@ class Dashboard {
 			`- Kanal: ${chan}`, `- Kilde: ${e.source || 'statisk'}${e.confidence ? ` (${e.confidence})` : ''}`,
 		].join('\n');
 		const p = new URLSearchParams({ labels: 'event-feedback', title: `[feil] ${e.title}`, body });
-		window.open(`https://github.com/CHaerem/zenji/issues/new?${p.toString()}`, '_blank', 'noopener');
+		window.open(`https://github.com/${SS_REPO}/issues/new?${p.toString()}`, '_blank', 'noopener');
 	}
 
 	/** On iOS Safari (not yet installed), a quiet, dismissible install hint —
@@ -1089,33 +1081,6 @@ class Dashboard {
 		} catch { /* ignore */ }
 	}
 
-	// ── Theme override (BINDING, DESIGN.md) ───────────────────────────────────
-	// A single quantized glyph cycles system → dark → light → system. 'system'
-	// clears data-theme so prefers-color-scheme decides; the glyph shows the
-	// current quantized state: ◐ system · ● dark · ○ light.
-	THEME_GLYPH = { system: '◐', dark: '●', light: '○' };
-	applyTheme(mode) {
-		const root = document.documentElement;
-		if (mode === 'system') delete root.dataset.theme;
-		else root.dataset.theme = mode;
-		const btn = document.getElementById('theme-toggle');
-		if (btn) {
-			btn.textContent = this.THEME_GLYPH[mode] || '◐';
-			btn.setAttribute('aria-label', `Tema: ${mode === 'dark' ? 'mørk' : mode === 'light' ? 'lys' : 'system'} (trykk for å bytte)`);
-		}
-	}
-	initTheme() {
-		// Migrate: an earlier 2-state toggle stored only 'dark' | 'light'.
-		let mode = localStorage.getItem('ss-theme') || 'system';
-		if (!['system', 'dark', 'light'].includes(mode)) mode = 'system';
-		this.applyTheme(mode);
-		document.getElementById('theme-toggle')?.addEventListener('click', () => {
-			const cur = localStorage.getItem('ss-theme') || 'system';
-			const next = cur === 'system' ? 'dark' : cur === 'dark' ? 'light' : 'system';
-			localStorage.setItem('ss-theme', next);
-			this.applyTheme(next);
-		});
-	}
 }
 
 const dashboard = new Dashboard();

--- a/docs/js/edit.js
+++ b/docs/js/edit.js
@@ -3,16 +3,13 @@
 // Issue Form with fields PRE-FILLED via query params (GitHub renders the form,
 // the user just submits). The existing workflow turns it into a PR they merge.
 // Nothing is written directly — same review-gated flow, just zero manual input.
-const REPO = 'CHaerem/zenji';
+// Repo slug (SS_REPO), escapeHtml and ssShortReason come from shared-constants.js
+// (loaded before this script); theme lives in js/theme.js.
 const KINDS = [
 	['athletes', 'Utøver', 'Utøvere'],
 	['teams', 'Lag', 'Lag'],
 	['tournaments', 'Turnering', 'Turneringer'],
 ];
-
-function escapeHtml(s) {
-	return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-}
 
 // GitHub Issue Forms DON'T prefill dropdowns from the URL — only text fields — so
 // prefilling the template left Handling/Type unset. Instead compose the whole
@@ -33,7 +30,7 @@ function issueUrl(f) {
 		title: `[følg] ${f.action}: ${f.name}`,
 		body: lines.join('\n\n'),
 	});
-	return `https://github.com/${REPO}/issues/new?${p.toString()}`;
+	return `https://github.com/${SS_REPO}/issues/new?${p.toString()}`;
 }
 
 /** Does this entry notify? Teams/athletes default on; tournaments default off. */
@@ -68,13 +65,6 @@ function briefRow(s) {
 	return `<div class="edit-row"><div class="edit-name"><span class="edit-brief">${escapeHtml(s)}</span></div><div class="edit-actions"><a class="btn btn-danger" href="${removeUrl}" target="_blank" rel="noopener">Fjern</a></div></div>`;
 }
 
-/** Trim an agent reason to a one-line gist (drops the provenance prefix). */
-function shortReason(r) {
-	if (!r) return '';
-	let s = String(r).replace(/^\s*(alwaysTrack\.\w+\.?|interests\.json#\S+)\s*/i, '').replace(/^[,.\s]+/, '').trim();
-	if (s.length > 130) s = s.slice(0, 128).replace(/\s+\S*$/, '') + '…';
-	return s;
-}
 /** Strip trailing year / parenthetical from a tracked name for a clean follow. */
 function coreName(name) {
 	return String(name).replace(/\s*\d{4}(?:\/\d{2})?/g, '').replace(/\s*\(.*?\)/g, '').trim();
@@ -83,7 +73,7 @@ function coreName(name) {
 /** "AI har funnet" row: a discovery, name + why + expiry, with a "Følg 🔔" action. */
 function aiRow(x, kind) {
 	const until = x.expires ? `<span class="tag">ut ${escapeHtml(x.expires.slice(0, 10))}</span>` : '';
-	const why = x.reason ? `<div class="edit-alias" title="${escapeHtml(x.reason)}">${escapeHtml(shortReason(x.reason))}</div>` : '';
+	const why = x.reason ? `<div class="edit-alias" title="${escapeHtml(x.reason)}">${escapeHtml(ssShortReason(x.reason))}</div>` : '';
 	const followUrl = issueUrl({ action: 'Legg til', kind, name: coreName(x.name), sport: x.sport || '', notify: 'Ja' });
 	return `<div class="edit-row"><div class="edit-name"><span class="edit-title">${escapeHtml(x.name)}</span>${until}${why}</div><div class="edit-actions"><a class="btn" href="${followUrl}" target="_blank" rel="noopener">Følg 🔔</a></div></div>`;
 }
@@ -175,7 +165,7 @@ function suggestionEl(c) {
 function renderSuggestions(list, q) {
 	const box = document.getElementById('add-suggestions');
 	if (!box) return;
-	const manualUrl = `https://github.com/${REPO}/issues/new?${new URLSearchParams({ template: 'follow.yml', name: q }).toString()}`;
+	const manualUrl = `https://github.com/${SS_REPO}/issues/new?${new URLSearchParams({ template: 'follow.yml', name: q }).toString()}`;
 	const manual = `<a class="suggestion manual" href="${manualUrl}" target="_blank" rel="noopener">Legg til «${escapeHtml(q)}» manuelt — velg type + sport</a>`;
 	box.innerHTML = list.slice(0, 8).map(suggestionEl).join('') + manual;
 }
@@ -209,12 +199,4 @@ Promise.all([
 	document.getElementById('add-search')?.addEventListener('input', (e) => onSearch(e.target.value));
 }).catch(() => {
 	document.getElementById('edit-root').innerHTML = '<p class="muted">Kunne ikke laste lista. Prøv å laste siden på nytt.</p>';
-});
-
-// Theme toggle — parity with the dashboard (same localStorage key).
-document.getElementById('theme-toggle')?.addEventListener('click', () => {
-	const cur = document.documentElement.dataset.theme || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-	const next = cur === 'dark' ? 'light' : 'dark';
-	document.documentElement.dataset.theme = next;
-	try { localStorage.setItem('ss-theme', next); } catch (e) { /* ignore */ }
 });

--- a/docs/js/shared-constants.js
+++ b/docs/js/shared-constants.js
@@ -2,6 +2,10 @@
 // Canonical source of truth for values shared between client (dashboard.js) and server (helpers.js).
 // Loaded as the first <script> tag — all symbols are globals.
 
+// ── Repo ────────────────────────────────────────────────────────────────────
+// The ONE repo slug — used for issue/PR deep links on all pages.
+const SS_REPO = 'CHaerem/zenji';
+
 // ── Time constants ──────────────────────────────────────────────────────────
 const MS_PER_MINUTE = 60000;
 const MS_PER_HOUR = 3600000;
@@ -73,6 +77,14 @@ function ssContainsTerm(haystack, term) {
 	return new RegExp(`(?:^|[^\\p{L}\\p{N}])${esc}(?:[^\\p{L}\\p{N}]|$)`, 'iu').test(ssNormalize(haystack));
 }
 
+/** Trim an agent reason to a one-line gist (drops the provenance prefix). */
+function ssShortReason(r, max = 130) {
+	if (!r) return '';
+	let s = String(r).replace(/^\s*(alwaysTrack\.\w+\.?|interests\.json#\S+)\s*/i, '').replace(/^[,.\s]+/, '').trim();
+	if (s.length > max) s = s.slice(0, max - 2).replace(/\s+\S*$/, '') + '…';
+	return s;
+}
+
 // ── Expose globals ──────────────────────────────────────────────────────────
 window.SS_CONSTANTS = Object.freeze({
 	MS_PER_MINUTE,
@@ -80,7 +92,9 @@ window.SS_CONSTANTS = Object.freeze({
 	MS_PER_DAY,
 });
 
+window.SS_REPO = SS_REPO;
 window.isEventInWindow = isEventInWindow;
+window.ssShortReason = ssShortReason;
 window.escapeHtml = escapeHtml;
 window.ssShortName = ssShortName;
 window.ssTeamMatch = ssTeamMatch;

--- a/docs/js/theme.js
+++ b/docs/js/theme.js
@@ -1,0 +1,44 @@
+// Zenji Theme — the ONE theme implementation, shared by all pages (WP-46).
+// A single quantized glyph cycles system → dark → light → system (DESIGN.md,
+// BINDING). 'system' clears data-theme so prefers-color-scheme decides; the
+// glyph shows the current quantized state: ◐ system · ● dark · ○ light.
+// Persisted in localStorage under 'ss-theme'. Each page also has a tiny
+// pre-paint <head> snippet that sets data-theme before first paint (no flash);
+// this module owns the glyph and the toggle.
+(function () {
+	const KEY = 'ss-theme';
+	const MODES = ['system', 'dark', 'light'];
+	const GLYPH = { system: '◐', dark: '●', light: '○' };
+	const LABEL = { system: 'system', dark: 'mørk', light: 'lys' };
+
+	function storedMode() {
+		// Migrate: an earlier 2-state toggle stored only 'dark' | 'light'.
+		let mode = null;
+		try { mode = localStorage.getItem(KEY); } catch { /* private mode */ }
+		return MODES.includes(mode) ? mode : 'system';
+	}
+
+	function applyTheme(mode) {
+		const root = document.documentElement;
+		if (mode === 'system') delete root.dataset.theme;
+		else root.dataset.theme = mode;
+		const btn = document.getElementById('theme-toggle');
+		if (btn) {
+			btn.textContent = GLYPH[mode] || '◐';
+			btn.setAttribute('aria-label', `Tema: ${LABEL[mode] || 'system'} (trykk for å bytte)`);
+		}
+	}
+
+	function initTheme() {
+		applyTheme(storedMode());
+		document.getElementById('theme-toggle')?.addEventListener('click', () => {
+			const cur = storedMode();
+			const next = cur === 'system' ? 'dark' : cur === 'dark' ? 'light' : 'system';
+			try { localStorage.setItem(KEY, next); } catch { /* ignore */ }
+			applyTheme(next);
+		});
+	}
+
+	if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initTheme);
+	else initTheme();
+})();

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -6,8 +6,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "theme_color": "#000000",
-  "background_color": "#000000",
+  "theme_color": "#0A0A0C",
+  "background_color": "#0A0A0C",
   "icons": [
     {
       "src": "icons/icon-192x192.png",

--- a/docs/rediger.html
+++ b/docs/rediger.html
@@ -4,15 +4,12 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 	<meta name="description" content="Rediger det du følger i Zenji.">
-	<meta name="theme-color" content="#0c0e11" media="(prefers-color-scheme: dark)">
-	<meta name="theme-color" content="#f6f3ec" media="(prefers-color-scheme: light)">
+	<meta name="theme-color" content="#0A0A0C" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F5F1E6" media="(prefers-color-scheme: light)">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>Rediger · Zenji</title>
-	<!-- Apply the chosen theme before paint so it matches the dashboard (no flash). -->
-	<script>try { var t = localStorage.getItem('ss-theme'); if (t) document.documentElement.dataset.theme = t; } catch (e) {}</script>
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
+	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
 	<link rel="stylesheet" href="css/base.css">
 	<link rel="stylesheet" href="css/layout.css">
 	<style>
@@ -76,6 +73,7 @@
 	</main>
 
 	<script src="js/shared-constants.js"></script>
+	<script src="js/theme.js"></script>
 	<script src="js/edit.js"></script>
 </body>
 </html>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Zenji v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportsync-v2-18';
+const CACHE_NAME = 'zenji-v2-19';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [
@@ -15,6 +15,7 @@ const SHELL_FILES = [
     '/css/layout.css',
     '/css/cards.css',
     '/js/shared-constants.js',
+    '/js/theme.js',
     '/js/dashboard.js',
     '/rediger.html',
     '/js/edit.js',


### PR DESCRIPTION
## Hva

FASE 0D · WP-46 — én tema-implementasjon i stedet for tre (to av dem subtilt feil), pluss undersidenes småfeil.

### Tema
- **Ny `docs/js/theme.js`** — 3-stegs system → mørk → lys-syklusen (◐/●/○, DESIGN.md BINDENDE) flyttet ut av `dashboard.js`, lastet på alle tre sider. Oppførselen er identisk med dagens dashboard-syklus — bare delt.
- **Pre-paint-snutt i `<head>` på alle tre sider** (var kun rediger.html; index hadde flash-of-wrong-theme-risiko). Snutten guardes mot `'system'` så `data-theme` aldri settes til en verdi uten CSS-selektor.
- De uavhengige 2-stegs-variantene i `activity.html` og `edit.js` er fjernet (kunne sette `data-theme="system"`, oppdaterte aldri ◐-glyfen).

### Småplukk
- Undersidenes `theme-color`-metaer `#0c0e11`/`#f6f3ec` → tokens `#0A0A0C`/`#F5F1E6`; manifest `theme_color`/`background_color` `#000000` → `#0A0A0C`
- IBM Plex Mono-taggene fjernet fra activity/rediger (lastes fra Google Fonts, brukes aldri) — **siten har nå null tredjeparts-requests**
- Repo-slug som én konstant `SS_REPO` i `shared-constants.js` (var tre steder, to stavinger `CHaerem/Zenji` vs `CHaerem/zenji`)
- `ssShortReason` flyttet til `shared-constants.js` — én implementasjon; callers beholder dagens trunkering (dashboard 95, edit 130) så rendringen er uendret
- `edit.js` bruker `escapeHtml` fra `shared-constants.js` (lastes allerede)
- `CACHE_NAME` → `zenji-v2-19` + `theme.js` i sw-shell-listen

## Bevis (aksept)

- **Tema-toggle identisk på alle tre sider** — Playwright-kjøring klikket toggle 3× per side; alle tre gir samme sekvens `(null/◐) → (dark/●) → (light/○) → (system, data-theme fjernet, ◐)`, og lagret `ss-theme` respekteres ved last (dark/light verifisert på index, rediger og activity, screenshots i begge temaer).
- **Null eksterne font-requests** — alle `fonts.googleapis.com`/`fonts.gstatic.com`-referanser fjernet (grep-bekreftet).
- **npm test grønt** — full suite viste 5s-timeout-støy på spawn-tunge filer under maskinlast; alle berørte filer re-kjørt enkeltvis: grønt (405 tester totalt).

PLAN.md WP-46-raden oppdatert i samme PR. Ikke-mål respektert: ingen designendringer, ingen dashboard-splitt (WP-47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)