### PR TITLE
WP-90: Kanal-korrekthets-kjeden (golf-tier + verified-wins + skill)

### DIFF
--- a/.claude/skills/norwegian-rights/SKILL.md
+++ b/.claude/skills/norwegian-rights/SKILL.md
@@ -37,15 +37,23 @@ known URL per broadcaster and won't clobber it with the generic landing.
 
 ## Football
 - Premier League → **TV 2 Play / TV 2 Sport Premium** [solid]
-- La Liga → **TV 2 Play** [verify]
+- La Liga → **TV 2 Play** [solid] (TV 2 renewed the Norwegian rights through summer 2030 — NTB press release kommunikasjon.ntb.no/pressemelding/18978442; the Disney+/ESPN shift is DK/SE/FI/IS only, not Norway; verified 2026-07-18)
 - Champions League / Europa League → **TV 2 Play** [solid]
 - OBOS-ligaen + Eliteserien → **TV 2 Play** [solid]
 - FIFA World Cup 2026 → **NRK + TV 2** (shared, per-match split) [verify per match]
 - Cross-check every football entry against `docs/data/tv-listings.json` when present.
 
 ## Golf
-- PGA Tour, DP World Tour, Masters, PGA Championship, The Open, US Open, Ryder Cup → **Viaplay** [solid]
-- Some overlap with **Discovery+/Eurosport** for majors [verify]
+Rights are **tiered for 2026** — the old "all golf → Viaplay" is WRONG and caused the
+Corales Puntacana revert-war (verify kept amending the channel to HBO Max, the fetcher
+map kept reverting it to Viaplay). Warner Bros. Discovery took ordinary PGA Tour +
+two majors; Viaplay keeps the other two majors + DP World Tour. Verified 2026-07-18.
+- Ordinary **PGA Tour** (incl. opposite-field events, e.g. Corales Puntacana) → **HBO Max (Sport) / Eurosport Norge** (WBD) [solid] — hbomax.com/no lists Corales/3M Open/Rocket Classic. Viaplay LOST PGA Tour for 2026.
+- **The Open Championship** + **US Open** → **Viaplay** [solid]
+- **DP World Tour** → **Viaplay** [verify] (golferen.no: Viaplay holds parts of DP World Tour)
+- **Ryder Cup** → **Viaplay** [verify]
+- **The Masters** → **Discovery+ / Max** (WBD) [solid] — WBD press release (presse.warnerbrosdiscovery.no)
+- **PGA Championship** → **Discovery+ / Max** (WBD) [verify]
 
 ## Motorsport
 - Formula 1 (all sessions) → **Viaplay** [solid]
@@ -61,8 +69,13 @@ known URL per broadcaster and won't clobber it with the generic landing.
 - Cross-country, ski jumping, nordic combined (FIS World Cup) → **NRK** [solid] through 2025/26; from season 2026/27 **TV 2 + Viaplay** share FIS World Cup rights [verify] (NTB press release Dec 2025, kommunikasjon.ntb.no/pressemelding/18377092; noted 2026-07-03)
 - Alpine (FIS World Cup) → **Viaplay** [verify]
 
+## Athletics (friidrett)
+- Wanda Diamond League (incl. Bislett Games) → **NRK** [solid] — NRK holds the rights 2025–2029 (14 meets/season + Bislett), acquired from Infront; NTB press release kommunikasjon.ntb.no/pressemelding/18535635 (announced 2025-05-22, verified 2026-07-18). NRK also has friidretts-EM 2026, VM t.o.m. 2029, and OL t.o.m. 2032.
+
 ## Cycling
 - Tour de France → **TV 2 Play** [solid] (TV 2 deal covers 2026–2030 per NTB press release; hjelp.tv2.no confirms TV 2 Direkte + TV 2 Play; Eurosport Norge reportedly shares 2026 rights per cyclingweekly.com [verify]; confirmed 2026-07-03). **Owner preference: show TV 2 Play only** for the Tour — don't re-add Max/Eurosport as a "+1" even though WBD carries the opening hour (they follow it on TV 2 Play).
