### PR TITLE
WP-82 · Hjelperen → native (oppdagbarhet)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -92,7 +92,7 @@ mennesket, aldri av en agent.
 | WP-70 | XCUITest: hovedflyter + launch-metrikk | 0E | – | ✅ merget (#283) — ny `ZenjiUITests`-target (bundle.ui-testing) + egen scheme (Zenji-scheme uendret → rask unit-run består); appen drives mot deterministisk `ZENJI_DEMO=uitest`-harness (`UITestSeed`: mock-assistent + seedet cache, ingen nett, ingen Apple Intelligence). 6 hovedflyter grønne i simulator (iPhone 17): onboarding (quick-picks + samtale), følg via kommandolinja → diff → Bekreft → rad dukker opp, N raske starter-pack-toggles uten heng (vokter WP-60-koalesceringen), event-detalj + «Hvorfor vises denne?», tema-toggle, nullstill (avbryt + gjennomfør). `XCTApplicationLaunchMetric` kaldstart-baseline ~0,97 s (5 kjøringer, RSD ~1–4 %). Additive accessibility-identifiers; `waitForExistence`/predikat-venter (ingen sleeps); ios/README §testing oppdatert |
 | WP-80 | Token- & typografi-fundament (Apple-native) | 0F | – | ✅ merget (#289) — semantiske farge-tokens (system + amber) + Dynamic Type-API (`Font.zenji`/`zenjiTabular`), `zenjiMono(size:)` beholdt som deprecated shim (alle 4 schemes bygger urørt), 529 iOS-tester grønt + 13/13 vektorer bit-like |
 | WP-81 | Agenda → native List + sveip/pressed-state | 0F | WP-80 | 🔬 |
-| WP-82 | Hjelperen → native (slank + sheet + oppdagbarhet) | 0F | WP-80 | ⬜ |
+| WP-82 | Hjelperen → native (slank + sheet + oppdagbarhet) | 0F | WP-80 | 🔬 |
 | WP-83 | Navigasjon (NavigationStack) + Deg-skjerm | 0F | WP-81,WP-82 | ⬜ |
 | WP-84 | Widget + web token-paritet | 0F | WP-80 | ⬜ |
 | WP-85 | Baseline-designsystem + HIG-gate (promoter DESIGN.md) | 0F | WP-80,WP-81,WP-82,WP-83,WP-84 | ⬜ |

--- a/ios/Zenji/Assistant/AssistantPanel.swift
+++ b/ios/Zenji/Assistant/AssistantPanel.swift
@@ -73,7 +73,7 @@ struct AssistantPanel: View {
     var body: some View {
         VStack(spacing: 0) {
             headerBar
-            Rectangle().fill(ZenjiTokens.hairline).frame(height: 1)
+            Rectangle().fill(ZenjiTokens.separator).frame(height: 1)
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     if let message = viewModel.availability.message { unavailableBanner(message) }
@@ -85,7 +85,7 @@ struct AssistantPanel: View {
                     if !viewModel.pending.isEmpty { proposalsSection }
                     if !viewModel.rejected.isEmpty { rejectionsSection }
                     if let explanation = viewModel.explanation { explanationSection(explanation) }
-                    Rectangle().fill(ZenjiTokens.hairline).frame(height: 1).padding(.vertical, 2)
+                    Rectangle().fill(ZenjiTokens.separator).frame(height: 1).padding(.vertical, 2)
                     quickChipsRow
                     profileSection
                     rerunOnboardingRow
@@ -103,8 +103,8 @@ struct AssistantPanel: View {
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
-        .background(ZenjiTokens.surface)
-        .foregroundStyle(ZenjiTokens.foreground)
+        .background(ZenjiTokens.cell)
+        .foregroundStyle(ZenjiTokens.label)
         .task { viewModel.refreshAvailability() }
         .onAppear {
             if let initialResetState {
@@ -115,6 +115,10 @@ struct AssistantPanel: View {
         // WP-66 — the «hva vet du om meg» command opens the memory page (the same
         // sheet the memoryEntry row opens), via a token the view model bumps.
         .onChange(of: viewModel.memoryRequestToken) { _, _ in memoryPageShown = true }
+        // WP-82 — one light success haptic on Bekreft (a mutation/command
+        // confirmed), DESIGN-BASELINE § Bevegelse & haptikk. The trigger only
+        // bumps on an explicit confirm, never on scroll or every tap.
+        .sensoryFeedback(.success, trigger: viewModel.confirmHaptic)
     }
 
     // MARK: - Header
@@ -122,13 +126,13 @@ struct AssistantPanel: View {
     private var headerBar: some View {
         HStack(alignment: .firstTextBaseline) {
             Text("ASSISTENT")
-                .font(.zenjiMono(size: 15, weight: .bold))
+                .font(.zenji(.subheadline, weight: .bold))
                 .foregroundStyle(ZenjiTokens.accent)
                 .tracking(2)
             Spacer()
             Button("Lukk") { dismiss() }
-                .font(.zenjiMono(size: 14))
-                .foregroundStyle(ZenjiTokens.muted)
+                .font(.zenji(.subheadline))
+                .foregroundStyle(ZenjiTokens.secondaryLabel)
                 .zenjiTapTarget()
         }
         .padding(.horizontal, 20)
@@ -140,12 +144,12 @@ struct AssistantPanel: View {
     private func unavailableBanner(_ message: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("APPLE INTELLIGENCE")
-                .font(.zenjiMono(size: 11, weight: .bold))
+                .font(.zenji(.caption2, weight: .bold))
                 .foregroundStyle(ZenjiTokens.accent.opacity(0.8))
                 .tracking(1.5)
             Text(message)
-                .font(.zenjiMono(size: 13))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.8))
+                .font(.zenji(.footnote))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.8))
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -155,8 +159,8 @@ struct AssistantPanel: View {
 
     private func errorRow(_ error: String) -> some View {
         Text(error)
-            .font(.zenjiMono(size: 13))
-            .foregroundStyle(ZenjiTokens.diffRemove)
+            .font(.zenji(.footnote))
+            .foregroundStyle(ZenjiTokens.destructive)
     }
 
     // MARK: - Answer (WP-16.4)
@@ -167,8 +171,8 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 10) {
             sectionTitle("SVAR")
             Text(answer.text)
-                .font(.zenjiMono(size: 14))
-                .foregroundStyle(ZenjiTokens.foreground)
+                .font(.zenji(.subheadline))
+                .foregroundStyle(ZenjiTokens.label)
                 .fixedSize(horizontal: false, vertical: true)
             if !answer.rows.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
@@ -178,31 +182,30 @@ struct AssistantPanel: View {
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.foreground.opacity(0.04))
-        .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.15), lineWidth: 1))
+        .background(ZenjiTokens.label.opacity(0.04))
+        .overlay(Rectangle().stroke(ZenjiTokens.label.opacity(0.15), lineWidth: 1))
     }
 
     private func answerRow(_ row: AnswerRow) -> some View {
         HStack(alignment: .top, spacing: 10) {
             VStack(alignment: .leading, spacing: 1) {
                 Text(row.dayLabel)
-                    .font(.zenjiMono(size: 10, weight: .semibold))
-                    .foregroundStyle(ZenjiTokens.muted)
+                    .font(.zenji(.caption2, weight: .semibold))
+                    .foregroundStyle(ZenjiTokens.secondaryLabel)
                     .tracking(1)
                 Text(row.timeLabel)
-                    .font(.zenjiMono(size: 13, weight: .semibold))
-                    .foregroundStyle(ZenjiTokens.foreground)
-                    .monospacedDigit()
+                    .font(.zenjiTabular(.footnote, weight: .semibold))
+                    .foregroundStyle(ZenjiTokens.label)
             }
             .frame(minWidth: 72, alignment: .leading)
             VStack(alignment: .leading, spacing: 2) {
                 Text(row.title)
-                    .font(.zenjiMono(size: 14))
-                    .foregroundStyle(ZenjiTokens.foreground)
+                    .font(.zenji(.subheadline))
+                    .foregroundStyle(ZenjiTokens.label)
                     .fixedSize(horizontal: false, vertical: true)
                 Text(row.channelLabel)
-                    .font(.zenjiMono(size: 12))
-                    .foregroundStyle(row.channelLabel == "–" ? ZenjiTokens.muted.opacity(0.5) : ZenjiTokens.muted)
+                    .font(.zenji(.caption))
+                    .foregroundStyle(row.channelLabel == "–" ? ZenjiTokens.secondaryLabel.opacity(0.5) : ZenjiTokens.secondaryLabel)
             }
         }
     }
@@ -217,14 +220,14 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 6) {
             sectionTitle("REGNSKAP")
             Text(tally.summary)
-                .font(.zenjiMono(size: 13))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                .font(.zenji(.footnote))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.85))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.foreground.opacity(0.04))
-        .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.15), lineWidth: 1))
+        .background(ZenjiTokens.label.opacity(0.04))
+        .overlay(Rectangle().stroke(ZenjiTokens.label.opacity(0.15), lineWidth: 1))
     }
 
     // MARK: - Command arm (WP-66)
