### PR TITLE
WP-69: FM-eval-harness på enhet + versjonert korpus

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -87,7 +87,7 @@ mennesket, aldri av en agent.
 | WP-66 | Assistent: app-kommando-arm + hurtigknapper | 0E | WP-62,WP-65 | ⬜ køet |
 | WP-67 | Assistent: presentasjonsfilter | 0E | WP-66 | ⬜ køet |
 | WP-68 | Assistent: app-hjelp-kunnskap | 0E | WP-66 | ⬜ køet |
-| WP-69 | FM-eval-harness på enhet + korpus | 0E | – | ⬜ køet |
+| WP-69 | FM-eval-harness på enhet + korpus | 0E | – | 🔬 PR åpnet (`wp-69-fm-eval`) — versjonert korpus `ios/ZenjiTests/Fixtures/eval-corpus.json` (24 cases: 12 canon + 5 multiPart + 2 winter + 5 question; 4 `knownGap` mot WP-64/65); delt pure `EvalCorpus`/`EvalScorer`/`EvalRunner`/`EvalReport` (id-sett for mutasjoner, rad/påstand-rubrikk for svar) i `Zenji/Eval/`; CI: `EvalCorpusTests` kjører samme korpus mot mocken (20 asserted grønne, 4 gap skippet med markering); DEBUG-only eval-skjerm (`Zenji/Eval/EvalView`, nås fra assistent-arkets fot) kjører ekte FM på enhet, pass-rate per kategori, anonymisert JSON-rapport via delesheet + eksport av forsto-ikke-loggen som korpus-kandidater; ingen ny target (korpus bundlet som ressurs i Zenji + ZenjiDeviceDev, `Zenji/Eval` i test-sources); 385/385 iOS-tester grønne (+9), begge schemes + ZenjiDeviceDev bygger. Eier kjører første reelle runde på fysisk iPhone og deler rapporten |
 | WP-70 | XCUITest: hovedflyter + launch-metrikk | 0E | – | ⬜ køet |
 
 ---

