### PR TITLE
Cleanup: agent-prompter Zenji → Sportivista

### DIFF
--- a/scripts/agents/coverage-critic.md
+++ b/scripts/agents/coverage-critic.md
@@ -1,6 +1,6 @@
-# Coverage Critic — Zenji
+# Coverage Critic — Sportivista
 
-You are Zenji's **completeness critic**. The product's hardest failure mode is
+You are Sportivista's **completeness critic**. The product's hardest failure mode is
 *recall* — an important event the user cares about that never makes it onto the
 dashboard. The static pipeline and research agent add what they find; your job is
 the opposite discipline: **reason adversarially about what is MISSING or WRONG.**

--- a/scripts/agents/editorial.md
+++ b/scripts/agents/editorial.md
@@ -1,4 +1,4 @@
-# Editorial Agent — Zenji
+# Editorial Agent — Sportivista
 
 Write ONE quiet Norwegian headline for the day — a single calm line shown under
 the date on the dashboard. This is a "nice extra", not a section: the product's

--- a/scripts/agents/improve.md
+++ b/scripts/agents/improve.md
@@ -1,4 +1,4 @@
-# Improve Agent — Zenji (evolution)
+# Improve Agent — Sportivista (evolution)
 
 Once a week you step back and ask: **what is this system doing poorly, and how
 could it do it better?** Then you make ONE concrete, evidenced improvement on a

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -1,6 +1,6 @@
-# Research Agent — Zenji
+# Research Agent — Sportivista
 
-You are Zenji's research agent. Your single job: **find sports events that
+You are Sportivista's research agent. Your single job: **find sports events that
 matter to a Norwegian sports fan that are NOT in the static data feeds**.
 
 ## Inputs (read these files first)

--- a/scripts/agents/scout.md
+++ b/scripts/agents/scout.md
@@ -1,4 +1,4 @@
-# Scout Agent — Zenji (the Watchtower)
+# Scout Agent — Sportivista (the Watchtower)
 
 You are a cheap, fast hourly scout. Your ONLY job: decide whether something has
 happened in the last few hours that the research agent (runs every 4h) should

--- a/scripts/agents/self-repair.md
+++ b/scripts/agents/self-repair.md
@@ -1,4 +1,4 @@
-# Self-Repair Agent — Zenji (the mechanic)
+# Self-Repair Agent — Sportivista (the mechanic)
 
 You keep the system *running*. The other agents fix data, coverage, and UI; you
 fix the machine itself: broken fetchers, failing tests, validation errors,

--- a/scripts/agents/ui-fix.md
+++ b/scripts/agents/ui-fix.md
@@ -1,4 +1,4 @@
-# UI Fix Agent — Zenji (self-healing loop)
+# UI Fix Agent — Sportivista (self-healing loop)
 
 You close the loop the **visual-qa** agent opens. Visual-qa *reports* rendering
 problems; you *fix* them — on a branch, re-verified with screenshots, opened as a

--- a/scripts/agents/verify.md
+++ b/scripts/agents/verify.md
@@ -1,4 +1,4 @@
-# Verify Agent — Zenji
+# Verify Agent — Sportivista
 
 Read `docs/data/events.json`. For events in the next 7 days where
 `source: "ai-research"` OR `confidence` is set OR `streaming` carries a

--- a/scripts/agents/visual-qa.md
+++ b/scripts/agents/visual-qa.md
@@ -1,6 +1,6 @@
-# Visual QA — Zenji
+# Visual QA — Sportivista
 
-You are Zenji's **visual quality reviewer**. Automated tests check the data and
+You are Sportivista's **visual quality reviewer**. Automated tests check the data and
 the code; you check what tests can't — **how the rendered dashboard actually looks**,
 by taking screenshots and *looking at them*. You have vision: use it.
 


### PR DESCRIPTION
## Summary

Fjerner alle gjenværende `Zenji`-spor fra `scripts/agents/*.md` (kun heading/prose-omtaler av produktnavnet — ingen `zenji.app`-URL-er ble funnet i disse filene). Ren navne-oppdatering: prompt-instruksjoner, kontrakter og skill-referanser er uendret.

### Treff-oversikt (9 treff → 9 bytter, 9 filer)

| Fil | Treff | Endring |
|---|---|---|
| `editorial.md` | 1 | heading |
| `coverage-critic.md` | 2 | heading + prose ("You are Zenji's completeness critic") |
| `ui-fix.md` | 1 | heading |
| `improve.md` | 1 | heading |
| `self-repair.md` | 1 | heading |
| `visual-qa.md` | 2 | heading + prose ("You are Zenji's visual quality reviewer") |
| `research.md` | 2 | heading + prose ("You are Zenji's research agent") |
| `scout.md` | 1 | heading |
| `verify.md` | 1 | heading |

Ingen av treffene var historiske («formerly Zenji»)-referanser, så alle ble byttet rett til Sportivista.

## Test plan
- [x] `grep -rn "Zenji\|zenji" scripts/agents/` → ingen treff
- [x] `npx vitest run --maxWorkers=1` → **37 test files / 475 tests, alle grønne**, inkl. `tests/agent-prompts.test.js` (koherens-testen for skill-referanser)
- [x] Ingenting utenfor `scripts/agents/` rørt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>