### PR TITLE
WP-84 (widget) · Token-migrering av WidgetKit

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -94,7 +94,7 @@ mennesket, aldri av en agent.
 | WP-81 | Agenda → native List + sveip/pressed-state | 0F | WP-80 | ✅ merget (#290) — native `List(.insetGrouped)`, rad=Button (pressed-state + a11y-rolle), SF Symbols (bell/info), sveip «Følg», detaljark på detents; 529 unit + 13/13 vektorer bit-like |
 | WP-82 | Hjelperen → native (oppdagbarhet) | 0F | WP-80 | ✅ merget (#291) — tre oppdagbarhets-tilstander (hvile-eksempel/fokus-forslag/live grunning), native felt (clear/diktering/autocap av), font-migrering; mock-suite urørt grønn. Samlet bølge-2-verifisering: unit 529 + UI 9/10 (begge nye flyter), `testEventDetailWhyShown` er pre-eksisterende feil (fikses separat) |
 | WP-83 | Navigasjon (NavigationStack) + Deg-skjerm | 0F | WP-81,WP-82 | ✅ merget (#293; samlet bølge-3-verif. grønn m/ #292) — agenda i `NavigationStack` + `gearshape`→Deg; v2-header-glyfer (`»_`/`◐`/klokke) fjernet; hjelperens resultat = native `.sheet` (detents); `AssistantPanel` slanket til samtale/resultat; ny `Profile/DegView.swift` re-hjemmer profil/minne/forsto-ikke/del/varsel/tema/nullstill/eval; alle 4 schemes bygger, 529 unit + 13/13 vektorer bit-like, UI-flyter (Deg-nav/tema/reset/sheet) grønne |
-| WP-84 | Widget + web token-paritet | 0F | WP-80 | ⬜ |
+| WP-84 | Widget + web token-paritet | 0F | WP-80 | 🔬 widget-delen migrert (PR) — WidgetKit av `zenjiMono`-shimen + deprecated farge-aliaser, over på `Font.zenji`/`zenjiTabular` + semantiske tokens; **web-delen (`docs/css` + `theme.js`) utsatt til egen beslutning** |
 | WP-85 | Baseline-designsystem + HIG-gate (promoter DESIGN.md) | 0F | WP-80,WP-81,WP-82,WP-83,WP-84 | ⬜ |
 
 ---
@@ -952,6 +952,11 @@ OPPFØRSEL endres (WP-82 er ren presentasjon — mock-suite grønn holder).
 - **Avhenger av:** WP-80. **Nabo:** WP-85.
 - **Ikke-mål:** app-skjermene (gjort i WP-81/82/83).
 - **Aksept:** ZenjiWidgetExtension bygger, web-screenshots begge temaer, `npm test` grønt.
+- **Status (🔬):** widget-delen er levert i egen PR — `ios/ZenjiWidget/*` migrert av
+  `zenjiMono(size:)`-shimen og de deprecated farge-aliasene (`foreground`/`muted`) til
+  `Font.zenji`/`zenjiTabular` + semantiske tokens (`label`/`secondaryLabel`), så shimen
+  trygt kan fjernes i WP-85. **Web-delen (`docs/css/*` + `docs/js/theme.js`) er bevisst
+  utsatt til en egen beslutning** og er IKKE med i denne PR-en.
 
 ### WP-85 · Baseline-designsystem + HIG-gate (SIST)
 - **Mål:** Fjern shimen, slå på HIG-gaten, promotér designdokumentet.

--- a/ios/ZenjiWidget/ZenjiWidget.swift
+++ b/ios/ZenjiWidget/ZenjiWidget.swift
@@ -79,7 +79,7 @@ struct ZenjiWidgetEntryView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Text("ZENJI")
-                    .font(.zenjiMono(size: 12, weight: .bold))
+                    .font(.zenji(.caption, weight: .bold))
                     .foregroundStyle(ZenjiTokens.accent)
                     .tracking(1)
                 if entry.content.isMustSee {
@@ -89,17 +89,17 @@ struct ZenjiWidgetEntryView: View {
             }
             Spacer(minLength: 2)
             Text(entry.content.title)
-                .font(.zenjiMono(size: family == .systemSmall ? 14 : 16, weight: .semibold))
-                .foregroundStyle(ZenjiTokens.foreground)
+                .font(.zenji(family == .systemSmall ? .subheadline : .callout, weight: .semibold))
+                .foregroundStyle(ZenjiTokens.label)
                 .lineLimit(family == .systemSmall ? 3 : 2)
             if entry.content.hasHighlight {
                 HStack(spacing: 6) {
-                    Text(entry.content.timeLabel).monospacedDigit()
+                    Text(entry.content.timeLabel)
                     Text("·")
                     Text(entry.content.channelLabel)
                 }
-                .font(.zenjiMono(size: 11))
-                .foregroundStyle(ZenjiTokens.muted)
+                .font(.zenjiTabular(.caption2))
+                .foregroundStyle(ZenjiTokens.secondaryLabel)
                 .lineLimit(1)
             }
         }


### PR DESCRIPTION
## Hva

Migrerer WidgetKit-utvidelsen (`ios/ZenjiWidget/*`) vekk fra det deprecated
`Font.zenjiMono(size:)`-shimen og de deprecated Tekst-TV-farge-aliasene, over på
WP-80-fundamentet (`Font.zenji`/`Font.zenjiTabular` + semantiske farge-tokens). Dette
er en av de siste brukerne av shimen — poenget er å la **WP-85 trygt fjerne shimen**.

Endringer i `ios/ZenjiWidget/ZenjiWidget.swift`:

| Før | Etter |
|---|---|
| `.zenjiMono(size: 12, .bold)` (ZENJI-ordmerke) | `.zenji(.caption, weight: .bold)` |
| `.zenjiMono(size: 14/16, .semibold)` (tittel) | `.zenji(.subheadline/.callout, weight: .semibold)` |
| `.zenjiMono(size: 11)` (tid/kanal-linja) | `.zenjiTabular(.caption2)` |
| `ZenjiTokens.foreground` | `ZenjiTokens.label` |
| `ZenjiTokens.muted` | `ZenjiTokens.secondaryLabel` |

Rendering er uendret: dette er nøyaktig de stil-/tabular-avbildningene shimen selv
produserte for de gamle punktstørrelsene, og farge-aliasene var computed properties
som returnerte `label`/`secondaryLabel`. **Migrering, ikke redesign** — Tekst-TV-
uttrykket beholdes. Den nå overflødige eksplisitte `.monospacedDigit()` på tidsetiketten
er fjernet (den tabulære tekststilen retter allerede inn sifrene).

`WidgetTimelineBuilder`-logikken og de gylne feed-vektorene er URØRT.

## Web-delen er utsatt

WP-84 dekker i PLAN.md både widget og web. **Web-delen (`docs/css/*` + `docs/js/theme.js`)
er bevisst holdt UTENFOR denne PR-en og utsatt til en egen beslutning.** PLAN.md-raden er
flippet `⬜`→`🔬` med denne noten (både i tabellen og i detalj-seksjonen).

## Aksept

- `xcodegen generate` OK.
- **Alle fire schemes bygger** — `ZenjiWidgetExtension` ✅ (kravet), `Zenji` ✅, `ZenjiDeviceDev` ✅, `ZenjiUITests` (build-for-testing) ✅.
- iOS unit-suite grønn: **529 passed / 1 skipped** (RealFM opt-in), inkl. `WidgetTimelineBuilderTests` 9/9, `FeedVectorTests` bit-like, `DesignTokensTests`.
- Widget-skjermbilder (systemSmall/systemMedium × tema): ikke rendret headless her — se «Rendering» under; visuell paritet følger av at avbildningene er identiske med shimens.

## Rendering (beskrivelse)

Uendret fra før migreringen i begge temaer: ZENJI-ordmerke i amber (`accent`) med
must-see-prikk, tittel i `label`-farge (subheadline small / callout medium, semibold),
og tid · kanal i `secondaryLabel` med tabulære sifre. `containerBackground` = `ZenjiTokens.background`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)