@@ -236,26 +239,26 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 10) {
             sectionTitle("BEKREFT")
             Text(command.confirmationPrompt ?? "Vil du gjøre dette?")
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.85))
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 10) {
                 Button("Bekreft") { viewModel.confirmCommand(); dismissIfDone() }
-                    .font(.zenjiMono(size: 13, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.diffRemove)
-                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.diffRemove))
+                    .font(.zenji(.footnote, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.destructive)
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.destructive))
                     .accessibilityIdentifier("command.confirm")
                 Button("Avbryt") { viewModel.cancelCommand(); dismissIfDone() }
-                    .font(.zenjiMono(size: 13))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
-                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.foreground))
+                    .font(.zenji(.footnote))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.6))
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.label))
                     .accessibilityIdentifier("command.cancel")
             }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.diffRemove.opacity(0.06))
-        .overlay(Rectangle().stroke(ZenjiTokens.diffRemove.opacity(0.3), lineWidth: 1))
+        .background(ZenjiTokens.destructive.opacity(0.06))
+        .overlay(Rectangle().stroke(ZenjiTokens.destructive.opacity(0.3), lineWidth: 1))
     }
 
     /// A calm one-line receipt after a harmless command executed ("Tema: mørkt.",
@@ -264,8 +267,8 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 6) {
             sectionTitle("UTFØRT")
             Text(receipt)
-                .font(.zenjiMono(size: 13))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                .font(.zenji(.footnote))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.85))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(12)
@@ -309,7 +312,7 @@ struct AssistantPanel: View {
     private func chip(_ label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
-                .font(.zenjiMono(size: 12, weight: .bold))
+                .font(.zenji(.caption, weight: .bold))
                 .foregroundStyle(ZenjiTokens.accent)
                 .tracking(1)
         }
@@ -327,9 +330,9 @@ struct AssistantPanel: View {
                 if viewModel.pending.count > 1 {
                     // WP-14.3: an action, not chrome — real button comfort.
                     Button("Bekreft alle") { viewModel.confirmAll(); dismissIfDone() }
-                        .font(.zenjiMono(size: 12, weight: .bold))
-                        .foregroundStyle(ZenjiTokens.diffAdd)
-                        .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.diffAdd))
+                        .font(.zenji(.caption, weight: .bold))
+                        .foregroundStyle(ZenjiTokens.live)
+                        .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.live))
                 }
             }
             ForEach(viewModel.pending) { mutation in proposalRow(mutation) }
@@ -340,34 +343,34 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(sign(for: mutation.kind))
-                    .font(.zenjiMono(size: 16, weight: .bold))
+                    .font(.zenji(.callout, weight: .bold))
                     .foregroundStyle(color(for: mutation.kind))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(mutation.entity.name)
-                        .font(.zenjiMono(size: 15, weight: .bold))
+                        .font(.zenji(.subheadline, weight: .bold))
                     Text(subtitle(for: mutation))
-                        .font(.zenjiMono(size: 12))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                        .font(.zenji(.caption))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.6))
                 }
             }
             Text(mutation.reason)
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.75))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.75))
             // WP-14.3: Bekreft/Avvis ARE the action, never glyph-small — a
             // real, comfortable button (min 44pt tall, roomy padding, a
             // hairline box in the action's own colour, never a filled pill).
             HStack(spacing: 10) {
                 Button("Bekreft") { viewModel.confirm(mutation); dismissIfDone() }
-                    .font(.zenjiMono(size: 13, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.diffAdd)
-                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.diffAdd))
+                    .font(.zenji(.footnote, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.live)
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.live))
                     // WP-70: stable handle for the follow-via-command-line flow's
                     // Bekreft (the test uses .firstMatch — a single-mutation diff).
                     .accessibilityIdentifier("assistant.confirm")
                 Button("Avvis") { viewModel.reject(mutation); dismissIfDone() }