+- Arctic Race of Norway → **TV 2 / TV 2 Play** [solid] (all stages live on TV 2 Direkte + Play — TV2 Sykkel's own announcement; also Eurosport Norge/Max internationally; verified 2026-07-18)
+- PostNord Tour of Denmark (Danmark Rundt) → **Norwegian broadcaster NOT confirmed for 2026** [verify] (historically Eurosport Norge/Max; DR/DRTV is the Danish holder). Leave `streaming` empty with an honest note until confirmed.
 - Other UCI races → [verify per event]
 
 ## Chess

--- a/PLAN.md
+++ b/PLAN.md
@@ -96,7 +96,7 @@ mennesket, aldri av en agent.
 | WP-83 | Navigasjon (NavigationStack) + Deg-skjerm | 0F | WP-81,WP-82 | ✅ merget (#293; samlet bølge-3-verif. grønn m/ #292) — agenda i `NavigationStack` + `gearshape`→Deg; v2-header-glyfer (`»_`/`◐`/klokke) fjernet; hjelperens resultat = native `.sheet` (detents); `AssistantPanel` slanket til samtale/resultat; ny `Profile/DegView.swift` re-hjemmer profil/minne/forsto-ikke/del/varsel/tema/nullstill/eval; alle 4 schemes bygger, 529 unit + 13/13 vektorer bit-like, UI-flyter (Deg-nav/tema/reset/sheet) grønne |
 | WP-84 | Widget token-paritet (web utsatt) | 0F | WP-80 | ✅ widget merget (#294) — WidgetKit av `zenjiMono`-shimen + deprecated farge-aliaser, over på `Font.zenji`/`zenjiTabular` + semantiske tokens; alle 4 schemes bygger, 529 unit. **Web-delen (`docs/css` + `theme.js`) utsatt til rebrandingen** (eierbeslutning 17.07 — web reskin'es uansett da) |
 | WP-85 | Baseline-designsystem + HIG-gate (promoter DESIGN.md) | 0F | WP-80,WP-81,WP-82,WP-83,WP-84 | ✅ merget (#295) — 105 font + 121 farge-kall migrert over de 4 siste filene, `zenjiMono`-shim + aliaser fjernet (null treff), HIG-gate `tests/ios-dynamic-type-gate.test.js` (dekker Zenji+ZenjiWidget), `DESIGN-BASELINE.md`→`DESIGN.md` promotert. Fable 5-sluttreview: KLAR (F1–F3 fikset i PR). Samlet verif.: npm+gate, 4 schemes, 526 unit + 12 UI + 13/13 vektorer |
-| WP-90 | Kanal-korrekthets-kjeden (golf/carry-forward/skill) | 0G | – | ⬜ |
+| WP-90 | Kanal-korrekthets-kjeden (golf/carry-forward/skill) | 0G | – | 🔬 |
 | WP-91 | CI-nervesystemet (403/push-auth/skill-write) — beskyttede stier | 0G | – | ⬜ |
 | WP-92 | Relevans-gaten (chess/esport + iOS-låssteg) | 0G | – | ⬜ |
 | WP-93 | Vaktene (grader/gap-detektor/kalibrering) | 0G | – | ⬜ |

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -193,6 +193,54 @@ const CARRY_FORWARD_FIELDS = [
 	"participants",
 	"summary",
 ];
+// A verified streaming channel must beat a *non-empty* default — not just fill an
+// empty one. The carry-forward above only fills gaps, and the streaming-resolution
+// pass further down re-derives the channel from the deterministic rights map
+// (`resolveStreaming`) on every rebuild. So when that map hard-codes the WRONG (but
+// confident, non-tentative) channel, it silently overwrites the verify agent's
+// correction every hour: the Corales Puntacana revert-war (the golf map emitted
+// Viaplay while verify had amended the channel to HBO Max — reverted for 5+ days).
+// Fix: when the previous event carries a *fresh* verify decision
+// (`confirmed`/`amended` within the TTL) whose channel differs from what the map
+// re-derives, the verified channel wins (enforced in the streaming-resolution pass).
+// The TTL lets a genuinely CHANGED value (a real rights move, or a corrected map
+// default) reclaim the field once the stale verification ages out — verify
+// re-checks near-term events daily, so a still-true decision is refreshed long
+// before it expires.
+const VERIFICATION_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+function verifiedDecisionIsFresh(prev, now) {
+	if (!prev) return false;
+	if (prev.verificationStatus !== "confirmed" && prev.verificationStatus !== "amended") return false;
+	const verifiedAt = Date.parse(prev.verifiedAt);
+	// No usable timestamp ⇒ can't establish freshness ⇒ don't override the map.
+	if (!Number.isFinite(verifiedAt)) return false;
+	return now - verifiedAt <= VERIFICATION_TTL_MS;
+}
+// Which broadcaster a `verificationSources` URL corroborates — used to spot a
+// STALE revert-war casualty: an event whose stored `streaming` array is the wrong
+// channel (the old confident-but-wrong map wrote it AFTER verify recorded the right
+// answer in its sources/summary), so the array must NOT be trusted over the
+// corrected map. Distinctive domain/name tokens only (no generic "sport"/"tv").
+const PLATFORM_SOURCE_TOKENS = [
+	{ match: /viaplay|v sport/, tokens: ["viaplay"] },
+	{ match: /hbo\s*max/, tokens: ["hbomax", "hbo-max"] },
+	{ match: /eurosport/, tokens: ["eurosport"] },
+	{ match: /discovery/, tokens: ["discoveryplus", "discovery.no", "presse.discovery", "warnerbrosdiscovery"] },
+	{ match: /\bmax\b/, tokens: ["max.com"] },
+	{ match: /nrk/, tokens: ["nrk.no"] },
+	{ match: /tv\s*2/, tokens: ["tv2.no", "tv 2"] },
+];
+function streamingBackedBySources(streaming, sources) {
+	if (!Array.isArray(streaming) || !Array.isArray(sources) || !sources.length) return false;
+	const src = sources.join(" ").toLowerCase();
+	for (const c of streaming) {
+		const p = ((c && c.platform) || "").toLowerCase();
+		for (const { match, tokens } of PLATFORM_SOURCE_TOKENS) {
+			if (match.test(p) && tokens.some((t) => src.includes(t))) return true;
+		}
+	}
+	return false;
+}
 // Fuzzy "same event" check, to de-dupe an ai-research event against a static one
 // when a sport|title|time key misses them. Two ways two sources point at one event:
 //   • "title": same sport + ≥2 shared title words (or one title's words ⊆ the
@@ -379,13 +427,16 @@ if (Array.isArray(previousEvents)) {
 // without this the hourly rebuild would overwrite it with the guess again.
 const prevConfirmedStreaming = new Map();
 const prevStreamingByKey = new Map();
+const prevByKey = new Map();
 if (Array.isArray(previousEvents)) {
 	for (const prev of previousEvents) {
+		const key = `${prev.sport}|${prev.title}|${prev.time}`;
+		prevByKey.set(key, prev);
 		const s = prev.streaming;
 		if (Array.isArray(s) && s.length) {
-			prevStreamingByKey.set(`${prev.sport}|${prev.title}|${prev.time}`, s);
+			prevStreamingByKey.set(key, s);
 			if (!s.some((c) => c && c.tentative)) {
-				prevConfirmedStreaming.set(`${prev.sport}|${prev.title}|${prev.time}`, s);
+				prevConfirmedStreaming.set(key, s);
 			}
 		}
 	}
@@ -435,6 +486,7 @@ function upgradeLanding(streaming) {
 // Resolve streaming to Norwegian channels — prefer REAL tvkampen.com listings
 // for football, fall back to the deterministic rights map (never FOX/ESPN).
 const tvListings = readJsonIfExists(path.join(dataDir, "tv-listings.json"))?.listings || [];
+const nowMs = Date.now();
 let fromTv = 0;
 let keptConfirmed = 0;
 for (const e of all) {
@@ -443,7 +495,25 @@ for (const e of all) {
 	const resolved = resolveStreaming(e, tvListings);
 	const resolvedTentative = !resolved.length || resolved.some((c) => c && c.tentative);
 	const priorConfirmed = prevConfirmedStreaming.get(key);
-	if (resolvedTentative && priorConfirmed) {
+	const prevEvent = prevByKey.get(key);
+	// A fresh verify decision (confirmed/amended within the TTL) wins over the map's
+	// re-derived channel when the two DIFFER — otherwise a confident-but-wrong map
+	// entry clobbers the correction every rebuild (the Corales revert-war). Stale
+	// verifications age out (TTL) so a corrected map default can reclaim the field.
+	const verifiedFresh =
+		priorConfirmed &&
+		verifiedDecisionIsFresh(prevEvent, nowMs) &&
+		JSON.stringify(priorConfirmed) !== JSON.stringify(resolved);
+	// …but if the event's OWN verification sources corroborate the (corrected) map's
+	// channel and NOT the stored array, the array is a stale revert-war casualty —
+	// the old wrong map overwrote it after verify recorded the right answer. Trust
+	// the corrected map, not the leftover array (the actual live Corales state:
+	// streaming=Viaplay, but sources=hbomax.com + summary=HBO Max).
+	const arrayIsStaleCasualty =
+		verifiedFresh &&
+		streamingBackedBySources(resolved, prevEvent?.verificationSources) &&
+		!streamingBackedBySources(priorConfirmed, prevEvent?.verificationSources);
+	if (priorConfirmed && (resolvedTentative || (verifiedFresh && !arrayIsStaleCasualty))) {
 		e.streaming = priorConfirmed; // keep the confirmed channel, don't re-guess
 		keptConfirmed++;
 	} else {

--- a/scripts/fetch/golf.js
+++ b/scripts/fetch/golf.js
@@ -5,15 +5,41 @@ import { fetchJson, iso, normalizeToUTC, espnDateRange } from "../lib/helpers.js
 import { validateESPNScoreboard } from "../lib/response-validator.js";
 import { fetchPGATourField, fetchPGATourTeeTimes, tournamentNameMatches } from "../lib/pgatour-scraper.js";
 
-// Norwegian streaming for golf (was lib/norwegian-streaming.js — v2 keeps a local map)
-function getNorwegianStreaming(_sport, tourName = "") {
-	if (/masters/i.test(tourName)) {
-		return [{ platform: "Discovery+", url: "https://www.discoveryplus.no", type: "streaming" }];
+// Norwegian golf broadcast rights, 2026 season (web-verified 2026-07-18 — see
+// `.claude/skills/norwegian-rights/SKILL.md` "Golf" for sources). The rights are
+// TIERED, not a flat "all golf → Viaplay" (the pre-2026 assumption that produced
+// the Corales Puntacana revert-war):
+//   • Ordinary PGA Tour (incl. opposite-field events, e.g. Corales) → HBO Max
+//     (Sport) / Eurosport Norge — Warner Bros. Discovery took PGA Tour for 2026;
+//     Viaplay LOST it. (hbomax.com/no lists Corales/3M Open/Rocket Classic.)
+//   • The Open Championship + US Open → Viaplay.
+//   • DP World Tour + Ryder Cup → Viaplay.
+//   • The Masters + PGA Championship → Warner Bros. Discovery (Discovery+/Max).
+// Tier is decided by the event name (majors ride the PGA Tour scoreboard), with
+// the tour name as a fallback for DP World Tour events.
+const GOLF_STREAM = {
+	viaplay: { platform: "Viaplay", url: "https://viaplay.no", type: "streaming" },
+	hbomax: { platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour", type: "streaming" },
+	eurosport: { platform: "Eurosport Norge", url: "https://www.hbomax.com/no/no/sports/pga-tour", type: "streaming" },
+	discovery: { platform: "Discovery+", url: "https://www.discoveryplus.no", type: "streaming" },
+};
+
+function getNorwegianStreaming(_sport, tourName = "", eventName = "") {
+	const name = `${eventName} ${tourName}`.toLowerCase();
+	// The Masters + PGA Championship → Warner Bros. Discovery (Discovery+/Max).
+	if (/\bmasters\b|pga championship/.test(name)) {
+		return [GOLF_STREAM.discovery];
 	}
-	return [
-		{ platform: "Viaplay", url: "https://viaplay.no", type: "streaming" },
-		{ platform: "Discovery+", url: "https://www.discoveryplus.no", type: "streaming" },
-	];
+	// The Open Championship + US Open → Viaplay.
+	if (/\bthe open\b|open championship|british open|u\.?s\.? open/.test(name)) {
+		return [GOLF_STREAM.viaplay];
+	}
+	// DP World Tour + Ryder Cup → Viaplay.
+	if (tourName === "DP World Tour" || /dp world|ryder cup/.test(name)) {
+		return [GOLF_STREAM.viaplay];
+	}
+	// Ordinary PGA Tour (incl. opposite-field, e.g. Corales) → HBO Max / Eurosport.
+	return [GOLF_STREAM.hbomax, GOLF_STREAM.eurosport];
 }
 
 // Load Norwegian golfers from config
@@ -137,7 +163,7 @@ function buildGolfTournament(tourName, ev, venue, { norwegian, norwegianPlayers,
 		endTime: tournamentEndTime(startTime),
 		venue,
 		sport: "golf",
-		streaming: getNorwegianStreaming("golf", tourName),
+		streaming: getNorwegianStreaming("golf", tourName, ev.name),
 		norwegian,
 		norwegianPlayers,
 		featuredGroups,
@@ -374,7 +400,7 @@ export async function fetchGolfESPN() {
 }
 
 // Exported for testing
-export { playerNameMatches, filterNorwegiansAgainstField, buildFeaturedGroups, buildGolfTournament };
+export { playerNameMatches, filterNorwegiansAgainstField, buildFeaturedGroups, buildGolfTournament, getNorwegianStreaming };
 
 // Run if executed directly
 if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -12,6 +12,7 @@ const CH = {
 	nrk: { platform: "NRK", url: "https://tv.nrk.no/direkte" },
 	discovery: { platform: "Discovery+", url: "https://www.discoveryplus.no" },
 	eurosport: { platform: "Eurosport", url: "https://www.eurosport.no" },
+	hbomax: { platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour" },
 	max: { platform: "Max", url: "https://www.max.com" },
 };
 
@@ -84,7 +85,16 @@ export function norwegianRights(ev) {
 		if (isNationVsNation(ev)) return [WC_SHARED]; // landskamp / WC labelled only "International"
 		return [];
 	}
-	if (sport === "golf") return /masters/.test(hay) ? [CH.discovery] : [CH.viaplay];
+	if (sport === "golf") {
+		// Tiered rights, 2026 season (web-verified 2026-07-18; see the golf section of
+		// .claude/skills/norwegian-rights/SKILL.md). NOT a flat "all golf → Viaplay":
+		// Warner Bros. Discovery took ordinary PGA Tour + the Masters/PGA Championship,
+		// Viaplay keeps The Open + US Open + DP World Tour + Ryder Cup.
+		if (/masters|pga championship/.test(hay)) return [CH.discovery];
+		if (/\bthe open\b|open championship|british open|u\.?s\.? open/.test(hay)) return [CH.viaplay];
+		if (/dp world|ryder cup/.test(hay)) return [CH.viaplay];
+		return [CH.hbomax, CH.eurosport]; // ordinary PGA Tour (incl. opposite-field, e.g. Corales)
+	}
 	if (sport === "f1" || sport === "formula1") return [CH.viaplay];
 	// Tour de France 2026 rights are shared: TV 2 (Play/Direkte) + WBD (Max/Eurosport
 	// carries the first hour of each stage). The owner follows the Tour on TV 2 Play,

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -138,6 +138,68 @@ describe("build-events", () => {
 		expect(derby.verificationStatus).toBe("confirmed");
 	});
 
+	// The Corales revert-war fix. Helper: a golf event the rights map sends to X,
+	// with a prior events.json carrying a verify amendment to Y.
+	const runGolfRevertWar = ({ title, tournament, priorStreaming, verifiedAt, verificationSources }) => {
+		const time = future(2);
+		fs.writeFileSync(
+			path.join(dataDir, "golf.json"),
+			JSON.stringify({ tournaments: [{ name: tournament, events: [
+				{ title, time, norwegian: true, norwegianPlayers: [{ name: "Someone" }] },
+			] }] })
+		);
+		fs.writeFileSync(
+			path.join(dataDir, "events.json"),
+			JSON.stringify([
+				{
+					sport: "golf", tournament, title, time,
+					norwegian: true, norwegianPlayers: [{ name: "Someone" }],
+					streaming: priorStreaming,
+					verificationStatus: "amended",
+					verifiedAt,
+					verificationSources,
+				},
+			])
+		);
+		const golf = runBuild().find((e) => e.title === title);
+		expect(golf).toBeTruthy();
+		return golf.streaming.map((s) => s.platform);
+	};
+
+	it("a fresh verify amendment survives a differing confident map default (verified-wins)", () => {
+		// The Open maps to Viaplay; verify amended to HBO Max and its SOURCES back HBO Max.
+		const platforms = runGolfRevertWar({
+			title: "The Open Championship", tournament: "PGA Tour",
+			priorStreaming: [{ platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour" }],
+			verifiedAt: new Date().toISOString(),
+			verificationSources: ["https://www.hbomax.com/no/no/sports/pga-tour"],
+		});
+		expect(platforms).toEqual(["HBO Max (Sport)"]); // verify's correction wins over the map's Viaplay
+	});
+
+	it("lets the map default reclaim the channel once the verification ages past its TTL", () => {
+		const platforms = runGolfRevertWar({
+			title: "The Open Championship", tournament: "PGA Tour",
+			priorStreaming: [{ platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour" }],
+			verifiedAt: new Date(Date.now() - 20 * 86400000).toISOString(), // 20 days — past the 14-day TTL
+			verificationSources: ["https://www.hbomax.com/no/no/sports/pga-tour"],
+		});
+		expect(platforms).toEqual(["Viaplay"]); // stale ⇒ the fresh map default wins again
+	});
+
+	it("discards a stale revert-war array the map + the event's own sources contradict (the live Corales state)", () => {
+		// The actual corrupt live state: streaming=Viaplay, but verificationSources
+		// point at hbomax.com and the map now (correctly) says HBO Max. The leftover
+		// Viaplay array must NOT be re-pinned — the corrected map wins.
+		const platforms = runGolfRevertWar({
+			title: "Corales Puntacana Championship", tournament: "PGA Tour",
+			priorStreaming: [{ platform: "Viaplay", url: "https://viaplay.no/no-no/sport" }],
+			verifiedAt: new Date().toISOString(),
+			verificationSources: ["https://golferen.no/tv-kampguiden-til-golfarrangementer/", "https://www.hbomax.com/no/en/sports/pga-tour"],
+		});
+		expect(platforms).toEqual(["HBO Max (Sport)", "Eurosport"]); // corrected map, not the stale Viaplay
+	});
+
 	it("upgrades a generic landing URL to a deeper per-event URL from the previous build", () => {
 		const time = future(2);
 		// biathlon → rights map returns the NRK sport-section landing (tv.nrk.no/direkte, depth 1).

--- a/tests/golf.test.js
+++ b/tests/golf.test.js
@@ -4,6 +4,7 @@ import {
 	filterNorwegiansAgainstField,
 	buildFeaturedGroups,
 	buildGolfTournament,
+	getNorwegianStreaming,
 } from "../scripts/fetch/golf.js";
 
 // --- playerNameMatches ---
@@ -100,8 +101,8 @@ describe("buildGolfTournament", () => {
 				venue: "Test National",
 				sport: "golf",
 				streaming: [
-					{ platform: "Viaplay", url: "https://viaplay.no", type: "streaming" },
-					{ platform: "Discovery+", url: "https://www.discoveryplus.no", type: "streaming" },
+					{ platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour", type: "streaming" },
+					{ platform: "Eurosport Norge", url: "https://www.hbomax.com/no/no/sports/pga-tour", type: "streaming" },
 				],
 				norwegian: true,
 				norwegianPlayers: [{ name: "Kristoffer Ventura", teeTime: null, teeTimeUTC: null, status: null }],
@@ -131,5 +132,39 @@ describe("buildGolfTournament", () => {
 		expect(out.events[0].streaming).toEqual([
 			{ platform: "Discovery+", url: "https://www.discoveryplus.no", type: "streaming" },
 		]);
+	});
+});
+
+// --- getNorwegianStreaming (2026 tiered golf rights) ---
+
+describe("getNorwegianStreaming (golf, 2026 tiers)", () => {
+	const platforms = (name, tour = "PGA Tour") =>
+		getNorwegianStreaming("golf", tour, name).map((s) => s.platform);
+
+	it("routes ordinary PGA Tour events (incl. Corales) to HBO Max / Eurosport, NOT Viaplay", () => {
+		// This is the Corales revert-war class: the flat Viaplay default was wrong.
+		expect(platforms("Corales Puntacana Championship")).toEqual(["HBO Max (Sport)", "Eurosport Norge"]);
+		expect(platforms("3M Open")).toEqual(["HBO Max (Sport)", "Eurosport Norge"]);
+		expect(platforms("Rocket Classic")).toEqual(["HBO Max (Sport)", "Eurosport Norge"]);
+	});
+
+	it("keeps The Open Championship + US Open on Viaplay", () => {
+		expect(platforms("The Open")).toEqual(["Viaplay"]);
+		expect(platforms("The Open Championship")).toEqual(["Viaplay"]);
+		expect(platforms("U.S. Open")).toEqual(["Viaplay"]);
+	});
+
+	it("does not mistake a regular 'Open' event for a major", () => {
+		expect(platforms("Genesis Scottish Open")).toEqual(["HBO Max (Sport)", "Eurosport Norge"]);
+		expect(platforms("RBC Canadian Open")).toEqual(["HBO Max (Sport)", "Eurosport Norge"]);
+	});
+
+	it("routes DP World Tour to Viaplay", () => {
+		expect(platforms("BMW International Open", "DP World Tour")).toEqual(["Viaplay"]);
+	});
+
+	it("routes The Masters + PGA Championship to Warner Bros. Discovery", () => {
+		expect(platforms("The Masters")).toEqual(["Discovery+"]);
+		expect(platforms("PGA Championship")).toEqual(["Discovery+"]);
 	});
 });

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -38,15 +38,30 @@ describe("normalizeStreaming", () => {
 
 import { resolveStreaming, matchTvListing } from "../scripts/lib/norwegian-rights.js";
 
-describe("Viaplay sports (golf, F1) link to the sport section, not the homepage", () => {
+describe("Viaplay's F1 links to the sport section, not the homepage", () => {
 	it("F1 resolves to Viaplay's sport section", () => {
 		const s = normalizeStreaming({ sport: "f1", tournament: "Belgian Grand Prix" });
 		expect(s[0].platform).toBe("Viaplay");
 		expect(s[0].url).toBe("https://viaplay.no/no-no/sport");
 	});
-	it("golf resolves to Viaplay's sport section", () => {
-		const s = normalizeStreaming({ sport: "golf", tournament: "PGA Tour" });
-		expect(s[0].url).toBe("https://viaplay.no/no-no/sport");
+});
+
+describe("golf rights are tiered for 2026 (not a flat Viaplay)", () => {
+	it("ordinary PGA Tour → HBO Max (Sport) / Eurosport, NOT Viaplay (the Corales class)", () => {
+		const s = normalizeStreaming({ sport: "golf", tournament: "PGA Tour", title: "Corales Puntacana Championship" });
+		expect(s.map((c) => c.platform)).toEqual(["HBO Max (Sport)", "Eurosport"]);
+		expect(s.some((c) => c.platform === "Viaplay")).toBe(false);
+	});
+	it("The Open + US Open stay on Viaplay", () => {
+		expect(normalizeStreaming({ sport: "golf", title: "The Open Championship" })[0].platform).toBe("Viaplay");
+		expect(normalizeStreaming({ sport: "golf", title: "U.S. Open" })[0].platform).toBe("Viaplay");
+	});
+	it("DP World Tour → Viaplay", () => {
+		expect(normalizeStreaming({ sport: "golf", tournament: "DP World Tour", title: "BMW International Open" })[0].platform).toBe("Viaplay");
+	});
+	it("The Masters + PGA Championship → Warner Bros. Discovery", () => {
+		expect(normalizeStreaming({ sport: "golf", title: "The Masters" })[0].platform).toBe("Discovery+");
+		expect(normalizeStreaming({ sport: "golf", title: "PGA Championship" })[0].platform).toBe("Discovery+");
 	});
 });
 


### PR DESCRIPTION
## WP-90 · Kanal-korrekthets-kjeden (HASTER — brukersynlig feil nå)

Fikser det brutte kjerneløftet «riktig norsk kanal». Corales Puntacana viste
`Viaplay` på tavla mens eventets egne `verificationSources` (hbomax.com) og summary
sa HBO Max — en 5+ dagers revert-krig.

### Funn → fiks

| Funn | Rotårsak | Fiks |
|---|---|---|
| Golf-kanaler feil (flat Viaplay) | `golf.js` (~l.8–16) hardkodet Viaplay for all ikke-Masters golf | `golf.js`: tier-splitt etter event-/tour-navn |
| **Verify-rettelser klobbes hver time** | Den EGENTLIGE klobberen er `norwegian-rights.js` `norwegianRights()` (golf → flat Viaplay), som `build-events` anvender via `resolveStreaming` og som en *confident* (ikke-tentativ) kart-verdi overskrev selv verify sin `confirmed`-verdi | `norwegianRights()`: samme tier-splitt (rot-fiksen). `build-events`: **verified-wins m/TTL** — en fersk (≤14 d) `confirmed`/`amended` kanal vinner over en *avvikende* confident kart-default; TTL slipper en reelt endret verdi gjennom når verifiseringen eldes |
| Corales-motsigelsen på tavla | Den lagrede `streaming`-arrayen (Viaplay) er en foreldet revert-krig-rest — verify skrev riktig svar i sources/summary, gammelt feil-kart overskrev arrayen etterpå | verified-wins er **guardet av `verificationSources`-korroborasjon**: når kildene bakker kartets kanal og IKKE den lagrede arrayen, er arrayen en foreldet rest → korrigert kart vinner (ikke re-pin av Viaplay) |
| Skillen sa fortsatt Viaplay | `norwegian-rights/SKILL.md` l.~47 | Golf-blokka omskrevet + de fire utkastede rettelsene (golf-tier, La Liga, Diamond League/NRK, Arctic Race/Tour of Denmark) |

### Web-verifiserte norske 2026-rettigheter (verifisert 18.07)

- **Vanlig PGA Tour** (inkl. opposite-field, f.eks. Corales) → **HBO Max (Sport)/Eurosport Norge** [solid] — hbomax.com/no lister Corales/3M Open/Rocket Classic; WBD overtok PGA Tour, Viaplay MISTET den for 2026.
- **The Open + US Open** → **Viaplay** [solid].
- **DP World Tour + Ryder Cup** → **Viaplay** [verify] (golferen.no: Viaplay har deler av DP World Tour).
- **The Masters + PGA Championship** → **WBD (Discovery+/Max)** — Masters [solid] (WBD-pressemelding), PGA Championship [verify].
- **La Liga** → **TV 2 Play** [solid] — TV 2 fornyet t.o.m. sommeren 2030 (NTB 18978442); Disney+/ESPN-skiftet gjelder DK/SE/FI/IS, ikke Norge.
- **Diamond League** (inkl. Bislett) → **NRK** [solid] — NRK 2025–2029 (NTB 18535635); også friidretts-EM 2026, VM t.o.m. 2029, OL t.o.m. 2032.
- **Arctic Race of Norway** → **TV 2 / TV 2 Play** [solid] — alle etapper live på TV 2 Direkte + Play (TV2 Sykkels egen kunngjøring).
- **PostNord Tour of Denmark** → norsk kringkaster **IKKE bekreftet for 2026** [verify] — la `streaming` stå tom m/ærlig note.

### Hvorfor ingen manuell redigering av `events.json`

Rørte den ikke. Riktige data flyter inn ved neste pipeline-kjøring: `norwegianRights()`
gir nå HBO Max som confident default for Corales, og verified-wins-guarden gjør at den
foreldede Viaplay-arrayen viker for det korrigerte kartet. Bekreftet lokalt:
`node scripts/build-events.js` → **Corales = «HBO Max (Sport) + Eurosport»**, The Open forblir Viaplay.

### Verifisering
- `npx vitest run --maxWorkers=1` → **486 passert (37 filer)**, inkl. nye golf-tier-, norwegian-rights-tier- og tre build-events-tester (verified-wins overlever; TTL-utløp → kart vinner; foreldet Corales-rest → korrigert kart vinner). `tests/feed-vectors` uendret grønn (relevans urørt).
- `node scripts/build-events.js && node scripts/validate-events.js` → rent (49 events, 0 errors). `docs/`-endringer forkastet, ikke committet.

Statusrad WP-90 ⬜→🔬 i samme PR. **Merger ikke selv.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
