### PR TITLE
Web: reskin til Apple-native baseline (lukker Tekst-TV-unntaket)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,7 @@
 Dette er den **levende designkontrakten**. iOS-appen og widgeten følger denne
 Apple-native baselinen: systemfont, semantiske system-farger, SF Symbols, native
 lister/sheets/navigasjon — med **amber som eneste aksent-token**. Web (`docs/`)
-beholder inntil videre Tekst-TV-uttrykket fra v2 (se § Cross-surface).
+følger nå de samme baseline-tokenene (se § Cross-surface).
 
 > **Om den senere rebrandingen:** Vi kommer sannsynligvis til å gjøre en full
 > rebranding (nytt navn — «Zenji» oppleves for lite intuitivt — og en egen
@@ -238,10 +238,14 @@ skal likevel bestå denne før merge; håndhev det som kan håndheves i CI:
 
 - **iOS-app + widget = baseline (nå).** Begge følger denne kontrakten fullt ut;
   widgeten er en miniatyr av samme språk (semantiske farger + Dynamic Type).
-- **Web (docs/) er det bevisste unntaket inntil rebrandingen.** Web beholder
-  Tekst-TV-uttrykket fra v2 (mono type-stack, amber, near-black side) — en
-  eierbeslutning: web-migreringen tas sammen med rebrandingen, ikke før. Til da
-  er `docs/`-flatens levende kontrakt fortsatt v2-tekst-TV-verdiene i `base.css`.
+- **Web (docs/) = baseline (nå).** Unntaket er lukket: `docs/`-flaten følger de
+  samme § Tokens-verdiene som appen — system-font-stacken, Apple-system-fargene
+  (true-black `#000000`-side i mørk, `#F2F2F7` grouped-light) og amber som eneste
+  aksent. Verdiene er tokenisert i `base.css` og skal stå verifiserbart mot
+  denne tabellen. Web beholder sine egne layout-detaljer (én kolonne maks 640px,
+  dag-gruppert agenda, den tikkende amber-klokka i toppen), men fargene og
+  typografien er baseline. Det historiske Tekst-TV-uttrykket (mono type-stack,
+  near-black `#0A0A0C`, varmt-papir) er dermed avviklet.
 - **Stemme:** norsk, lavmælt, presis. «Kanal ukjent», ikke «Ingen streaming!».
   Aldri utropstegn i kromet. Feil forklarer hva og hvorfor.
 

--- a/docs/activity.html
+++ b/docs/activity.html
@@ -4,8 +4,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 	<meta name="description" content="Hva automatikken bak Sportivista har gjort — forbedringer, reparasjoner og research, med lenke til hver endring.">
-	<meta name="theme-color" content="#0A0A0C" media="(prefers-color-scheme: dark)">
-	<meta name="theme-color" content="#F5F1E6" media="(prefers-color-scheme: light)">
+	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>Sportivista · Aktivitet</title>
 	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->

--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -1,53 +1,55 @@
-/* Zenji — design tokens, reset, typography. The normative contract is DESIGN.md.
+/* Sportivista — design tokens, reset, typography. The normative contract is DESIGN.md.
    One purpose: a quiet, scannable overview of the events you follow — when · what ·
-   where. One mono typeface (tabular numerals), one accent (amber, used sparingly),
-   flat rows on hairlines. No cards, no washes, no second colour. */
+   where. Apple-native baseline: the system font (tabular numerals where digits align),
+   one accent (amber, used sparingly), flat rows on hairlines. No cards, no washes,
+   no second colour. */
 
-/* Token values are the DESIGN.md table verbatim. Amber is the ONLY accent and is
-   used only for: wordmark, day headers, the must-see dot, the clock, selected
-   state. Live is a sparse semantic green. Hairlines are solid, not translucent. */
+/* Token values are the DESIGN.md § Tokens table verbatim (Apple system colours + one
+   amber accent). Amber is the ONLY accent and is used only for: wordmark, day headers,
+   the must-see dot, the clock, selected state. Live is systemGreen, sparse. Separators
+   are the Apple hairline tokens. */
 :root {
-	/* Dark — the merkevare default (near-black "page") */
-	--bg: #0A0A0C;
-	--surface: #131316;        /* ark / detalj surface — used only in detail sheets */
-	--fg: #E8E6E0;
-	--fg-2: #8A877E;           /* dempet */
-	--fg-3: #5C5A52;           /* fainter — derived, one step below dempet */
-	--line: #26251F;           /* hårlinje */
-	--accent: #FFB000;         /* amber — the ONLY accent */
-	--accent-ink: #0A0A0C;     /* ink on an amber block */
-	--live: #5BD990;           /* live — semantic, sparse */
+	/* Dark — the baseline default (true-black "page", system cell for depth) */
+	--bg: #000000;
+	--surface: #1C1C1E;                  /* cell — list/detail surface */
+	--fg: #FFFFFF;                        /* label */
+	--fg-2: rgba(235, 235, 245, 0.6);     /* secondaryLabel — dempet */
+	--fg-3: rgba(235, 235, 245, 0.3);     /* tertiaryLabel — fainter, one step below dempet */
+	--line: rgba(84, 84, 88, 0.6);        /* separator — hairline */
+	--accent: #FFB000;                    /* amber — the ONLY accent */
+	--accent-ink: #000000;                /* ink on an amber block */
+	--live: #30D158;                      /* systemGreen (dark) — live, sparse */
 
-	--font: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, "Cascadia Mono", "Roboto Mono", monospace;
+	--font: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, system-ui, sans-serif;
 	--display: var(--font);
 	--max-w: 640px;            /* one column, max 640 on large surfaces, centered */
 	--time-col: 120px;         /* fixed time column so titles align + a date window fits one line */
 }
 
 :root[data-theme="light"] {
-	/* Light — the warm-paper sibling (equally polished; never a plain inversion) */
-	--bg: #F5F1E6;
-	--surface: #EDE8D9;
-	--fg: #1D1B15;
-	--fg-2: #6E6A5C;
-	--fg-3: #9A9484;
-	--line: #D9D3C0;
-	--accent: #8F6400;
-	--accent-ink: #F5F1E6;
-	--live: #2E7D4F;
+	/* Light — the Apple grouped-light sibling (never a plain inversion) */
+	--bg: #F2F2F7;                        /* systemGroupedBackground */
+	--surface: #FFFFFF;                   /* cell */
+	--fg: #000000;                        /* label */
+	--fg-2: rgba(60, 60, 67, 0.6);        /* secondaryLabel — dempet */
+	--fg-3: rgba(60, 60, 67, 0.3);        /* tertiaryLabel — fainter */
+	--line: #C6C6C8;                      /* separator */
+	--accent: #9A6800;                    /* amber (light) — AA on paper */
+	--accent-ink: #FFFFFF;                /* ink on an amber block */
+	--live: #34C759;                      /* systemGreen (light) */
 }
 
 @media (prefers-color-scheme: light) {
 	:root:not([data-theme="dark"]) {
-		--bg: #F5F1E6;
-		--surface: #EDE8D9;
-		--fg: #1D1B15;
-		--fg-2: #6E6A5C;
-		--fg-3: #9A9484;
-		--line: #D9D3C0;
-		--accent: #8F6400;
-		--accent-ink: #F5F1E6;
-		--live: #2E7D4F;
+		--bg: #F2F2F7;
+		--surface: #FFFFFF;
+		--fg: #000000;
+		--fg-2: rgba(60, 60, 67, 0.6);
+		--fg-3: rgba(60, 60, 67, 0.3);
+		--line: #C6C6C8;
+		--accent: #9A6800;
+		--accent-ink: #FFFFFF;
+		--live: #34C759;
 	}
 }
 
@@ -61,7 +63,8 @@ body {
 	font-size: 15px;
 	line-height: 1.5;
 	font-weight: 400;
-	font-feature-settings: "tnum" 1;   /* tabular numerals — times line up */
+	/* Proportional numerals in prose (Apple baseline); tabular is opted into where
+	   digits must line up (time column, clock, scores) via font-variant-numeric. */
 	-webkit-font-smoothing: antialiased;
 	text-rendering: optimizeLegibility;
 	padding-bottom: env(safe-area-inset-bottom);

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 	<meta name="description" content="En rolig oversikt over sporten du følger — når det skjer og hvor du ser det.">
-	<meta name="theme-color" content="#0A0A0C" media="(prefers-color-scheme: dark)">
-	<meta name="theme-color" content="#F5F1E6" media="(prefers-color-scheme: light)">
+	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
 	<link rel="manifest" href="manifest.webmanifest">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -6,8 +6,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "theme_color": "#0A0A0C",
-  "background_color": "#0A0A0C",
+  "theme_color": "#000000",
+  "background_color": "#000000",
   "icons": [
     {
       "src": "icons/icon-192x192.png",

--- a/docs/rediger.html
+++ b/docs/rediger.html
@@ -4,8 +4,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
 	<meta name="description" content="Rediger det du følger i Sportivista.">
-	<meta name="theme-color" content="#0A0A0C" media="(prefers-color-scheme: dark)">
-	<meta name="theme-color" content="#F5F1E6" media="(prefers-color-scheme: light)">
+	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
 	<link rel="icon" type="image/png" href="favicon.png">
 	<title>Rediger · Sportivista</title>
 	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
@@ -27,7 +27,7 @@
 		.edit-actions { display: flex; gap: 8px; flex-shrink: 0; }
 		.btn { font-size: 12.5px; padding: 5px 11px; border-radius: 999px; border: 1px solid var(--line); background: var(--surface); color: var(--fg); text-decoration: none; white-space: nowrap; transition: border-color 0.12s, color 0.12s; }
 		.btn:hover { border-color: var(--accent); color: var(--accent); }
-		.btn-danger:hover { border-color: #c0483a; color: #c0483a; }
+		.btn-danger:hover { border-color: #FF453A; color: #FF453A; }
 		.add-box { margin: 4px 0 26px; }
 		.add-box h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); margin: 0 0 10px; }
 		.add-search { width: 100%; box-sizing: border-box; font: inherit; font-size: 15px; padding: 10px 13px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: var(--fg); }

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Zenji v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-2';
+const CACHE_NAME = 'sportivista-v1-3';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [


### PR DESCRIPTION
## Hva

Flytter web-dashboardet (`docs/`) fra v2 **Tekst-TV**-identiteten til de samme **Apple-native baseline-tokenene** som iOS-appen allerede følger. DESIGN.md sa at web var «det bevisste unntaket inntil rebrandingen» — rebrandingen har skjedd, så dette **lukker unntaket**.

Funksjonalitet, HTML-struktur, JS-logikk og layout-lovene (én rolig kolonne maks 640px, dag-gruppert agenda, når·hva·hvor) er **urørt**. Kun farge-, font- og skall-tokens er byttet.

## Før → etter

**Farger (`base.css`-tokens)**
| | Før (Tekst-TV) | Etter (baseline) |
|---|---|---|
| mørk bakgrunn | `#0A0A0C` near-black | `#000000` true-black |
| mørk flate/cell | `#131316` | `#1C1C1E` |
| mørk tekst | `#E8E6E0` | `#FFFFFF` |
| mørk dempet / skille | `#8A877E` / `#26251F` | `rgba(235,235,245,.6)` / `rgba(84,84,88,.6)` |
| lys bakgrunn / cell | `#F5F1E6` varmt-papir / `#EDE8D9` | `#F2F2F7` grouped / `#FFFFFF` |
| lys tekst / dempet / skille | `#1D1B15` / `#6E6A5C` / `#D9D3C0` | `#000000` / `rgba(60,60,67,.6)` / `#C6C6C8` |
| aksent (amber, mørk/lys) | `#FFB000` / `#8F6400` | `#FFB000` / `#9A6800` |
| live | `#5BD990` / `#2E7D4F` | systemGreen `#30D158` / `#34C759` |

Amber er fortsatt **eneste aksent**. Mørk forblir default via `prefers-color-scheme` + tema-toggle.

**Typografi:** mono type-stack (`ui-monospace, "SF Mono", …`) → system-stack (`-apple-system, BlinkMacSystemFont, "SF Pro Text", …`). Global `font-feature-settings: "tnum"` fjernet fra `body` (proporsjonale sifre i brødtekst, Apple-baseline); `font-variant-numeric: tabular-nums` beholdt eksplisitt der sifre rettes inn (tidskolonne, klokke, scores).

**Detaljer:**
- `meta[name=theme-color]` (index/rediger/activity) + `manifest.webmanifest` `theme_color`/`background_color` → `#000000` mørk / `#F2F2F7` lys.
- `rediger.html` `.btn-danger` `#c0483a` → systemRed `#FF453A` (destructive-token, ikke aksent).
- `sw.js` cache: `sportivista-v1-2` → `sportivista-v1-3`.
- Merkelåsen «Sportivista» + amber kolon, must-see-prikk (amber) og ærlighets-reglene («–» for ukjent) urørt.

**DESIGN.md § Cross-surface + intro:** oppdatert til at web nå følger baseline-tokenene fullt ut (unntaket lukket). Dokumentet er ellers ikke omskrevet.

## Verifisering

- `npx vitest run --maxWorkers=1` → **475/475 grønn** (37 filer).
- Skjermbilder (Playwright, `deviceScaleFactor: 2`) — sett og godkjent:
  - `index` mørk @390, lys @390, mørk @1280 (bred)
  - `rediger` mørk @390, lys @390
  - `activity` mørk @390
  - System-font, ny mørk (true-black) og lys (grouped-grey) palett, amber-aksent, merkelås intakt, ingen overflow/trunkering/kontrastbrudd; single-column bevart på bred visning.
  - Filer: `scratchpad/index-{dark,light}-390.png`, `scratchpad/index-dark-1280.png`, `scratchpad/{rediger-dark,rediger-light,activity-dark}-390.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)