-                    .font(.zenjiMono(size: 13))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
-                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.foreground))
+                    .font(.zenji(.footnote))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.6))
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.label))
             }
         }
         .padding(12)
@@ -392,12 +395,12 @@ struct AssistantPanel: View {
             ForEach(viewModel.rejected) { rejection in
                 VStack(alignment: .leading, spacing: 6) {
                     Text(rejection.explanation)
-                        .font(.zenjiMono(size: 13))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                        .font(.zenji(.footnote))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.85))
                     if !rejection.suggestions.isEmpty {
                         Text("Trykk for å foreslå endringen:")
-                            .font(.zenjiMono(size: 11))
-                            .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                            .font(.zenji(.caption2))
+                            .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                         VStack(alignment: .leading, spacing: 4) {
                             ForEach(rejection.suggestions, id: \.id) { suggestion in
                                 // WP-14.3: a «mente du»-forslag IS the action
@@ -408,7 +411,7 @@ struct AssistantPanel: View {
                                     viewModel.choose(suggestion, for: rejection)
                                 } label: {
                                     Text("› \(suggestion.name)")
-                                        .font(.zenjiMono(size: 13, weight: .bold))
+                                        .font(.zenji(.footnote, weight: .bold))
                                         .foregroundStyle(ZenjiTokens.accent)
                                 }
                                 .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.accent, fullWidth: true))
@@ -416,14 +419,14 @@ struct AssistantPanel: View {
                         }
                     }
                     Button("OK") { viewModel.dismissRejection(rejection); dismissIfDone() }
-                        .font(.zenjiMono(size: 12))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                        .font(.zenji(.caption))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.6))
                         .zenjiTapTarget()
                 }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(ZenjiTokens.diffRemove.opacity(0.06))
-                .overlay(Rectangle().stroke(ZenjiTokens.diffRemove.opacity(0.3), lineWidth: 1))
+                .background(ZenjiTokens.destructive.opacity(0.06))
+                .overlay(Rectangle().stroke(ZenjiTokens.destructive.opacity(0.3), lineWidth: 1))
             }
         }
     }
@@ -434,16 +437,16 @@ struct AssistantPanel: View {
         VStack(alignment: .leading, spacing: 6) {
             sectionTitle("INGEN ENDRING")
             Text(explanation.understood)
-                .font(.zenjiMono(size: 13))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                .font(.zenji(.footnote))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.85))
             Text(explanation.reason)
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.65))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.65))
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.foreground.opacity(0.05))
-        .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.2), lineWidth: 1))
+        .background(ZenjiTokens.label.opacity(0.05))
+        .overlay(Rectangle().stroke(ZenjiTokens.label.opacity(0.2), lineWidth: 1))
     }
 
     // MARK: - Profile ("Hva jeg følger") — a quiet disclosure
@@ -453,8 +456,8 @@ struct AssistantPanel: View {
             VStack(alignment: .leading, spacing: 0) {
                 if viewModel.profile.isEmpty {
                     Text("Ingenting ennå. Skriv en ytring i linjen for å begynne.")
-                        .font(.zenjiMono(size: 13))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.55))
+                        .font(.zenji(.footnote))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.55))
                         .padding(.top, 10)
                 } else {
                     ForEach(viewModel.profile.rules) { rule in ruleRow(rule) }
@@ -463,34 +466,34 @@ struct AssistantPanel: View {
             .padding(.top, 8)
         } label: {
             Text("HVA JEG FØLGER (\(viewModel.profile.rules.count))")
-                .font(.zenjiMono(size: 12, weight: .bold))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                .font(.zenji(.caption, weight: .bold))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                 .tracking(1.5)
         }
-        .tint(ZenjiTokens.muted)
+        .tint(ZenjiTokens.secondaryLabel)
     }
 
     private func ruleRow(_ rule: InterestRule) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             HStack(alignment: .firstTextBaseline) {
                 Text(rule.entityName)
-                    .font(.zenjiMono(size: 14, weight: .bold))
+                    .font(.zenji(.subheadline, weight: .bold))
                 Spacer()
                 Button("Fjern") { viewModel.removeRule(rule) }
-                    .font(.zenjiMono(size: 12))
-                    .foregroundStyle(ZenjiTokens.diffRemove.opacity(0.8))
+                    .font(.zenji(.caption))
+                    .foregroundStyle(ZenjiTokens.destructive.opacity(0.8))
                     .zenjiTapTarget()
             }
             Text(ruleSubtitle(rule))
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.6))
             Text(rule.reason)
-                .font(.zenjiMono(size: 11))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                .font(.zenji(.caption2))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.5))
         }
         .padding(.vertical, 8)
         .overlay(alignment: .bottom) {
-            Rectangle().fill(ZenjiTokens.foreground.opacity(0.1)).frame(height: 1)
+            Rectangle().fill(ZenjiTokens.label.opacity(0.1)).frame(height: 1)
         }
     }
 
