### PR TITLE
Fix: EventDetail whyShown UI-test (pre-eksisterende)

### DIFF
--- a/ios/ZenjiUITests/MainFlowsUITests.swift
+++ b/ios/ZenjiUITests/MainFlowsUITests.swift
@@ -135,8 +135,12 @@ final class MainFlowsUITests: ZenjiUITestCase {
 		let why = app.staticTexts["Hvorfor vises denne?"]
 		assertExists(why, "the detail sheet should offer «Hvorfor vises denne?»")
 		why.tap()
-		assertExists(staticText(containing: "Fordi FK Lyn Oslo spiller", in: app),
-		             "expanding it should show the deterministic reason")
+		// The disclosure sits at the foot of the sheet; on the .medium detent the
+		// revealed reason lands below the fold, and the List is lazy so its cell
+		// isn't realised until scrolled into view. Bring it on-screen, then assert.
+		let reason = staticText(containing: "Fordi FK Lyn Oslo spiller", in: app)
+		scrollUntilHittable(reason, in: app)
+		assertExists(reason, "expanding it should show the deterministic reason")
 
 		app.buttons["Lukk"].tap()
 		assertExists(app.textFields["command.field"], "closing the sheet returns to the agenda")

--- a/ios/ZenjiUITests/ZenjiUITestCase.swift
+++ b/ios/ZenjiUITests/ZenjiUITestCase.swift
@@ -77,8 +77,11 @@ class ZenjiUITestCase: XCTestCase {
 
 	/// The first staticText whose label CONTAINS `substring` — for labels that
 	/// carry a variable tail (e.g. the "· varsler deg før start" suffix).
+	/// Uses `.matching` (the element's OWN label), not `.containing` (which
+	/// filters to elements with a DESCENDANT matching — never true for a leaf
+	/// staticText, so it silently found nothing).
 	func staticText(containing substring: String, in app: XCUIApplication) -> XCUIElement {
-		app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", substring)).firstMatch
+		app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", substring)).firstMatch
 	}
 
 	/// An agenda row, queried by the row Button's own accessibility label.


### PR DESCRIPTION
## Rotårsak (test, ikke funksjon)

`ZenjiUITests/MainFlowsUITests/testEventDetailWhyShown` feilet identisk på ren `main` (MainFlowsUITests.swift:138): etter å ha ekspandert «Hvorfor vises denne?»-disclosuren i detaljarket fant testen aldri den deterministiske grunn-teksten «Fordi FK Lyn Oslo spiller».

Diagnostisert via kjøring + inspeksjon av tilgjengelighets-hierarkiet. To feil, begge i TESTEN:

1. **Feil query-API i hjelperen.** `staticText(containing:)` i `ZenjiUITestCase.swift` brukte `XCUIElementQuery.containing(_:)`, som filtrerer til elementer med en *descendant* som matcher predikatet — aldri sant for en løv-`StaticText`, så den fant alltid ingenting. Rettet til `.matching(_:)` (elementets *eget* label).
2. **Rullet aldri grunn-teksten inn i syne.** «Hvorfor vises denne?»-`DisclosureGroup` ligger nederst i arket. På `.medium`-detenten havner den ekspanderte grunn-teksten under folden, og `List` er lat så cellen realiseres ikke før den rulles inn i syne. Testen tappet for å ekspandere (bekreftet: chevron-`identifier` → `'expanded'`) men rullet aldri. Lagt til `scrollUntilHittable` før assert.

**Funksjonen er verifisert korrekt** — `whyShown` = «Fordi FK Lyn Oslo spiller» rendres (data-flyten `EffectiveInterests.merge` → `FeedCompiler.whyShown` er intakt), og disclosuren toggler riktig. Ingen app-kode endret; `EventDetailSheet.swift` og fixturen trengte ingen fiks.

## Fiks

- `ZenjiUITests/ZenjiUITestCase.swift`: `staticText(containing:)` → `.matching`.
- `ZenjiUITests/MainFlowsUITests.swift` (kun `testEventDetailWhyShown`): scroll grunn-teksten inn i syne før assert.

Minimal og innenfor eierskaps-grensen (rørte ikke ContentView / Assistant / Profile / EventDetailSheet / fixture; la ikke til nye test-metoder).

## Verifisering

- `testEventDetailWhyShown` grønn (14 s, ned fra 52 s timeout).
- Hele `ZenjiUITests` 10/10 grønn.
- `Zenji` unit-suite: 529 tester, 1 hoppet over (opt-in RealFM-eval), 0 feil — inkl. 13/13 gylne feed-vektorer bit-like.
- Alle fire schemes bygger (`Zenji`, `ZenjiUITests`, `ZenjiWidgetExtension`, `ZenjiDeviceDev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)