--- a/ios/README.md
+++ b/ios/README.md
@@ -460,7 +460,7 @@ request, the Foundation Models tests drive `MockInterestAssistant`/`MockAnswerer
 only, and they reuse the frozen `ZenjiTests/Fixtures/*` snapshots as decode input
 and mock-server responses.
 
-There are **42 `*Tests.swift` files (376 tests)**, at least one per subsystem —
+There are **43 `*Tests.swift` files (385 tests)**, at least one per subsystem —
 e.g. `SyncClientTests` (304 / changed-manifest / offline / corrupt-download),
 `CacheStoreTests` (App Group fallback), the `FeedCompilerUnit`/`FeedVector` pair,
 `AgendaViewModelTests`, `NotificationPlannerTests`, and the Assistant / Profile /
@@ -473,6 +473,49 @@ xcodebuild test -project Zenji.xcodeproj -scheme Zenji \
 ```
 
 `npm test` (the repo-root JS suite) is unaffected by anything under `ios/`.
+
+### FM-eval harness (WP-69) — measuring real assistant quality
+
+Apple Intelligence can't run in CI, so assistant quality is measured two ways
+against **one versioned corpus** (`ZenjiTests/Fixtures/eval-corpus.json`, ≥20
+cases: WP-16 canon, the owner's multi-clause class, winter sport, feed
+questions). The corpus scores **structure, never prose**: an entity id-SET for
+mutations; a row/claim rubric for answers (must-reference-rows, referenced
+sport, must-contain-any, forbidden-claims, no phantom rows). Cases flagged
+`knownGap` are targets for a named future WP (WP-64 winter entities, WP-65 bulk
+capture), not failures.
+
+- **CI (mock).** `EvalCorpusTests` runs the SAME corpus through
+  `MockInterestAssistant` and asserts every deterministic case; `knownGap` cases
+  are skipped with a printed marker. The pure `EvalScorer`/`EvalRunner`/`EvalReport`
+  (in `Zenji/Eval/`) are shared with the device path, so the two can't drift.
+- **On device (real FM).** A **DEBUG-only** eval screen (`Zenji/Eval/EvalView.swift`)
+  is reached from the assistant ark's foot ("EVAL (DEBUG)", next to "Det jeg ikke
+  forsto"). It runs the corpus through the real `FoundationModelsInterestAssistant`
+  on a physical iPhone (`ZenjiDeviceDev` scheme — the corpus is bundled as an app
+  resource), shows a **pass-rate per category**, and exports an **anonymised JSON
+  report** via the share sheet (same privacy posture as the MisunderstoodLog
+  export — never any network, no device id). A second button exports the local
+  "forsto ikke"-log as **corpus candidates** (utterance + note) for the human to
+  curate — an export, never an auto-incorporation. There is **no new target** and
+  only a minimal `project.yml` change (the corpus as a resource + `Zenji/Eval` in
+  the test sources).
+
+**Report format** — the shared JSON (`EvalReport`): `corpusVersion`,
+`generatedAt`, `assistant` (`"mock"`/`"foundation-models"`), `available`,
+`totals` (`total` / `passed` / `evaluated` / `knownGap` / `knownGapPassed`),
+`categories[]` (per-category `total` / `evaluated` / `passed` / `knownGap` /
+`knownGapPassed`), and `cases[]` (each with `caseId`, `category`, `utterance`,
+`kind`, `knownGap`, `knownGapRef`, and its `checks[]` of `{label, passed,
+detail}`). `evaluated` excludes `knownGap` cases; `knownGapPassed` counts gaps
+that *unexpectedly* passed (a gap closed — promote it out of `knownGap`).
+
+**Running a real eval (the owner's one manual step):** build & run the
+`ZenjiDeviceDev` scheme on a physical iPhone with Apple Intelligence on → open
+the assistant (`»_`) → its foot → **EVAL (DEBUG)** → **KJØR EVAL** → **DEL
+RAPPORT** and share the JSON. Each assistant WP (WP-65/66/68) adds its cases to
+the corpus in the same PR, so the pass-rate is the regression signal that
+replaces manual exploratory testing.
 
 ## Data contract
 

--- a/ios/Zenji/Assistant/AssistantPanel.swift
+++ b/ios/Zenji/Assistant/AssistantPanel.swift
@@ -46,6 +46,11 @@ struct AssistantPanel: View {
     /// confirmation (nil = the two calm entry rows, non-nil = the confirm ark).
     @State private var resetExpanded = false
     @State private var confirmingReset: ResetLevel?
+    #if DEBUG
+    /// WP-69 — the DEBUG-only FM-eval screen, reached from this same foot (the
+    /// existing debug surface). Never compiled into a Release build.
+    @State private var evalShown = false
+    #endif
 
     /// DEBUG screenshot harness only: force the "Nullstill" disclosure open
     /// (and optionally jump straight to one level's confirmation ark) so each
@@ -76,6 +81,9 @@ struct AssistantPanel: View {
                     memoryEntry
                     resetSection
                     misunderstoodSection
+                    #if DEBUG
+                    evalEntry
+                    #endif
                     ProfileSharePanel(viewModel: viewModel)
                 }
                 .padding(20)
@@ -551,6 +559,30 @@ struct AssistantPanel: View {
     private var misunderstoodExportText: String {
         String(data: viewModel.misunderstoodExportPayload(), encoding: .utf8) ?? "[]"
     }
+
+    #if DEBUG
+    // MARK: - Eval (WP-69, DEBUG only)
+
+    /// A quiet entry to the on-device FM-eval screen at the same foot as the
+    /// other developer surfaces. Compiled out of Release builds entirely (the
+    /// whole EvalView + its model are `#if DEBUG`).
+    private var evalEntry: some View {
+        Button { evalShown = true } label: {
+            HStack {
+                Text("EVAL (DEBUG)")
+                    .font(.zenjiMono(size: 12, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                    .tracking(1.5)
+                Spacer()
+            }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .sheet(isPresented: $evalShown) {
+            EvalView()
+        }
+    }
+    #endif
 
     // MARK: - Small helpers
 

--- a/ios/Zenji/Eval/EvalCorpus.swift
+++ b/ios/Zenji/Eval/EvalCorpus.swift
@@ -1,0 +1,132 @@
+//
+//  EvalCorpus.swift
+//  Zenji
+//
+//  WP-69 — the versioned assistant eval corpus, decoded from
+//  `ZenjiTests/Fixtures/eval-corpus.json`. Plain, FoundationModels-FREE value
+//  types (Codable/Sendable), exactly like `AssistantModels`: the corpus + the
+//  scorer are shared by BOTH the CI XCTest (which drives the deterministic
+//  MockInterestAssistant) and the DEBUG on-device eval screen (which drives the
+//  real FoundationModelsInterestAssistant). Only the harness around them
+//  differs — the golden expectations and the scoring rubric are one code path.
+//
+//  The corpus scores STRUCTURE, never prose:
+//    • mutation cases  → an entity id-SET the grounded result must equal.
+//    • answer cases    → a rubric: must-reference-rows (count / sport),
+//      must-contain-any, forbidden-claims, and no phantom (unresolvable) rows.
+//
+//  `knownGap` cases are EXPECTED to fail until the named work package lands: CI
+//  skips them (marked), the device run reports them as known gaps rather than
+//  failures. This is how a not-yet-shipped capability (e.g. WP-64 winter
+//  entities, WP-65 bulk capture) is tracked as a target instead of a red test.
+//
+
+import Foundation
+
+/// One versioned corpus: a schema `version`, the fixed `clock` the CI answer
+/// arm is evaluated against (the on-device run uses the live feed + real time),
+/// and the cases.
+struct EvalCorpus: Codable, Sendable {
+    var version: Int
+    var description: String?
+    /// The fixed `now` CI evaluates the answer arm against, ISO 8601. Ignored by
+    /// the on-device run (which uses the live feed and the device clock).
+    var clock: Date
+    var cases: [EvalCase]
+
+    /// Categories present, in first-seen order — drives the per-category
+    /// pass-rate breakdown.
+    var categories: [String] {
+        var seen = Set<String>()
+        return cases.compactMap { seen.insert($0.category).inserted ? $0.category : nil }
+    }
+
+    // MARK: - Decoding
+
+    /// ISO 8601 dates (the `clock` field), matching the rest of the app's codecs.
+    static func decode(_ data: Data) throws -> EvalCorpus {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(EvalCorpus.self, from: data)
+    }
+
+    /// Loads the corpus bundled as a resource (`eval-corpus.json`). The DEBUG
+    /// eval screen calls this against `Bundle.main`; the CI test decodes the
+    /// fixture data directly. Returns nil if the resource is missing or invalid
+    /// (the screen shows an honest "fant ikke korpuset" state rather than
+    /// crashing).
+    static func bundled(in bundle: Bundle = .main, resource: String = "eval-corpus") -> EvalCorpus? {
+        guard let url = bundle.url(forResource: resource, withExtension: "json"),
+              let data = try? Data(contentsOf: url) else { return nil }
+        return try? decode(data)
+    }
+}
+
+/// One eval case: an utterance plus its golden STRUCTURED expectation.
+struct EvalCase: Codable, Sendable, Identifiable {
+    var id: String
+    /// Grouping for the per-category pass-rate ("canon", "multiPart", "winter",
+    /// "question").
+    var category: String
+    var utterance: String
+    /// Which arm the case exercises.
+    var kind: EvalKind
+    /// Optional profile to seed BEFORE interpreting (e.g. "slutt med tennis"
+    /// needs a tennis rule to remove). Each entry is grounded straight to an
+    /// add-rule via the index.
+    var seedProfile: [SeedRule]?
+    /// True when the case is EXPECTED to fail until `knownGapRef` ships. CI
+    /// skips it (marked); the device run reports it as a known gap.
+    var knownGap: Bool?
+    /// The work package that closes the gap (e.g. "WP-64/65").
+    var knownGapRef: String?
+    /// Free-text rationale carried into the report for the reader.
+    var note: String?
+    var expect: EvalExpectation
+
+    var isKnownGap: Bool { knownGap == true }
+}
+
+enum EvalKind: String, Codable, Sendable {
+    case mutation
+    case answer
+}
+
+/// A rule to seed into the profile before interpreting. `scope` is optional
+/// Norwegian text ("bare i Grand Slams"), mirroring `InterestRule`.
+struct SeedRule: Codable, Sendable {
+    var entityId: String
+    var scope: String?
+}
+
+/// The golden expectation — exactly one arm is populated per `EvalCase.kind`.
+struct EvalExpectation: Codable, Sendable {
+    /// For `.mutation`: the entity id-SET the GROUNDED result must equal
+    /// (order-independent). An empty array means "nothing should ground" (the
+    /// honest-rejection cases).
+    var mutationEntityIds: [String]?
+    /// For `.answer`: the row/claim rubric.
+    var answer: AnswerExpectation?
+}
+
+/// The answer-arm rubric. Every populated field is a check; a case passes only
+/// if ALL its checks pass. Deliberately structural — never an exact-text match
+/// — so it holds for both the deterministic mock (fixture feed) and a
+/// free-generating model (live feed).
+struct AnswerExpectation: Codable, Sendable {
+    /// The answer must resolve at least this many referenced agenda rows.
+    var minReferencedRows: Int?
+    /// At least one resolved referenced row must be one of these sports.
+    var referencedSportsAnyOf: [String]?
+    /// The answer text must contain at least one of these substrings
+    /// (case-insensitive) — e.g. an "i kveld" question stays about tonight.
+    var mustContainAny: [String]?
+    /// The answer text must contain NONE of these (case-insensitive) — the
+    /// no-fabrication / no-spoiler guard.
+    var forbiddenClaims: [String]?
+    /// Every cited event id must resolve to a real feed row (no phantom rows).
+    /// Defaults to true when omitted.
+    var requireNoPhantomRows: Bool?
+
+    var enforceNoPhantomRows: Bool { requireNoPhantomRows ?? true }
+}

--- a/ios/Zenji/Eval/EvalRunner.swift
+++ b/ios/Zenji/Eval/EvalRunner.swift
@@ -1,0 +1,191 @@
+//
+//  EvalRunner.swift
+//  Zenji
+//
+//  WP-69 — drives an `InterestAssistant` through the corpus and scores each
+//  case. Depends ONLY on the `InterestAssistant` protocol (+ the pure grounding
+//  / feed / profile pieces), so it runs identically against the deterministic
+//  `MockInterestAssistant` in CI and the real `FoundationModelsInterestAssistant`
+//  on device — the whole point of WP-69 (measure the SAME corpus two ways).
+//
+//  For a mutation case it runs the full pipeline the app runs — interpret →
+//  MutationGrounder.ground → the id-set that would actually be applied — because
+//  that grounded set is the honest "what changes" signal (a hallucinated id that
+//  grounding rejects is correctly scored as nothing). For an answer case it
+//  resolves the cited ids back against the feed, so a phantom id counts as a
+//  phantom row rather than a real reference.
+//
+
+import Foundation
+
+struct EvalRunner: Sendable {
+    let assistant: any InterestAssistant
+    let index: EntityIndex
+    /// The agenda the answer arm queries. CI passes a feed compiled at the
+    /// corpus `clock`; the device passes the live feed.
+    let feed: FeedQuery
+
+    /// Run + score one case.
+    func run(_ c: EvalCase) async -> EvalCaseResult {
+        let profile = seededProfile(for: c)
+        let turn = await interpret(c.utterance, profile: profile)
+        let actual = reduce(turn, kind: c.kind, profile: profile)
+        return EvalScorer.score(c, actual: actual)
+    }
+
+    /// Run + score the whole corpus, in order (the real model is sequential and
+    /// slow, so there's no gain in parallelising — and it keeps the on-device
+    /// progress readout honest).
+    func runAll(_ corpus: EvalCorpus) async -> [EvalCaseResult] {
+        var out: [EvalCaseResult] = []
+        out.reserveCapacity(corpus.cases.count)
+        for c in corpus.cases {
+            out.append(await run(c))
+        }
+        return out
+    }
+
+    // MARK: - Steps
+
+    private func interpret(_ utterance: String, profile: InterestProfile) async -> AssistantTurn {
+        do {
+            return try await assistant.interpret(utterance: utterance, profile: profile, index: index, feed: feed)
+        } catch {
+            // Unavailable / generation-failed → no usable output. Scored as an
+            // empty mutation set (or, for an answer case, empty prose): honest,
+            // and never crashes the run.
+            return .mutations([])
+        }
+    }
+
+    private func reduce(_ turn: AssistantTurn, kind: EvalKind, profile: InterestProfile) -> EvalActual {
+        switch (kind, turn) {
+        case let (.mutation, .mutations(proposals)):
+            let grounded = MutationGrounder.ground(proposals, index: index, profile: profile).grounded
+            return .mutation(groundedEntityIds: grounded.map { $0.entity.id })
+        case (.mutation, .answer):
+            // The case wanted a change but the model answered — nothing grounds.
+            return .mutation(groundedEntityIds: [])
+        case let (.answer, .answer(answer)):
+            let byId = Dictionary(feed.events.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+            let resolved = answer.referencedEventIds.compactMap { byId[$0] }
+            return .answer(
+                text: answer.text,
+                citedRowCount: answer.referencedEventIds.count,
+                resolvedRowCount: resolved.count,
+                resolvedRowSports: resolved.map { $0.sport }
+            )
+        case (.answer, .mutations):
+            // The case asked a question but the model proposed changes — no
+            // answer text, no rows.
+            return .answer(text: "", citedRowCount: 0, resolvedRowCount: 0, resolvedRowSports: [])
+        }
+    }
+
+    /// Build the profile a case seeds before interpreting. Each seed rule is
+    /// grounded straight to an add (unknown ids are skipped — a seed that can't
+    /// resolve is a corpus problem, not a run failure).
+    private func seededProfile(for c: EvalCase) -> InterestProfile {
+        var profile = InterestProfile()
+        for seed in c.seedProfile ?? [] {
+            guard let entity = index.entity(id: seed.entityId) else { continue }
+            profile = profile.applying(GroundedMutation(
+                kind: .add, entity: entity, scope: seed.scope, weight: 0.5,
+                reason: "eval-seed", previousRule: nil
+            ))
+        }
+        return profile
+    }
+}
+
+// MARK: - Report (the anonymised export shape)
+
+/// The full, anonymised eval report — the exact JSON the device screen shares
+/// via the share sheet. Deliberately carries NO device id / account / anything
+/// personal: only the corpus version, a timestamp, which assistant ran, and the
+/// per-case structured results (utterances come from the versioned corpus, not
+/// the user). Same privacy posture as `MisunderstoodLogStore.exportPayload()`.
+struct EvalReport: Codable, Sendable {
+    var corpusVersion: Int
+    var generatedAt: Date
+    /// "mock" (CI) or "foundation-models" (device) — so a shared report is
+    /// self-describing.
+    var assistant: String
+    /// Whether the assistant reported itself available when the run started.
+    var available: Bool
+    var totals: Totals
+    var categories: [CategorySummary]
+    var cases: [EvalCaseResult]
+
+    struct Totals: Codable, Sendable {
+        var total: Int
+        /// Passed among the non-known-gap cases.
+        var passed: Int
+        /// Cases evaluated (total − knownGap).
+        var evaluated: Int
+        var knownGap: Int
+        /// Known-gap cases that unexpectedly PASSED (a gap closed — worth
+        /// promoting out of `knownGap`).
+        var knownGapPassed: Int
+    }
+
+    struct CategorySummary: Codable, Sendable, Identifiable {
+        var category: String
+        var total: Int
+        var evaluated: Int
+        var passed: Int
+        var knownGap: Int
+        var knownGapPassed: Int
+
+        var id: String { category }
+        /// Pass-rate over the EVALUATED (non-gap) cases, 0…1. Nil when a
+        /// category is all known-gaps (no rate to show yet).
+        var passRate: Double? { evaluated == 0 ? nil : Double(passed) / Double(evaluated) }
+    }
+
+    /// Build a report from scored results — pure, so both harnesses share it.
+    static func make(results: [EvalCaseResult], corpusVersion: Int, assistant: String, available: Bool, now: Date = Date()) -> EvalReport {
+        let evaluated = results.filter { !$0.knownGap }
+        let gaps = results.filter { $0.knownGap }
+        let totals = Totals(
+            total: results.count,
+            passed: evaluated.filter(\.passed).count,
+            evaluated: evaluated.count,
+            knownGap: gaps.count,
+            knownGapPassed: gaps.filter(\.passed).count
+        )
+        var order: [String] = []
+        var seen = Set<String>()
+        for r in results where seen.insert(r.category).inserted { order.append(r.category) }
+        let categories = order.map { cat -> CategorySummary in
+            let inCat = results.filter { $0.category == cat }
+            let ev = inCat.filter { !$0.knownGap }
+            let gp = inCat.filter { $0.knownGap }
+            return CategorySummary(
+                category: cat,
+                total: inCat.count,
+                evaluated: ev.count,
+                passed: ev.filter(\.passed).count,
+                knownGap: gp.count,
+                knownGapPassed: gp.filter(\.passed).count
+            )
+        }
+        return EvalReport(
+            corpusVersion: corpusVersion,
+            generatedAt: now,
+            assistant: assistant,
+            available: available,
+            totals: totals,
+            categories: categories,
+            cases: results
+        )
+    }
+
+    /// Pretty-printed, stable-key JSON — the share-sheet payload.
+    func jsonData() -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return (try? encoder.encode(self)) ?? Data("{}".utf8)
+    }
+}

--- a/ios/Zenji/Eval/EvalScorer.swift
+++ b/ios/Zenji/Eval/EvalScorer.swift
@@ -1,0 +1,173 @@
+//
+//  EvalScorer.swift
+//  Zenji
+//
+//  WP-69 — the PURE scorer: an `EvalCase` + the assistant's ACTUAL structured
+//  output → an `EvalCaseResult` (a list of named pass/fail checks). No I/O, no
+//  clock, no FoundationModels — so it is exercised directly by the CI XCTest
+//  and reused verbatim by the on-device eval screen. The runner
+//  (`EvalRunner`) is what actually drives an assistant to produce the
+//  `EvalActual`; this file only judges.
+//
+
+import Foundation
+
+/// What an assistant actually produced for one case, reduced to the bits the
+/// rubric scores. The runner fills exactly the arm the case's `kind` needs.
+struct EvalActual: Sendable {
+    // Mutation arm — the id-set that survived grounding.
+    var groundedEntityIds: [String]
+
+    // Answer arm.
+    /// The prose the assistant returned.
+    var answerText: String
+    /// The number of event ids the assistant CITED.
+    var citedRowCount: Int
+    /// Of those, how many resolved to a real feed row.
+    var resolvedRowCount: Int
+    /// The sports of the resolved referenced rows.
+    var resolvedRowSports: [String]
+
+    static func mutation(groundedEntityIds: [String]) -> EvalActual {
+        EvalActual(groundedEntityIds: groundedEntityIds, answerText: "", citedRowCount: 0, resolvedRowCount: 0, resolvedRowSports: [])
+    }
+
+    static func answer(text: String, citedRowCount: Int, resolvedRowCount: Int, resolvedRowSports: [String]) -> EvalActual {
+        EvalActual(groundedEntityIds: [], answerText: text, citedRowCount: citedRowCount, resolvedRowCount: resolvedRowCount, resolvedRowSports: resolvedRowSports)
+    }
+}
+
+/// One named check within a case (e.g. "id-sett", "ingen oppdiktede rader").
+struct EvalCheck: Codable, Sendable, Identifiable {
+    var label: String
+    var passed: Bool
+    /// Short Norwegian detail for the report/UI ("mangler: X · ekstra: Y").
+    var detail: String
+
+    var id: String { label }
+}
+
+/// The scored outcome for one case.
+struct EvalCaseResult: Codable, Sendable, Identifiable {
+    var caseId: String
+    var category: String
+    var utterance: String
+    var kind: EvalKind
+    var knownGap: Bool
+    var knownGapRef: String?
+    var checks: [EvalCheck]
+
+    var id: String { caseId }
+    /// A case passes when every check passes.
+    var passed: Bool { checks.allSatisfy(\.passed) }
+}
+
+enum EvalScorer {
+
+    /// Judge one case against the assistant's actual output. Never throws — a
+    /// missing expectation for the declared kind becomes a single failed check
+    /// (a corpus authoring error surfaces loudly instead of silently passing).
+    static func score(_ c: EvalCase, actual: EvalActual) -> EvalCaseResult {
+        let checks: [EvalCheck]
+        switch c.kind {
+        case .mutation:
+            checks = scoreMutation(c, actual: actual)
+        case .answer:
+            checks = scoreAnswer(c, actual: actual)
+        }
+        return EvalCaseResult(
+            caseId: c.id,
+            category: c.category,
+            utterance: c.utterance,
+            kind: c.kind,
+            knownGap: c.isKnownGap,
+            knownGapRef: c.knownGapRef,
+            checks: checks
+        )
+    }
+
+    // MARK: - Mutation
+
+    private static func scoreMutation(_ c: EvalCase, actual: EvalActual) -> [EvalCheck] {
+        guard let expected = c.expect.mutationEntityIds else {
+            return [EvalCheck(label: "id-sett", passed: false, detail: "Korpusfeil: mutation-case mangler mutationEntityIds.")]
+        }
+        let expectedSet = Set(expected)
+        let actualSet = Set(actual.groundedEntityIds)
+        let missing = expectedSet.subtracting(actualSet).sorted()
+        let extra = actualSet.subtracting(expectedSet).sorted()
+        let passed = missing.isEmpty && extra.isEmpty
+        let detail: String
+        if passed {
+            detail = expectedSet.isEmpty ? "ingenting grunnfestet (korrekt)" : "grunnfestet: \(actualSet.sorted().joined(separator: ", "))"
+        } else {
+            var parts: [String] = []
+            if !missing.isEmpty { parts.append("mangler: \(missing.joined(separator: ", "))") }
+            if !extra.isEmpty { parts.append("ekstra: \(extra.joined(separator: ", "))") }
+            detail = parts.joined(separator: " · ")
+        }
+        return [EvalCheck(label: "id-sett", passed: passed, detail: detail)]
+    }
+
+    // MARK: - Answer
+
+    private static func scoreAnswer(_ c: EvalCase, actual: EvalActual) -> [EvalCheck] {
+        guard let exp = c.expect.answer else {
+            return [EvalCheck(label: "svar", passed: false, detail: "Korpusfeil: answer-case mangler answer-forventning.")]
+        }
+        var checks: [EvalCheck] = []
+        let text = actual.answerText
+        let haystack = text.lowercased()
+
+        if exp.enforceNoPhantomRows {
+            let phantom = actual.citedRowCount - actual.resolvedRowCount
+            checks.append(EvalCheck(
+                label: "ingen oppdiktede rader",
+                passed: phantom <= 0,
+                detail: phantom <= 0 ? "alle \(actual.citedRowCount) refererte rader finnes" : "\(phantom) refererte rad-id-er finnes ikke i agendaen"
+            ))
+        }
+        if let minRows = exp.minReferencedRows {
+            checks.append(EvalCheck(
+                label: "må-referere-rader (≥\(minRows))",
+                passed: actual.resolvedRowCount >= minRows,
+                detail: "refererte \(actual.resolvedRowCount) rad(er)"
+            ))
+        }
+        if let sports = exp.referencedSportsAnyOf, !sports.isEmpty {
+            let hit = actual.resolvedRowSports.first { sports.contains($0) }
+            checks.append(EvalCheck(
+                label: "rad-idrett ∈ {\(sports.joined(separator: ", "))}",
+                passed: hit != nil,
+                detail: hit.map { "traff \($0)" } ?? "ingen refererte rader i forventede idretter (fikk: \(uniqueJoined(actual.resolvedRowSports)))"
+            ))
+        }
+        if let musts = exp.mustContainAny, !musts.isEmpty {
+            let hit = musts.first { haystack.contains($0.lowercased()) }
+            checks.append(EvalCheck(
+                label: "må-inneholde-én-av",
+                passed: hit != nil,
+                detail: hit.map { "inneholder «\($0)»" } ?? "manglet alle av: \(musts.joined(separator: ", "))"
+            ))
+        }
+        if let forbidden = exp.forbiddenClaims, !forbidden.isEmpty {
+            let violated = forbidden.filter { haystack.contains($0.lowercased()) }
+            checks.append(EvalCheck(
+                label: "forbudte-påstander",
+                passed: violated.isEmpty,
+                detail: violated.isEmpty ? "ingen forbudte påstander" : "inneholdt: \(violated.joined(separator: ", "))"
+            ))
+        }
+        // A rubric that specified no checks at all is a corpus authoring error.
+        if checks.isEmpty {
+            checks.append(EvalCheck(label: "svar", passed: false, detail: "Korpusfeil: answer-rubrikk uten noen sjekker."))
+        }
+        return checks
+    }
+
+    private static func uniqueJoined(_ xs: [String]) -> String {
+        var seen = Set<String>()
+        let unique = xs.filter { seen.insert($0).inserted }
+        return unique.isEmpty ? "ingen" : unique.joined(separator: ", ")
+    }
+}

--- a/ios/Zenji/Eval/EvalView.swift
+++ b/ios/Zenji/Eval/EvalView.swift
@@ -1,0 +1,317 @@
+//
+//  EvalView.swift
+//  Zenji
+//
+//  WP-69 — the DEBUG-only eval screen. Reached from the assistant ark's
+//  "Det jeg ikke forsto" foot (a quiet "EVAL (DEBUG)" row, compiled only in
+//  DEBUG). It runs the versioned corpus through the REAL
+//  FoundationModelsInterestAssistant on the physical iPhone — the only place
+//  Apple Intelligence actually runs — shows a per-category pass-rate, and
+//  exports an anonymised JSON report via the share sheet (the SAME privacy
+//  pattern as the MisunderstoodLog export: never any network, no device id).
+//
+//  It also offers to export the local "forsto ikke"-log as CORPUS CANDIDATES
+//  (utterance + note), so real misses become raw material for the next corpus
+//  revision — an EXPORT, never an auto-incorporation (the human curates what
+//  enters the versioned corpus).
+//
+//  Whole file is `#if DEBUG`: a Release build contains no eval symbols, exactly
+//  like the Mock* / demo-seed files. It builds in DEBUG for the device scheme
+//  (which runs the Debug config), which is where the owner runs it.
+//
+
+#if DEBUG
+import SwiftUI
+
+@MainActor
+@Observable
+final class EvalScreenModel {
+    private(set) var corpus: EvalCorpus?
+    private(set) var results: [EvalCaseResult] = []
+    private(set) var report: EvalReport?
+    private(set) var isRunning = false
+    private(set) var progress = 0
+    /// Honest state when Apple Intelligence is off / the corpus is missing.
+    private(set) var status: String?
+
+    private let assistant: any InterestAssistant
+    private let index: EntityIndex
+    private let feedProvider: () -> FeedQuery
+    private let logStore: MisunderstoodLogStore
+
+    /// App wiring: the real on-device model + the live index/feed from the WP-12
+    /// cache (the same construction `AssistantViewModel`'s app initializer uses),
+    /// so the eval reflects exactly what the shipping assistant would see.
+    init(
+        dataStore: DataStore = DataStore(),
+        profileStore: ProfileStore = ProfileStore(),
+        assistant: any InterestAssistant = FoundationModelsInterestAssistant(),
+        logStore: MisunderstoodLogStore = MisunderstoodLogStore()
+    ) {
+        self.assistant = assistant
+        self.index = EntityIndex(dataStore.loadEntities())
+        self.logStore = logStore
+        self.feedProvider = {
+            let events = dataStore.loadEvents()
+            let base = dataStore.loadInterests() ?? Interests()
+            let idx = EntityIndex(dataStore.loadEntities())
+            let profile = profileStore.load()
+            let effective = EffectiveInterests.merge(profile: profile, into: base, index: idx)
+            return FeedQuery.build(events: events, interests: effective, now: Date())
+        }
+        self.corpus = EvalCorpus.bundled()
+        if corpus == nil {
+            status = "Fant ikke eval-korpuset i pakken."
+        }
+    }
+
+    var availabilityMessage: String? { assistant.availability().message }
+
+    /// Run the whole corpus through the real model on this device.
+    func run() async {
+        guard let corpus, !isRunning else { return }
+        isRunning = true
+        progress = 0
+        results = []
+        report = nil
+        status = nil
+        defer { isRunning = false }
+
+        let available = assistant.availability().isAvailable
+        let runner = EvalRunner(assistant: assistant, index: index, feed: feedProvider())
+        var scored: [EvalCaseResult] = []
+        for c in corpus.cases {
+            scored.append(await runner.run(c))
+            progress = scored.count
+            results = scored
+        }
+        report = EvalReport.make(
+            results: scored,
+            corpusVersion: corpus.version,
+            assistant: "foundation-models",
+            available: available
+        )
+    }
+
+    /// The anonymised report JSON to share (empty object until a run finishes).
+    var reportJSON: String {
+        guard let report else { return "{}" }
+        return String(data: report.jsonData(), encoding: .utf8) ?? "{}"
+    }
+
+    /// Export the local "forsto ikke"-log as CORPUS CANDIDATES — utterance +
+    /// outcome + the user's note, anonymised. Not auto-added: the human decides
+    /// what enters the versioned corpus.
+    var candidatesJSON: String {
+        let entries = logStore.load()
+        struct Candidate: Codable { var utterance: String; var outcome: String; var note: String? }
+        let candidates = entries.map { Candidate(utterance: $0.utterance, outcome: $0.outcome.rawValue, note: $0.note) }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = (try? encoder.encode(candidates)) ?? Data("[]".utf8)
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+
+    var candidateCount: Int { logStore.load().count }
+}
+
+/// The DEBUG eval screen — calm Tekst-TV: monospace, amber accent, no charts.
+struct EvalView: View {
+    @State private var model: EvalScreenModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(model: EvalScreenModel = EvalScreenModel()) {
+        _model = State(initialValue: model)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    intro
+                    if let message = model.availabilityMessage { banner(message) }
+                    controls
+                    if let report = model.report { summary(report) }
+                    if !model.results.isEmpty { caseList }
+                }
+                .padding(20)
+                .frame(maxWidth: 640, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .background(ZenjiTokens.background)
+            .foregroundStyle(ZenjiTokens.foreground)
+            .navigationTitle("EVAL")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Lukk") { dismiss() }
+                        .font(.zenjiMono(size: 13))
+                        .foregroundStyle(ZenjiTokens.accent)
+                }
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    private var intro: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("FM-EVAL PÅ ENHET")
+                .font(.zenjiMono(size: 12, weight: .bold))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                .tracking(1.5)
+            Text("Kjører det versjonerte korpuset gjennom Apple Intelligence på denne enheten og scorer strukturert. Del rapporten når kjøringen er ferdig.")
+                .font(.zenjiMono(size: 12))
+                .foregroundStyle(ZenjiTokens.foreground.opacity(0.7))
+            if let corpus = model.corpus {
+                Text("Korpus v\(corpus.version) · \(corpus.cases.count) ytringer")
+                    .font(.zenjiMono(size: 11))
+                    .foregroundStyle(ZenjiTokens.muted)
+            } else if let status = model.status {
+                Text(status)
+                    .font(.zenjiMono(size: 12))
+                    .foregroundStyle(ZenjiTokens.diffRemove)
+            }
+        }
+    }
+
+    private func banner(_ message: String) -> some View {
+        Text(message)
+            .font(.zenjiMono(size: 12))
+            .foregroundStyle(ZenjiTokens.foreground.opacity(0.8))
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(ZenjiTokens.surface)
+    }
+
+    private var controls: some View {
+        HStack(spacing: 16) {
+            Button {
+                Task { await model.run() }
+            } label: {
+                Text(model.isRunning ? "KJØRER … \(model.progress)/\(model.corpus?.cases.count ?? 0)" : "KJØR EVAL")
+                    .font(.zenjiMono(size: 13, weight: .bold))
+                    .foregroundStyle(model.isRunning ? ZenjiTokens.muted : ZenjiTokens.accent)
+            }
+            .disabled(model.isRunning || model.corpus == nil)
+            .zenjiTapTarget()
+
+            Spacer()
+
+            if model.report != nil {
+                ShareLink(item: model.reportJSON, preview: SharePreview("zenji-eval-rapport.json")) {
+                    Text("DEL RAPPORT")
+                        .font(.zenjiMono(size: 12, weight: .bold))
+                        .foregroundStyle(ZenjiTokens.accent)
+                }
+                .zenjiTapTarget()
+            }
+        }
+    }
+
+    private func summary(_ report: EvalReport) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Rectangle().fill(ZenjiTokens.hairline).frame(height: 1)
+            HStack {
+                Text("BESTÅTT \(report.totals.passed)/\(report.totals.evaluated)")
+                    .font(.zenjiMono(size: 13, weight: .bold))
+                Spacer()
+                if report.totals.knownGap > 0 {
+                    Text("\(report.totals.knownGap) kjente hull\(report.totals.knownGapPassed > 0 ? " · \(report.totals.knownGapPassed) lukket!" : "")")
+                        .font(.zenjiMono(size: 11))
+                        .foregroundStyle(report.totals.knownGapPassed > 0 ? ZenjiTokens.diffAdd : ZenjiTokens.muted)
+                }
+            }
+            ForEach(report.categories) { cat in
+                categoryRow(cat)
+            }
+        }
+    }
+
+    private func categoryRow(_ cat: EvalReport.CategorySummary) -> some View {
+        HStack {
+            Text(cat.category)
+                .font(.zenjiMono(size: 12))
+                .frame(width: 110, alignment: .leading)
+            if let rate = cat.passRate {
+                Text("\(cat.passed)/\(cat.evaluated)")
+                    .font(.zenjiMono(size: 12, weight: .bold))
+                    .foregroundStyle(cat.passed == cat.evaluated ? ZenjiTokens.diffAdd : ZenjiTokens.accent)
+                Text("\(Int((rate * 100).rounded()))%")
+                    .font(.zenjiMono(size: 11))
+                    .foregroundStyle(ZenjiTokens.muted)
+            } else {
+                Text("— kun kjente hull")
+                    .font(.zenjiMono(size: 11))
+                    .foregroundStyle(ZenjiTokens.muted)
+            }
+            Spacer()
+            if cat.knownGap > 0 {
+                Text("(\(cat.knownGap) hull)")
+                    .font(.zenjiMono(size: 10))
+                    .foregroundStyle(ZenjiTokens.muted)
+            }
+        }
+    }
+
+    private var caseList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Rectangle().fill(ZenjiTokens.hairline).frame(height: 1)
+            ForEach(model.results) { result in
+                EvalCaseRow(result: result)
+            }
+            candidateFooter
+        }
+    }
+
+    private var candidateFooter: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Rectangle().fill(ZenjiTokens.hairline).frame(height: 1).padding(.top, 8)
+            ShareLink(item: model.candidatesJSON, preview: SharePreview("forsto-ikke-kandidater.json")) {
+                Text("DEL KORPUS-KANDIDATER (\(model.candidateCount))")
+                    .font(.zenjiMono(size: 11, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.accent)
+            }
+            .disabled(model.candidateCount == 0)
+            .zenjiTapTarget()
+            Text("Eksporterer «forsto ikke»-loggen som korpus-kandidater. Du bestemmer selv hva som legges inn.")
+                .font(.zenjiMono(size: 10))
+                .foregroundStyle(ZenjiTokens.muted)
+        }
+    }
+}
+
+/// One scored case row: the utterance, a pass/fail glyph, and each check's
+/// detail. A known-gap case is shown quietly (never as a hard failure).
+struct EvalCaseRow: View {
+    let result: EvalCaseResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(glyph)
+                    .font(.zenjiMono(size: 13, weight: .bold))
+                    .foregroundStyle(glyphColor)
+                Text("«\(result.utterance)»")
+                    .font(.zenjiMono(size: 12, weight: .bold))
+                Spacer()
+                if result.knownGap {
+                    Text("KJENT HULL\(result.knownGapRef.map { " · \($0)" } ?? "")")
+                        .font(.zenjiMono(size: 9, weight: .bold))
+                        .foregroundStyle(ZenjiTokens.muted)
+                }
+            }
+            ForEach(result.checks) { check in
+                Text("\(check.passed ? "·" : "✕") \(check.label): \(check.detail)")
+                    .font(.zenjiMono(size: 10))
+                    .foregroundStyle(check.passed ? ZenjiTokens.foreground.opacity(0.55) : ZenjiTokens.diffRemove.opacity(0.85))
+            }
+        }
+    }
+
+    private var glyph: String { result.passed ? "✓" : (result.knownGap ? "○" : "✕") }
+    private var glyphColor: Color {
+        if result.passed { return ZenjiTokens.diffAdd }
+        return result.knownGap ? ZenjiTokens.muted : ZenjiTokens.diffRemove
+    }
+}
+#endif

--- a/ios/ZenjiTests/EvalCorpusTests.swift
+++ b/ios/ZenjiTests/EvalCorpusTests.swift
@@ -1,0 +1,132 @@
+//
+//  EvalCorpusTests.swift
+//  ZenjiTests
+//
+//  WP-69 — the CI half of the eval harness. The SAME versioned corpus the
+//  on-device screen runs through the real FoundationModelsInterestAssistant is
+//  run here through the deterministic MockInterestAssistant and asserted. Apple
+//  Intelligence can't run in CI, so this proves the corpus + scorer + runner
+//  pipeline is sound and that the deterministic cases hold; the `knownGap`
+//  cases are SKIPPED with a marker (they're targets for WP-64/65, not red
+//  tests). The scorer itself is also unit-tested against synthetic output so
+//  its rubric logic is covered independently of the mock.
+//
+
+import XCTest
+
+final class EvalCorpusTests: XCTestCase {
+
+    private func loadCorpus() throws -> EvalCorpus {
+        try EvalCorpus.decode(Fixture.data("eval-corpus"))
+    }
+
+    // MARK: - Corpus shape (the acceptance floor)
+
+    func test_corpus_isVersionedWithEnoughCases() throws {
+        let corpus = try loadCorpus()
+        XCTAssertGreaterThanOrEqual(corpus.version, 1)
+        XCTAssertGreaterThanOrEqual(corpus.cases.count, 20, "the corpus must carry at least 20 cases (WP-69 acceptance)")
+        // Every case id is unique.
+        XCTAssertEqual(Set(corpus.cases.map(\.id)).count, corpus.cases.count, "case ids must be unique")
+    }
+
+    func test_corpus_coversTheRequiredCategories() throws {
+        let corpus = try loadCorpus()
+        let categories = Set(corpus.cases.map(\.category))
+        for required in ["canon", "multiPart", "winter", "question"] {
+            XCTAssertTrue(categories.contains(required), "corpus must cover the '\(required)' category")
+        }
+    }
+
+    func test_corpus_knownGapCasesAreMarkedWithARef() throws {
+        let corpus = try loadCorpus()
+        let gaps = corpus.cases.filter(\.isKnownGap)
+        XCTAssertFalse(gaps.isEmpty, "the corpus documents at least one known gap (the winter case)")
+        for gap in gaps {
+            XCTAssertNotNil(gap.knownGapRef, "known-gap case \(gap.id) must name the WP that closes it")
+        }
+        // The winter umbrella case is the canonical known gap.
+        XCTAssertTrue(gaps.contains { $0.category == "winter" }, "the vintersport case must be a known gap until WP-64/65")
+    }
+
+    // MARK: - The mock run (deterministic cases asserted, gaps skipped)
+
+    func test_mockRun_deterministicCasesPass_knownGapsSkipped() async throws {
+        let corpus = try loadCorpus()
+        let index = AssistantTestSupport.liveIndex()
+        let feed = AssistantTestSupport.liveFeed(now: corpus.clock)
+        let runner = EvalRunner(assistant: MockInterestAssistant(), index: index, feed: feed)
+
+        var skipped: [String] = []
+        for c in corpus.cases {
+            let result = await runner.run(c)
+            if c.isKnownGap {
+                skipped.append("\(c.id) (\(c.knownGapRef ?? "?"))")
+                continue
+            }
+            XCTAssertTrue(
+                result.passed,
+                "corpus case \(c.id) — «\(c.utterance)» — failed under the mock: " +
+                result.checks.filter { !$0.passed }.map { "\($0.label): \($0.detail)" }.joined(separator: " · ")
+            )
+        }
+        // Marker: the skipped known-gap cases are recorded, not silently ignored.
+        XCTAssertFalse(skipped.isEmpty)
+        print("WP-69 eval — skipped \(skipped.count) known-gap case(s): \(skipped.joined(separator: ", "))")
+    }
+
+    func test_mockRun_reportAggregates() async throws {
+        let corpus = try loadCorpus()
+        let index = AssistantTestSupport.liveIndex()
+        let feed = AssistantTestSupport.liveFeed(now: corpus.clock)
+        let runner = EvalRunner(assistant: MockInterestAssistant(), index: index, feed: feed)
+        let results = await runner.runAll(corpus)
+        let report = EvalReport.make(results: results, corpusVersion: corpus.version, assistant: "mock", available: true)
+
+        XCTAssertEqual(report.totals.total, corpus.cases.count)
+        XCTAssertEqual(report.totals.evaluated + report.totals.knownGap, corpus.cases.count)
+        // Every deterministic (non-gap) case passes under the mock.
+        XCTAssertEqual(report.totals.passed, report.totals.evaluated, "all evaluated cases pass under the mock")
+        // The report is real, encodable JSON (the share payload) with no crash.
+        XCTAssertFalse(report.jsonData().isEmpty)
+    }
+
+    // MARK: - Scorer unit tests (independent of the mock)
+
+    func test_scorer_mutation_idSetMatch() {
+        let c = EvalCase(id: "x", category: "canon", utterance: "u", kind: .mutation,
+                         seedProfile: nil, knownGap: nil, knownGapRef: nil, note: nil,
+                         expect: EvalExpectation(mutationEntityIds: ["a", "b"], answer: nil))
+        XCTAssertTrue(EvalScorer.score(c, actual: .mutation(groundedEntityIds: ["b", "a"])).passed, "id-set is order-independent")
+        XCTAssertFalse(EvalScorer.score(c, actual: .mutation(groundedEntityIds: ["a"])).passed, "a missing id fails")
+        XCTAssertFalse(EvalScorer.score(c, actual: .mutation(groundedEntityIds: ["a", "b", "c"])).passed, "an extra id fails")
+    }
+
+    func test_scorer_mutation_emptyExpectationIsRejectionCase() {
+        let c = EvalCase(id: "x", category: "canon", utterance: "u", kind: .mutation,
+                         seedProfile: nil, knownGap: nil, knownGapRef: nil, note: nil,
+                         expect: EvalExpectation(mutationEntityIds: [], answer: nil))
+        XCTAssertTrue(EvalScorer.score(c, actual: .mutation(groundedEntityIds: [])).passed, "nothing grounded == expected empty set")
+        XCTAssertFalse(EvalScorer.score(c, actual: .mutation(groundedEntityIds: ["a"])).passed)
+    }
+
+    func test_scorer_answer_phantomRowsFail() {
+        let c = EvalCase(id: "q", category: "question", utterance: "u", kind: .answer,
+                         seedProfile: nil, knownGap: nil, knownGapRef: nil, note: nil,
+                         expect: EvalExpectation(mutationEntityIds: nil,
+                                                 answer: AnswerExpectation(minReferencedRows: nil, referencedSportsAnyOf: nil, mustContainAny: nil, forbiddenClaims: nil, requireNoPhantomRows: true)))
+        // Cited 2, resolved 1 → one phantom row → fail.
+        XCTAssertFalse(EvalScorer.score(c, actual: .answer(text: "t", citedRowCount: 2, resolvedRowCount: 1, resolvedRowSports: ["cycling"])).passed)
+        XCTAssertTrue(EvalScorer.score(c, actual: .answer(text: "t", citedRowCount: 1, resolvedRowCount: 1, resolvedRowSports: ["cycling"])).passed)
+    }
+
+    func test_scorer_answer_forbiddenClaimsAndSports() {
+        let c = EvalCase(id: "q", category: "question", utterance: "u", kind: .answer,
+                         seedProfile: nil, knownGap: nil, knownGapRef: nil, note: nil,
+                         expect: EvalExpectation(mutationEntityIds: nil,
+                                                 answer: AnswerExpectation(minReferencedRows: 1, referencedSportsAnyOf: ["cycling"], mustContainAny: nil, forbiddenClaims: ["vant"], requireNoPhantomRows: true)))
+        XCTAssertTrue(EvalScorer.score(c, actual: .answer(text: "Kommende sykkelritt", citedRowCount: 1, resolvedRowCount: 1, resolvedRowSports: ["cycling"])).passed)
+        XCTAssertFalse(EvalScorer.score(c, actual: .answer(text: "Norge VANT etappen", citedRowCount: 1, resolvedRowCount: 1, resolvedRowSports: ["cycling"])).passed, "a forbidden claim fails")
+        XCTAssertFalse(EvalScorer.score(c, actual: .answer(text: "Kommende", citedRowCount: 1, resolvedRowCount: 1, resolvedRowSports: ["tennis"])).passed, "wrong sport fails")
+    }
+}

--- a/ios/ZenjiTests/Fixtures/eval-corpus.json
+++ b/ios/ZenjiTests/Fixtures/eval-corpus.json
@@ -1,0 +1,222 @@
+{
+  "version": 1,
+  "description": "WP-69 — versioned assistant eval corpus. Golden STRUCTURED expectations (entity id-sets for mutations; row/claim rubric for answers), NEVER exact prose. Runs two ways: through MockInterestAssistant as a deterministic XCTest (CI), and through the REAL FoundationModelsInterestAssistant on a physical iPhone via the DEBUG eval screen. `clock` is the fixed `now` CI evaluates the answer arm against (the checked-in events fixture); the on-device run uses the live feed and real time. `knownGap` cases are EXPECTED to fail until the named work package lands — CI skips them (marked), the device run reports them as known gaps.",
+  "clock": "2026-07-13T05:00:00Z",
+  "cases": [
+    {
+      "id": "canon-01-ruud-grand-slams",
+      "category": "canon",
+      "utterance": "Følg Casper Ruud bare i Grand Slams",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["casper-ruud"] }
+    },
+    {
+      "id": "canon-02-magnus-carlsen",
+      "category": "canon",
+      "utterance": "Følg Magnus Carlsen",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["magnus-carlsen"] }
+    },
+    {
+      "id": "canon-03-lyn-obosligaen",
+      "category": "canon",
+      "utterance": "Følg Lyn i OBOS-ligaen",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["fk-lyn-oslo"] }
+    },
+    {
+      "id": "canon-04-mer-sykkel-juli",
+      "category": "canon",
+      "utterance": "Mer sykkel i juli",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["tour-de-france-2026"] }
+    },
+    {
+      "id": "canon-05-slutt-med-tennis",
+      "category": "canon",
+      "utterance": "Slutt med tennis",
+      "kind": "mutation",
+      "seedProfile": [{ "entityId": "casper-ruud", "scope": "bare i Grand Slams" }],
+      "expect": { "mutationEntityIds": ["casper-ruud"] }
+    },
+    {
+      "id": "canon-06-fjern-hovland",
+      "category": "canon",
+      "utterance": "Fjern Hovland",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["viktor-hovland"] }
+    },
+    {
+      "id": "canon-07-karsten-warholm",
+      "category": "canon",
+      "utterance": "Følg Karsten Warholm",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["karsten-warholm"] }
+    },
+    {
+      "id": "canon-08-tour-de-france",
+      "category": "canon",
+      "utterance": "Følg Tour de France",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["tour-de-france-2026"] }
+    },
+    {
+      "id": "canon-09-prioriter-100thieves",
+      "category": "canon",
+      "utterance": "Prioriter 100 Thieves høyere",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["100-thieves"] }
+    },
+    {
+      "id": "canon-10-cricket-unresolved",
+      "category": "canon",
+      "utterance": "Følg cricket",
+      "kind": "mutation",
+      "note": "Free-text entity NOT in the index → grounding rejects it → nothing applied. The honest-rejection contract: an empty grounded set is the correct outcome.",
+      "expect": { "mutationEntityIds": [] }
+    },
+    {
+      "id": "canon-11-tdf-norsk-fokus",
+      "category": "canon",
+      "utterance": "Følg Tour de France med fokus på norske utøvere",
+      "kind": "mutation",
+      "note": "The lens case (WP-16.1). Scored on the entity id-set only; the Norwegian lens itself is covered by MutationGrounderTests.",
+      "expect": { "mutationEntityIds": ["tour-de-france-2026"] }
+    },
+    {
+      "id": "canon-12-mer-sykkel-norske",
+      "category": "canon",
+      "utterance": "Mer sykkel, bare de norske",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["tour-de-france-2026"] }
+    },
+    {
+      "id": "multi-01-hovland-og-ruud",
+      "category": "multiPart",
+      "utterance": "Følg Viktor Hovland og Casper Ruud",
+      "kind": "mutation",
+      "note": "Two explicit index entities in one utterance — the id-set must contain BOTH (a clause dropped silently is the bug WP-65 guards against).",
+      "expect": { "mutationEntityIds": ["viktor-hovland", "casper-ruud"] }
+    },
+    {
+      "id": "multi-02-carlsen-og-warholm",
+      "category": "multiPart",
+      "utterance": "Følg Magnus Carlsen og Karsten Warholm",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["magnus-carlsen", "karsten-warholm"] }
+    },
+    {
+      "id": "multi-03-lyn-og-carlsen",
+      "category": "multiPart",
+      "utterance": "Følg FK Lyn Oslo og Magnus Carlsen",
+      "kind": "mutation",
+      "expect": { "mutationEntityIds": ["fk-lyn-oslo", "magnus-carlsen"] }
+    },
+    {
+      "id": "multi-04-owner-full-utterance",
+      "category": "multiPart",
+      "utterance": "Jeg liker golf, spesielt Hovland, og all vintersport, og følger Brann og litt F1",
+      "kind": "mutation",
+      "knownGap": true,
+      "knownGapRef": "WP-65",
+      "note": "The owner's real utterance class. Single-generation keyword parsing catches only the first explicit clause; WP-65 (bulk-fangst + delvis rapportering) is what makes every clause land. The golden id-set is provisional — WP-64 mints the 'vintersport' + 'Brann' ids and WP-65 finalizes this expectation in the same PR.",
+      "expect": { "mutationEntityIds": ["viktor-hovland", "vintersport", "sk-brann", "f1-world-championship-2026"] }
+    },
+    {
+      "id": "multi-05-owner-declarative-variant",
+      "category": "multiPart",
+      "utterance": "Jeg følger Hovland og Ruud, og vil gjerne ha med litt sjakk og F1 også",
+      "kind": "mutation",
+      "knownGap": true,
+      "knownGapRef": "WP-65",
+      "note": "Declarative «jeg følger …» phrasing with a mix of entities and whole-sports. WP-65 routes declarative cues to the mutation arm and fans out per clause; finalizes this expectation.",
+      "expect": { "mutationEntityIds": ["viktor-hovland", "casper-ruud", "magnus-carlsen", "f1-world-championship-2026"] }
+    },
+    {
+      "id": "winter-01-all-vintersport",
+      "category": "winter",
+      "utterance": "Følg all vintersport",
+      "kind": "mutation",
+      "knownGap": true,
+      "knownGapRef": "WP-64/65",
+      "note": "«vintersport» is ungroundable today: no winter entities in the index and no umbrella term in SportVocabulary. WP-64 publishes sport/category entities for the followBroadly winter sports; the golden ids below are provisional and finalized by WP-64/65.",
+      "expect": { "mutationEntityIds": ["skiskyting", "langrenn", "alpint", "hopp"] }
+    },
+    {
+      "id": "winter-02-skiskyting",
+      "category": "winter",
+      "utterance": "Følg skiskyting",
+      "kind": "mutation",
+      "knownGap": true,
+      "knownGapRef": "WP-64",
+      "note": "A single broadly-followed winter sport. Expected to ground to a sport/category follow once WP-64 lands the entity.",
+      "expect": { "mutationEntityIds": ["skiskyting"] }
+    },
+    {
+      "id": "q-01-neste-tour-de-france",
+      "category": "question",
+      "utterance": "Når er neste Tour de France?",
+      "kind": "answer",
+      "note": "Entity-resolve branch — the next matching agenda row for a resolved tournament. Must cite a real cycling row.",
+      "expect": {
+        "answer": {
+          "minReferencedRows": 1,
+          "referencedSportsAnyOf": ["cycling"],
+          "requireNoPhantomRows": true
+        }
+      }
+    },
+    {
+      "id": "q-02-kommende-sykkel",
+      "category": "question",
+      "utterance": "Hva er kommende innen sykkel",
+      "kind": "answer",
+      "note": "Sport-keyword branch — what's coming up in a whole sport.",
+      "expect": {
+        "answer": {
+          "minReferencedRows": 1,
+          "referencedSportsAnyOf": ["cycling"],
+          "requireNoPhantomRows": true
+        }
+      }
+    },
+    {
+      "id": "q-03-hva-i-kveld",
+      "category": "question",
+      "utterance": "Hva skjer i kveld",
+      "kind": "answer",
+      "note": "The «i kveld» calendar question. An empty evening is a legitimate honest answer, so no row count is required — but the reply must be about tonight and must not invent rows.",
+      "expect": {
+        "answer": {
+          "mustContainAny": ["kveld"],
+          "requireNoPhantomRows": true
+        }
+      }
+    },
+    {
+      "id": "q-04-hva-i-dag",
+      "category": "question",
+      "utterance": "Hva er på i dag",
+      "kind": "answer",
+      "expect": {
+        "answer": {
+          "mustContainAny": ["dag"],
+          "requireNoPhantomRows": true
+        }
+      }
+    },
+    {
+      "id": "q-05-spoiler-result",
+      "category": "question",
+      "utterance": "Hvem vant sykkeletappen i går?",
+      "kind": "answer",
+      "note": "The assistant answers over the LOCAL agenda (when/where), never past results. It must not fabricate an outcome — the forbidden-claims guard is the real-FM signal here.",
+      "expect": {
+        "answer": {
+          "forbiddenClaims": ["vant", "vinner", "seier", "slo"],
+          "requireNoPhantomRows": true
+        }
+      }
+    }
+  ]
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -34,6 +34,13 @@ targets:
     deploymentTarget: "26.0"
     sources:
       - path: Zenji
+      # WP-69: the versioned eval corpus lives with the tests (one source of
+      # truth — the CI XCTest loads it from the test bundle), but the DEBUG
+      # on-device eval screen (Zenji/Eval/EvalView) loads it from the app
+      # bundle, so bundle just this one JSON as an app resource. The widget
+      # target deliberately does NOT list it (no eval code in the widget).
+      - path: ZenjiTests/Fixtures/eval-corpus.json
+        buildPhase: resources
     info:
       path: Zenji/Info.plist
       properties:
@@ -175,6 +182,13 @@ targets:
       # @testable import" pattern). App + ZenjiDeviceDev pick these up via
       # `path: Zenji`; the widget deliberately does NOT (onboarding is app-only).
       - path: Zenji/Onboarding
+      # WP-69: the FM-eval harness — the pure corpus/scorer/runner + the
+      # DEBUG-only eval screen — compiled into the hostless bundle so
+      # EvalCorpusTests can drive the SAME corpus through MockInterestAssistant
+      # that the on-device screen drives through the real FoundationModels one
+      # (same "no @testable import" pattern). App + ZenjiDeviceDev pick these up
+      # via `path: Zenji`; the corpus JSON they bundle as a resource (above).
+      - path: Zenji/Eval
       # WP-13: the SAME golden feed-vector fixtures the JS reference test
       # (tests/feed-vectors.test.js) replays — referenced directly at the repo
       # root, never copied, so the two runners can never drift. XcodeGen
@@ -227,6 +241,11 @@ targets:
         # Zenji/Info.plist (auto-excluded). Exclude it explicitly here.
         excludes:
           - Info.plist
+      # WP-69: the eval corpus as an app resource, so the DEBUG on-device eval
+      # screen (Zenji/Eval/EvalView) can load it from Bundle.main on the
+      # physical iPhone — this is the build the owner actually runs the eval on.
+      - path: ZenjiTests/Fixtures/eval-corpus.json
+        buildPhase: resources
     info:
       path: ZenjiDeviceDev/Info.plist
       properties:


### PR DESCRIPTION
## Hva

Måler assistent-kvalitet uten manuell eier-testing. Ett **versjonert korpus** kjøres to veier:
- **CI (mock):** deterministisk XCTest mot `MockInterestAssistant`.
- **På enhet (ekte FM):** en DEBUG-only eval-skjerm kjører korpuset gjennom den EKTE `FoundationModelsInterestAssistant` på fysisk iPhone — den eneste plassen Apple Intelligence faktisk kjører.

Dette er forutsetningen (WP-65 avhenger av den) for at pass-rate blir regresjonssignalet som erstatter utforskende eier-testing.

## Innhold

- **Korpus** `ios/ZenjiTests/Fixtures/eval-corpus.json` — 24 cases: **12 canon** (WP-16-kanonene), **5 multiPart** (eierens flerledds-klasse «jeg liker golf, spesielt Hovland, og all vintersport, og følger Brann og litt F1» + varianter), **2 winter** (vintersport), **5 question** (feed-spørsmål). Golden **struktur**, aldri eksakt tekst: id-sett for mutasjoner; rad/påstand-rubrikk for svar (må-referere-rader · rad-idrett · må-inneholde-én-av · forbudte-påstander · ingen oppdiktede rader). 4 cases markert `knownGap` (forventet-feiler-inntil WP-64/65).
- **Delt pure kjerne** `ios/Zenji/Eval/` — `EvalCorpus` (Codable + loader), `EvalScorer`, `EvalRunner` (interpret → `MutationGrounder.ground` → id-sett), `EvalReport` (anonymisert JSON). Ingen FoundationModels-avhengighet, så CI og enhet deler **nøyaktig samme scoring**.
- **CI** `EvalCorpusTests` — samme korpus mot mocken: 20 evaluerte cases asserteres grønne, 4 `knownGap` skippes med markering. Scorer-rubrikken enhetstestes uavhengig av mocken.
- **DEBUG-only eval-skjerm** `Zenji/Eval/EvalView` — nås fra assistent-arkets fot («EVAL (DEBUG)», ved siden av «Det jeg ikke forsto»); kjører ekte FM på enhet, viser **pass-rate per kategori**, eksporterer **anonymisert JSON-rapport** via delesheet (samme personvernmønster som MisunderstoodLog — aldri nettverk, ingen enhets-id), + knapp for å eksportere forsto-ikke-loggen som **korpus-kandidater** (eksport, ikke auto-innlemming).
- **Ingen ny target** — korpus bundlet som app-ressurs i `Zenji` + `ZenjiDeviceDev`, `Zenji/Eval` lagt til test-sources (minimal `project.yml`-endring med per-linje-begrunnelse).

## Ikke-mål (holdt)

FM kjøres ikke i CI (umulig); ingen auto-tuning.

## Verifisert

- **385/385** iOS-tester grønne (+9 nye), **463/463** JS urørt.
- Begge schemes + **ZenjiDeviceDev** bygger; eval-skjermen kompilerer i DEBUG for device-schemet; korpus-JSON bekreftet bundlet i `ZenjiDeviceDev.app` + `Zenji.app`.
- `ios/README` §testing: rapportformat + kjøre-instruks dokumentert. PLAN.md WP-69-rad ⬜ → 🔬.

## Eierens ene manuelle steg (første reelle eval)

Bygg/kjør `ZenjiDeviceDev` på fysisk iPhone med Apple Intelligence på → åpne assistenten (`»_`) → foten → **EVAL (DEBUG)** → **KJØR EVAL** → **DEL RAPPORT** og del JSON-en.

🤖 Generated with [Claude Code](https://claude.com/claude-code)