@@ -500,13 +503,13 @@ struct AssistantPanel: View {
         Button { onRerunOnboarding() } label: {
             HStack {
                 Text("SETT OPP DET DU FØLGER")
-                    .font(.zenjiMono(size: 12, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                    .font(.zenji(.caption, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                     .tracking(1.5)
                 Spacer()
                 Text("»_")
-                    .font(.zenjiMono(size: 13, weight: .semibold))
-                    .foregroundStyle(ZenjiTokens.muted)
+                    .font(.zenji(.footnote, weight: .semibold))
+                    .foregroundStyle(ZenjiTokens.secondaryLabel)
             }
             .frame(minHeight: 44)
             .contentShape(Rectangle())
@@ -531,8 +534,8 @@ struct AssistantPanel: View {
         Button { memoryPageShown = true } label: {
             HStack {
                 Text("HVA JEG VET OM DEG (\(viewModel.memoryItemCount))")
-                    .font(.zenjiMono(size: 12, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                    .font(.zenji(.caption, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                     .tracking(1.5)
                 Spacer()
             }
@@ -557,8 +560,8 @@ struct AssistantPanel: View {
                     resetConfirmation(level)
                 } else {
                     Text("Dette gjelder DENNE enheten — du trenger aldri installere Zenji på nytt for å nullstille.")
-                        .font(.zenjiMono(size: 12))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                        .font(.zenji(.caption))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.6))
                         .fixedSize(horizontal: false, vertical: true)
                     resetRow(
                         title: "Nullstill det du følger",
@@ -577,22 +580,22 @@ struct AssistantPanel: View {
             .padding(.top, 10)
         } label: {
             Text("NULLSTILL")
-                .font(.zenjiMono(size: 12, weight: .bold))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                .font(.zenji(.caption, weight: .bold))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                 .tracking(1.5)
         }
-        .tint(ZenjiTokens.muted)
+        .tint(ZenjiTokens.secondaryLabel)
     }
 
     private func resetRow(title: String, detail: String, identifier: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
-                    .font(.zenjiMono(size: 13, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.diffRemove.opacity(0.85))
+                    .font(.zenji(.footnote, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.destructive.opacity(0.85))
                 Text(detail)
-                    .font(.zenjiMono(size: 11))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.55))
+                    .font(.zenji(.caption2))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.55))
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
@@ -615,31 +618,31 @@ struct AssistantPanel: View {
     private func resetConfirmation(_ level: ResetLevel) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(resetConfirmationText(level))
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.85))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.85))
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 10) {
                 Button("Nullstill") {
                     onReset(level)
                     confirmingReset = nil
                 }
-                .font(.zenjiMono(size: 13, weight: .bold))
-                .foregroundStyle(ZenjiTokens.diffRemove)
-                .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.diffRemove))
+                .font(.zenji(.footnote, weight: .bold))
+                .foregroundStyle(ZenjiTokens.destructive)
+                .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.destructive))
                 // WP-70: stable handles for the reset flow (cancel + confirm) —
                 // the labels ("Nullstill"/"Avbryt") also appear elsewhere.
                 .accessibilityIdentifier("reset.confirm")
                 Button("Avbryt") { confirmingReset = nil }
-                    .font(.zenjiMono(size: 13))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
-                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.foreground))
+                    .font(.zenji(.footnote))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.6))
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.label))
                     .accessibilityIdentifier("reset.cancel")
             }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.diffRemove.opacity(0.06))
-        .overlay(Rectangle().stroke(ZenjiTokens.diffRemove.opacity(0.3), lineWidth: 1))
+        .background(ZenjiTokens.destructive.opacity(0.06))
+        .overlay(Rectangle().stroke(ZenjiTokens.destructive.opacity(0.3), lineWidth: 1))
     }
 
     private func resetConfirmationText(_ level: ResetLevel) -> String {
@@ -660,7 +663,7 @@ struct AssistantPanel: View {
                 HStack(spacing: 16) {
                     ShareLink(item: misunderstoodExportText, preview: SharePreview("forsto-ikke-rapport.json")) {
                         Text("DEL RAPPORT")
-                            .font(.zenjiMono(size: 11, weight: .bold))
+                            .font(.zenji(.caption2, weight: .bold))
                             .foregroundStyle(ZenjiTokens.accent)
                     }
                     .disabled(viewModel.misunderstoodEntries.isEmpty)
@@ -668,15 +671,15 @@ struct AssistantPanel: View {
                     Spacer()
                     if !viewModel.misunderstoodEntries.isEmpty {
                         Button("Slett alt") { viewModel.deleteAllMisunderstood() }
-                            .font(.zenjiMono(size: 11))
-                            .foregroundStyle(ZenjiTokens.diffRemove.opacity(0.75))
+                            .font(.zenji(.caption2))
+                            .foregroundStyle(ZenjiTokens.destructive.opacity(0.75))
                             .zenjiTapTarget()
                     }
                 }
                 if viewModel.misunderstoodEntries.isEmpty {
                     Text("Ingenting her ennå — det dukker opp når jeg ikke klarer å gjøre en ytring om til en endring.")
-                        .font(.zenjiMono(size: 12))
-                        .foregroundStyle(ZenjiTokens.foreground.opacity(0.55))
+                        .font(.zenji(.caption))
+                        .foregroundStyle(ZenjiTokens.label.opacity(0.55))
                 } else {
                     ForEach(viewModel.misunderstoodEntries) { entry in
                         MisunderstoodEntryRow(
@@ -690,11 +693,11 @@ struct AssistantPanel: View {
             .padding(.top, 12)
         } label: {
             Text("DET JEG IKKE FORSTO (\(viewModel.misunderstoodCount))")
-                .font(.zenjiMono(size: 12, weight: .bold))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                .font(.zenji(.caption, weight: .bold))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                 .tracking(1.5)
         }
-        .tint(ZenjiTokens.muted)
+        .tint(ZenjiTokens.secondaryLabel)
     }
 
     private var misunderstoodExportText: String {
@@ -711,8 +714,8 @@ struct AssistantPanel: View {
         Button { evalShown = true } label: {
             HStack {
                 Text("EVAL (DEBUG)")
-                    .font(.zenjiMono(size: 12, weight: .bold))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                    .font(.zenji(.caption, weight: .bold))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                     .tracking(1.5)
                 Spacer()
             }
@@ -730,8 +733,8 @@ struct AssistantPanel: View {
     /// mono, never a badge; the calmest possible «oppdater meg»-signal.
     private var versionLine: some View {
         Text(AppVersionCheck.footLine(published: publishedAppVersion))
-            .font(.zenjiMono(size: 11))
-            .foregroundStyle(ZenjiTokens.muted)
+            .font(.zenjiTabular(.caption2))
+            .foregroundStyle(ZenjiTokens.secondaryLabel)
             .tracking(1.0)
             .padding(.top, 8)
             .accessibilityIdentifier("versionLine")
@@ -747,8 +750,8 @@ struct AssistantPanel: View {
 
     private func sectionTitle(_ text: String) -> some View {
         Text(text)
-            .font(.zenjiMono(size: 12, weight: .bold))
-            .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+            .font(.zenji(.caption, weight: .bold))
+            .foregroundStyle(ZenjiTokens.label.opacity(0.5))
             .tracking(1.5)
     }
 
@@ -762,9 +765,9 @@ struct AssistantPanel: View {
 
     private func color(for kind: MutationKind) -> Color {
         switch kind {
-        case .add: return ZenjiTokens.diffAdd
+        case .add: return ZenjiTokens.live
         case .update: return ZenjiTokens.accent
-        case .remove: return ZenjiTokens.diffRemove
+        case .remove: return ZenjiTokens.destructive
         }
     }
 
@@ -795,48 +798,48 @@ struct MisunderstoodEntryRow: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
                 Text("«\(entry.utterance)»")
-                    .font(.zenjiMono(size: 13, weight: .bold))
+                    .font(.zenji(.footnote, weight: .bold))
                 Spacer()
                 if entry.isResolved {
                     Text("LØST")
-                        .font(.zenjiMono(size: 10, weight: .bold))
-                        .foregroundStyle(ZenjiTokens.diffAdd)
+                        .font(.zenji(.caption2, weight: .bold))
+                        .foregroundStyle(ZenjiTokens.live)
                 }
             }
             Text(entry.outcome.label)
-                .font(.zenjiMono(size: 11))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                .font(.zenji(.caption2))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.6))
             Text(entry.explanation.reason)
-                .font(.zenjiMono(size: 12))
-                .foregroundStyle(ZenjiTokens.foreground.opacity(0.75))
+                .font(.zenji(.caption))
+                .foregroundStyle(ZenjiTokens.label.opacity(0.75))
 
             if isEditingNote {
                 TextField("Hva mente du egentlig?", text: $noteDraft, axis: .vertical)
-                    .font(.zenjiMono(size: 12))
+                    .font(.zenji(.caption))
                     .textFieldStyle(.plain)
                     .lineLimit(1...3)
                     .padding(8)
-                    .background(ZenjiTokens.foreground.opacity(0.06))
-                    .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.2), lineWidth: 1))
+                    .background(ZenjiTokens.label.opacity(0.06))
+                    .overlay(Rectangle().stroke(ZenjiTokens.label.opacity(0.2), lineWidth: 1))
                 HStack(spacing: 14) {
                     Button("Lagre notat") {
                         onSaveNote(noteDraft)
                         isEditingNote = false
                     }
-                    .font(.zenjiMono(size: 11, weight: .bold))
+                    .font(.zenji(.caption2, weight: .bold))
                     .foregroundStyle(ZenjiTokens.accent)
                     .zenjiTapTarget()
                     Button("Avbryt") {
                         noteDraft = entry.note ?? ""
                         isEditingNote = false
                     }
-                    .font(.zenjiMono(size: 11))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.5))
+                    .font(.zenji(.caption2))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.5))
                     .zenjiTapTarget()
                 }
             } else if let note = entry.note, !note.isEmpty {
                 Text("Notat: \(note)")
-                    .font(.zenjiMono(size: 12))
+                    .font(.zenji(.caption))
                     .foregroundStyle(ZenjiTokens.accent.opacity(0.85))
             }
 
@@ -845,19 +848,19 @@ struct MisunderstoodEntryRow: View {
                     Button(entry.note?.isEmpty == false ? "Endre notat" : "Legg til notat") {
                         isEditingNote = true
                     }
-                    .font(.zenjiMono(size: 11))
-                    .foregroundStyle(ZenjiTokens.foreground.opacity(0.6))
+                    .font(.zenji(.caption2))
+                    .foregroundStyle(ZenjiTokens.label.opacity(0.6))
                     .zenjiTapTarget()
                 }
                 Button("Slett") { onDelete() }
-                    .font(.zenjiMono(size: 11))
-                    .foregroundStyle(ZenjiTokens.diffRemove.opacity(0.7))
+                    .font(.zenji(.caption2))
+                    .foregroundStyle(ZenjiTokens.destructive.opacity(0.7))
                     .zenjiTapTarget()
             }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.foreground.opacity(0.04))
