### PR TITLE
Liquid Glass: kommandolinja som flytende glass-kontroll (iOS 26)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,6 +117,13 @@ Apple-system-farger + én amber-aksent. Ved rebrand endres KUN denne tabellen.
 ### Bevegelse & haptikk
 
 - **Navigasjon:** Apples native push/sheet/tilbake-swipe. Ingen egendefinerte kurver.
+- **Liquid Glass (iOS 26 — BINDENDE presisering):** plattformens kontroll-materiale
+  er *native*, ikke dekor. Standard-komponenter arver det automatisk (bygg mot
+  iOS 26-SDK, aldri `UIDesignRequiresCompatibility`-opt-out); appens egne
+  kontroll-flater (kommandolinja) adopterer `glassEffect` og flyter over innholdet
+  (`safeAreaInset`). Glass hører KUN til kontroll-laget — innhold (agenda-rader,
+  detaljark-innhold) glasses ALDRI. Egenlaget blur/glassmorfisme er fortsatt
+  forbudt; det historiske forbudet gjaldt DIY-dekor, ikke systemmaterialet.
 - **Hjelperens resultat:** native `.sheet` med `.presentationDetents`
   (grabber, dra-ned) — ikke et egendefinert fade-lag.
 - **Haptikk (sparsom):** `.sensoryFeedback(.success, …)` på Bekreft,
@@ -174,7 +181,9 @@ Seksjoner: Arena · Om · **Hvor ser jeg det** (lenker) · **Funnet av AI**
 Visjonens kjerne, bygd som native mønstre — ikke en bespoke kontroll.
 
 - **Bunn-linje** på agenda + Deg: et native tekstfelt i søke-/skrivelinje-form
-  (`mic` for diktering, send/retur). Forstår BÅDE profil-endringer OG spørsmål.
+  (`mic` for diktering, send/retur), som en **flytende Liquid Glass-flate**
+  (`glassEffect` + `safeAreaInset` — Safari-bunnfeltet-mønsteret; agendaen
+  scroller under). Forstår BÅDE profil-endringer OG spørsmål.
 - **Resultat i native sheet** (detents): diff (`+` grønn / `±` amber / `−` rød,
   semantiske signalfarger) med Bekreft/Avvis, eller et rolig svar over LOKAL data.
 - **Kontekstbevisst:** agenda → følg/spør om tavla; detaljark → forhåndsscopet
@@ -242,4 +251,6 @@ Faste punktstørrelser som ignorerer Dynamic Type · `.onTapGesture`-rader uten
 pressed-state/a11y-rolle · trunkerte titler · fortid i agendaen · mer enn én
 aksentfarge (amber) · to amber-elementer i samme rad · badges med tall ·
 spinnere · haptikk-fest · egendefinerte overgangskurver der Apple har en native ·
+egenlaget blur/glassmorfisme (system-Liquid Glass på kontroll-laget er native og
+påkrevd; DIY-glass — særlig på innhold — er forbudt) ·
 egne ikoner der en SF Symbol finnes · «AI-slop»-estetikk. Ved tvil: fjern.

--- a/ios/Zenji/Assistant/CommandLineView.swift
+++ b/ios/Zenji/Assistant/CommandLineView.swift
@@ -51,10 +51,15 @@ struct CommandLineView: View {
             }
             inputRow
         }
-        .background(ZenjiTokens.cell)
-        .overlay(alignment: .top) {
-            Rectangle().fill(ZenjiTokens.separator).frame(height: 1)
-        }
+        // Liquid Glass (iOS 26): the platform's own control material replaces
+        // the opaque bar + hairline. Glass belongs on the CONTROL layer only —
+        // content (the agenda) never gets glassed. A rounded rect (not a
+        // capsule) so the shape stays calm when the discovery section expands
+        // the bar to two rows. System glass handles Reduce Transparency /
+        // legibility fallbacks automatically.
+        .glassEffect(.regular, in: .rect(cornerRadius: 26))
+        .padding(.horizontal, 10)
+        .padding(.bottom, 4)
         .animation(.easeOut(duration: 0.15), value: focused)
         .animation(.easeOut(duration: 0.15), value: trimmed.isEmpty)
     }

--- a/ios/Zenji/ContentView.swift
+++ b/ios/Zenji/ContentView.swift
@@ -184,6 +184,14 @@ struct ContentView: View {
                 filterLine
                 AgendaView(viewModel: agenda, onFollow: follow, onOpen: { assistant.recordOpened($0) },
                            openEventID: $requestedEventID)
+            }
+            // Liquid Glass (iOS 26): the command line is the app's ONE custom
+            // control surface — it floats over the agenda as a glass capsule
+            // (the Safari bottom-bar pattern) instead of sitting as an opaque
+            // bar in the VStack. `safeAreaInset` keeps the List scrollable
+            // beneath it with the correct automatic bottom inset, and the bar
+            // still rides above the keyboard natively.
+            .safeAreaInset(edge: .bottom) {
                 CommandLineView(viewModel: assistant, focused: $commandFocused, onOpenBrowse: openBrowse)
             }
             .background(ZenjiTokens.background.ignoresSafeArea())


### PR DESCRIPTION
Kommandolinja (appens ene custom kontroll-flate) → flytende `glassEffect`-flate via `safeAreaInset` (Safari-mønsteret); agendaen scroller under. DESIGN.md får bindende Liquid Glass-presisering (kontroll-lag = native/påkrevd, innhold aldri, DIY-blur fortsatt forbudt).

Verifisert lokalt (iOS kan ikke kjøre i CI): 4 schemes bygger, unit grønn, ZenjiUITests 12/12, skjermbilder begge temaer inspisert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)