-        .overlay(Rectangle().stroke(ZenjiTokens.foreground.opacity(0.15), lineWidth: 1))
+        .background(ZenjiTokens.label.opacity(0.04))
+        .overlay(Rectangle().stroke(ZenjiTokens.label.opacity(0.15), lineWidth: 1))
     }
 }

--- a/ios/Zenji/Assistant/AssistantViewModel.swift
+++ b/ios/Zenji/Assistant/AssistantViewModel.swift
@@ -64,6 +64,11 @@ final class AssistantViewModel {
 
     /// Bound to the command-line text field.
     var utterance: String = ""
+    /// WP-82 — bumped every time a mutation or command is CONFIRMED (Bekreft),
+    /// so the command surface can play ONE light `.sensoryFeedback(.success)` on
+    /// confirm (DESIGN-BASELINE § Bevegelse & haptikk). A pure signal — no
+    /// behaviour or routing changes.
+    private(set) var confirmHaptic = 0
     private(set) var isThinking = false
     /// A blocking error (model unavailable / generation failed) shown verbatim.
     private(set) var errorMessage: String?
@@ -412,6 +417,7 @@ final class AssistantViewModel {
     func confirmCommand() {
         guard let command = pendingCommand else { return }
         pendingCommand = nil
+        confirmHaptic &+= 1
         onCommand?(command)
         utterance = ""
     }
@@ -515,6 +521,7 @@ final class AssistantViewModel {
         pending.removeAll { $0.id == mutation.id }
         pendingBatchConfirmedAny = true
         resolveIfMentedFrom(mutation)
+        confirmHaptic &+= 1
         onProfileChanged?()
         if pending.isEmpty { utterance = "" }
     }
@@ -526,6 +533,7 @@ final class AssistantViewModel {
         persist()
         pendingBatchConfirmedAny = true
         pending = []
+        confirmHaptic &+= 1
         onProfileChanged?()
         utterance = ""
     }
@@ -768,6 +776,40 @@ final class AssistantViewModel {
 
     private func refreshMisunderstoodLog() {
         misunderstoodEntries = misunderstoodLog.load()
+    }
+
+    // MARK: - WP-82 — command-line discoverability (rest · focus · typing)
+
+    /// REST state: a CONCRETE example placeholder (not an abstract instruction),
+    /// so an empty line still teaches what the assistant can do
+    /// (DESIGN-BASELINE § Hjelperen: "hvile = konkret eksempel-placeholder").
+    let restPlaceholder = "Prøv «følg Bodø/Glimt» eller «når spiller Ruud?»"
+
+    /// FOCUS state: a small, calm row of context suggestions that rises over the
+    /// line while it has focus. Tapping one FILLS the line (the user still edits
+    /// or sends it) — discovery, never an applied action. These are example
+    /// prompts spanning the assistant's arms (følg · spør · vis), scoped to the
+    /// agenda context the command line lives in.
+    var focusSuggestions: [String] {
+        ["følg et lag", "hva skjer i kveld?", "vis bare fotball"]
+    }
+
+    /// Fill the command line with a tapped focus suggestion. Deliberately does
+    /// NOT submit — the user reviews/edits/sends it, so a tap never surprises
+    /// them with a change.
+    func fillSuggestion(_ text: String) { utterance = text }
+
+    /// TYPING state: live grounding of the in-progress utterance against the
+    /// SAME entity index the grounder uses — "velg, ikke stav". Reuses
+    /// `EntityIndex.nearestMatches` (no new matching logic); empty until there's
+    /// something groundable, so the row stays silent for very short input or a
+    /// phrase that resolves to nothing (e.g. a pure question). Selecting a hit
+    /// runs `proposeFollow` (below), the exact grounded diff/confirm flow the
+    /// detail sheet's «Følg X» uses.
+    func groundingHits(for text: String, limit: Int = 3) -> [Entity] {
+        let q = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard q.count >= 2, hasEntities else { return [] }
+        return index.nearestMatches(to: q, limit: limit)
     }
 
     // MARK: - Helpers

--- a/ios/Zenji/Assistant/CommandLineView.swift
+++ b/ios/Zenji/Assistant/CommandLineView.swift
@@ -2,19 +2,29 @@
 //  CommandLineView.swift
 //  Zenji
 //
-//  WP-16.4 — THE KOMMANDOLINJE. The seamless-assistant brief's first move: a
-//  fixed, quiet prompt line pinned to the bottom of the agenda (above the
-//  safe-area), the PRIMARY way into the assistant — "assistenten ER
-//  grensesnittet", not a room behind a button. Tekst-TV to the core: a mono
-//  `»_` sigil, a plain text field, and a blinking `▌` block cursor (static
-//  under Reduce Motion — the clock is the app's only sanctioned motion, and
-//  this one honours the same rule).
+//  WP-16.4 → WP-82 — THE KOMMANDOLINJE. A quiet write-/search-line pinned to the
+//  bottom of the agenda (above the safe-area), the PRIMARY way into the
+//  assistant — "assistenten ER grensesnittet", not a room behind a button.
+//
+//  WP-82 makes the line INTUITIVE via the three discoverability states
+//  (DESIGN-BASELINE § Hjelperen), with NO permanent chrome:
+//    • REST     — a CONCRETE example placeholder (not an abstract instruction).
+//    • FOCUS    — a small, calm row of context-suggestion pills rises OVER the
+//                 line; it disappears the moment focus is released.
+//    • TYPING   — live grounding against the entity index: matches show as
+//                 tappable rows while you type ("Bodø/Glimt · fotball") so you
+//                 CHOOSE, don't spell. Selecting runs the grounded follow flow.
+//  The field itself is a native text field: autocorrect/autocap OFF (proper
+//  nouns), a clear button, the keyboard's own dictation mic left untouched, and
+//  a sensible send/return. Typography is the WP-80 Dynamic Type API + semantic
+//  colour tokens (the deprecated Tekst-TV `zenjiMono` shim is gone here).
 //
 //  It carries no logic of its own: it binds the field to
-//  AssistantViewModel.utterance, fires `run()` on submit (cancellable), and
-//  leaves raising the result "ark" to ContentView (which watches
-//  `presentToken`). While the model works it shows a dimmed "tenker …" next to
-//  the blinking cursor — never a spinner (move 5) — and an Avbryt.
+//  AssistantViewModel.utterance, fires `run()` on submit (cancellable), reads
+//  the discovery helpers off the view model, and leaves raising the result "ark"
+//  to ContentView (which watches `presentToken`). While the model works it shows
+//  a dimmed "tenker …" next to the blinking cursor — never a spinner — and an
+//  Avbryt.
 //
 
 import SwiftUI
@@ -32,12 +42,32 @@ struct CommandLineView: View {
     }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // FOCUS / TYPING discovery rises over the line, and collapses the
+            // instant focus is released — no permanent chrome.
+            if focused {
+                discoverySection
+                    .transition(.opacity)
+            }
+            inputRow
+        }
+        .background(ZenjiTokens.cell)
+        .overlay(alignment: .top) {
+            Rectangle().fill(ZenjiTokens.separator).frame(height: 1)
+        }
+        .animation(.easeOut(duration: 0.15), value: focused)
+        .animation(.easeOut(duration: 0.15), value: trimmed.isEmpty)
+    }
+
+    // MARK: - The input line
+
+    private var inputRow: some View {
         HStack(alignment: .center, spacing: 10) {
             // The sigil — a quiet, tappable "oppslag" into the flow.
             Button(action: onOpenBrowse) {
                 Text("»_")
-                    .font(.zenjiMono(size: 15, weight: .semibold))
-                    .foregroundStyle(ZenjiTokens.muted)
+                    .font(.zenji(.subheadline, weight: .semibold))
+                    .foregroundStyle(ZenjiTokens.secondaryLabel)
             }
             .accessibilityLabel("Åpne assistenten")
             // WP-70: a stable handle for the XCUITest that opens the assistant ark
@@ -46,12 +76,17 @@ struct CommandLineView: View {
             // WP-14.3: same glyph, ≥44×44pt hit area.
             .zenjiTapTarget()
 
-            TextField("Skriv eller spør …", text: $viewModel.utterance, axis: .vertical)
-                .font(.zenjiMono(size: 15))
+            TextField(viewModel.restPlaceholder, text: $viewModel.utterance, axis: .vertical)
+                .font(.zenji(.subheadline))
                 .textFieldStyle(.plain)
                 .lineLimit(1...3)
                 .focused($focused)
                 .submitLabel(.send)
+                // WP-82: proper nouns (Bodø/Glimt, Ruud) must not be
+                // auto-capitalised or auto-corrected out from under the user; the
+                // keyboard's own dictation mic is left in place (free, native).
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
                 .disabled(viewModel.isThinking)
                 .onSubmit(submit)
                 // WP-70: stable handle for the follow-via-command-line flow.
@@ -62,13 +97,83 @@ struct CommandLineView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZenjiTokens.surface)
-        .overlay(alignment: .top) {
-            Rectangle().fill(ZenjiTokens.hairline).frame(height: 1)
-        }
     }
 
-    // MARK: - Trailing state (cursor · thinking · send)
+    // MARK: - Discovery (WP-82 — focus suggestions · typing grounding)
+
+    /// While focused: grounding hits when the user is typing, else the calm
+    /// context-suggestion row. An empty view (no hits for a short/question-only
+    /// phrase) simply collapses.
+    @ViewBuilder
+    private var discoverySection: some View {
+        let hits = viewModel.groundingHits(for: viewModel.utterance)
+        Group {
+            if !trimmed.isEmpty {
+                if !hits.isEmpty { groundingHits(hits) }
+            } else {
+                focusSuggestions
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, ZenjiSpacing.s)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// FOCUS state: flat hairline pills in amber (never filled), each ≥44 pt via
+    /// `ZenjiActionButtonStyle`. Horizontally scrollable so a narrow width never
+    /// forces the body to scroll sideways.
+    private var focusSuggestions: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: ZenjiSpacing.s) {
+                ForEach(Array(viewModel.focusSuggestions.enumerated()), id: \.offset) { index, text in
+                    Button {
+                        viewModel.fillSuggestion(text)
+                    } label: {
+                        Text(text)
+                            .font(.zenji(.footnote))
+                            .foregroundStyle(ZenjiTokens.accent)
+                    }
+                    .buttonStyle(ZenjiActionButtonStyle(tint: ZenjiTokens.accent))
+                    .accessibilityIdentifier("assistant.suggestion.\(index)")
+                }
+            }
+            .padding(.bottom, ZenjiSpacing.s)
+        }
+        .accessibilityIdentifier("assistant.suggestions")
+    }
+
+    /// TYPING state: live grounding rows — "velg, ikke stav". Selecting a hit
+    /// drops it into the grounded diff/confirm flow (`proposeFollow`), the SAME
+    /// path the detail sheet's «Følg X» uses.
+    private func groundingHits(_ hits: [Entity]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(hits, id: \.id) { entity in
+                Button {
+                    select(entity)
+                } label: {
+                    HStack(spacing: ZenjiSpacing.s) {
+                        Text(entity.name)
+                            .font(.zenji(.subheadline))
+                            .foregroundStyle(ZenjiTokens.label)
+                        Text("·")
+                            .font(.zenji(.subheadline))
+                            .foregroundStyle(ZenjiTokens.secondaryLabel.opacity(0.6))
+                        Text(SportVocabulary.display(for: entity.sport))
+                            .font(.zenji(.footnote))
+                            .foregroundStyle(ZenjiTokens.secondaryLabel)
+                        Spacer(minLength: 0)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("grounding.\(entity.id)")
+            }
+        }
+        .padding(.bottom, ZenjiSpacing.xs)
+    }
+
+    // MARK: - Trailing state (cursor · thinking · clear + send)
 
     @ViewBuilder
     private var trailing: some View {
@@ -76,24 +181,38 @@ struct CommandLineView: View {
             HStack(spacing: 8) {
                 BlinkingCursor()
                 Text("tenker …")
-                    .font(.zenjiMono(size: 13))
-                    .foregroundStyle(ZenjiTokens.muted)
+                    .font(.zenji(.footnote))
+                    .foregroundStyle(ZenjiTokens.secondaryLabel)
                 Button("Avbryt") { viewModel.cancel() }
-                    .font(.zenjiMono(size: 12))
-                    .foregroundStyle(ZenjiTokens.muted)
+                    .font(.zenji(.caption))
+                    .foregroundStyle(ZenjiTokens.secondaryLabel)
                     .zenjiTapTarget()
             }
         } else if !trimmed.isEmpty {
-            Button(action: submit) {
-                Text("↵")
-                    .font(.zenjiMono(size: 17, weight: .semibold))
-                    .foregroundStyle(ZenjiTokens.accent)
+            HStack(spacing: 4) {
+                // Native-feel clear button (the plain axis text field has none of
+                // UIKit's `.clearButtonMode`). Muted, so send stays the single
+                // amber element in the row (DESIGN: never two amber together).
+                Button(action: clear) {
+                    Text("✕")
+                        .font(.zenji(.subheadline))
+                        .foregroundStyle(ZenjiTokens.secondaryLabel)
+                }
+                .accessibilityLabel("Tøm")
+                .accessibilityIdentifier("command.clear")
+                .zenjiTapTarget()
+
+                Button(action: submit) {
+                    Text("↵")
+                        .font(.zenji(.body, weight: .semibold))
+                        .foregroundStyle(ZenjiTokens.accent)
+                }
+                .accessibilityLabel("Send")
+                // WP-70: a distinct id — the `submitLabel(.send)` keyboard key ALSO
+                // carries the "Send" label, so the XCUITest needs an unambiguous handle.
+                .accessibilityIdentifier("command.send")
+                .zenjiTapTarget()
             }
-            .accessibilityLabel("Send")
-            // WP-70: a distinct id — the `submitLabel(.send)` keyboard key ALSO
-            // carries the "Send" label, so the XCUITest needs an unambiguous handle.
-            .accessibilityIdentifier("command.send")
-            .zenjiTapTarget()
         } else {
             // Idle: the blinking prompt cursor IS the whole affordance.
             BlinkingCursor()
@@ -105,18 +224,32 @@ struct CommandLineView: View {
         focused = false
         viewModel.run()
     }
+
+    /// Clear the line but keep focus — the user is still composing.
+    private func clear() {
+        viewModel.utterance = ""
+        focused = true
+    }
+
+    /// Select a live grounding hit ("velg, ikke stav") — hand it to the grounded
+    /// follow flow (the panel rises via `presentToken`, exactly like a typed
+    /// "Følg X"); nothing is applied until the user taps Bekreft.
+    private func select(_ entity: Entity) {
+        focused = false
+        viewModel.proposeFollow(entity)
+    }
 }
 
 /// The Tekst-TV block cursor. Blinks (the assistant's only motion besides the
 /// clock) unless Reduce Motion is on, in which case it holds steady — same
-/// contract the header clock follows (DESIGN.md "Bevegelse & lyd").
+/// contract the header clock follows (DESIGN-BASELINE "Bevegelse & haptikk").
 struct BlinkingCursor: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var dim = false
 
     var body: some View {
         Text("▌")
-            .font(.zenjiMono(size: 15, weight: .semibold))
+            .font(.zenji(.subheadline, weight: .semibold))
             .foregroundStyle(ZenjiTokens.accent)
             .opacity(dim ? 0.12 : 1)
             .onAppear {

--- a/ios/ZenjiUITests/MainFlowsUITests.swift
+++ b/ios/ZenjiUITests/MainFlowsUITests.swift
@@ -226,4 +226,55 @@ final class MainFlowsUITests: ZenjiUITestCase {
 		assertExists(agendaRow(UITestFixture.footballTitle, in: app), "resetting the filter restores the full board")
 		XCTAssertFalse(app.staticTexts["agenda.filter.label"].exists, "the filter line is gone after reset")
 	}
+
+	// MARK: - Flow 8 · Command-line discoverability — focus shows context suggestions (WP-82)
+
+	func testCommandLineFocusShowsContextSuggestions() {
+		let app = launchApp(state: "agenda")
+
+		// At rest, the suggestion row is NOT present — it appears only on focus.
+		let suggestion = app.buttons["assistant.suggestion.0"]
+		XCTAssertFalse(suggestion.exists, "context suggestions must not show before the line is focused")
+
+		// Focusing the command line raises the calm context-suggestion row.
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		assertExists(suggestion, "focusing the line should raise a context-suggestion pill")
+
+		// Tapping a suggestion FILLS the line (it does not submit) — the value
+		// lands in the field (read as the text field's `value`) so the user can
+		// edit or send it. "lag" is an ASCII token of the first suggestion that
+		// the placeholder does NOT contain, so the match is unambiguous.
+		suggestion.tap()
+		let value = (field.value as? String) ?? ""
+		XCTAssertTrue(value.contains("lag"),
+		              "tapping a suggestion should fill the command line with its text (got «\(value)»)")
+	}
+
+	// MARK: - Flow 9 · Command-line discoverability — typing shows live grounding hits (WP-82)
+
+	func testCommandLineTypingShowsGroundingHits() {
+		let app = launchApp(state: "agenda")
+
+		// Type a prefix of a known entity (ASCII-only — typeText with æøå is flaky).
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		field.typeText("ski")
+
+		// A live grounding hit for the seeded biathlon tournament appears as a
+		// tappable row — "velg, ikke stav".
+		let hit = app.buttons["grounding.skiskyting-verdenscup"]
+		assertExists(hit, "typing should surface a live grounding hit for the entity")
+
+		// Selecting the hit runs the grounded follow flow: a confirmable diff
+		// rises, and confirming it surfaces the biathlon row on the recompiled board.
+		hit.tap()
+		let confirm = app.buttons["assistant.confirm"].firstMatch
+		assertExists(confirm, "selecting a grounding hit should raise a confirmable follow diff")
+		confirm.tap()
+		assertExists(app.staticTexts[UITestFixture.biathlonTitle],
+		             "confirming the selected follow should surface the biathlon row")
+	}
 }


### PR DESCRIPTION
## Hva

WP-82 gjør kommandolinja intuitiv (eier `ios/Zenji/Assistant/`). De strukturelle grepene (ContentView→NavigationStack, overlay→native sheet, flytting av permanente seksjoner til Deg) er bevisst holdt til **WP-83** — dette er hjelperens *oppdagbarhet* alene.

**De tre oppdagbarhets-tilstandene** (`CommandLineView` + støtte i `AssistantViewModel`):
- **Hvile** — konkret eksempel-placeholder: «Prøv «følg Bodø/Glimt» eller «når spiller Ruud?»» (ikke abstrakt instruksjon).
- **Fokus** — en rolig rad flate hårlinje-«pills» i amber (≥44pt) stiger opp over linja ved fokus, og forsvinner når fokus slippes. Tapp fyller linja (sender ikke).
- **Skriving** — live grunning mot entitets-indeksen (gjenbruker `EntityIndex.nearestMatches` — ingen ny logikk): treff vises som tappbare «navn · sport»-rader. Å velge et treff kjører den eksisterende grunnede `proposeFollow`-diff/bekreft-flyten («velg, ikke stav»).

**Native tekstfelt-oppførsel:** clear-knapp, autocap/autocorrect AV for egennavn, tastatur-diktering (mic) urørt, fornuftig send/retur.

**Typografi + tokens:** migrert ALL `Assistant/`-typografi fra den deprecated `zenjiMono(size:)`-shimen til `Font.zenji(...)`/`zenjiTabular(...)` + semantiske farge-tokens (label/secondaryLabel/cell/separator/live/destructive/accent).

**Haptikk:** lett `.sensoryFeedback(.success)` på Bekreft (via VM-`confirmHaptic`-trigger).

**Ikke rørt (bindende):** FM-intent-tolkning/modell-oppførsel (ingen nye eval-cases); `ContentView.swift`; ark-presentasjonen (overlay→sheet er WP-83); de permanente `AssistantPanel`-seksjonene (kun font-migrert, står); `Agenda/**` (WP-81); beskyttede stier.

PLAN.md: WP-82 ⬜→🔬 (samme PR, andre rader urørt).

## Aksept
- `xcodegen generate` + **alle fire schemes bygger** (Zenji, ZenjiUITests, ZenjiWidgetExtension, ZenjiDeviceDev).
- **iOS unit-suite grønn** inkl. mock-suiten (beviser at FM-oppførsel ikke er rørt) + **13/13 feed-vektorer bit-like**. (Én `AgendaMatchingPerfTests`-blink skyldes maskinlast fra 4 back-to-back-bygg — grønn isolert.)
- **ZenjiUITests:** de to nye tilstands-casene (`testCommandLineFocusShowsContextSuggestions`, `testCommandLineTypingShowsGroundingHits`) + follow-flyten grønne.
- **Skjermbilder** av alle tre tilstandene i BEGGE temaer tatt (rest/fokus/skriving).
- Én forbigående UITest, `testEventDetailWhyShown`, feiler — men **feiler identisk på ren `main`** (stashet): en pre-eksisterende `Agenda/`-EventDetailSheet-sak i WP-81s territorium, ikke WP-82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)