### PR TITLE
WP-94: drifts-småplukk (kvote-gate-ferskhet, validate-degradering, UCL-placeholder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ npm-debug.log*
 !/docs/data/manifest.json
 !/docs/data/app-version.json
 !/docs/data/entities.json
+!/docs/data/build-alert.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/PLAN.md
+++ b/PLAN.md
@@ -100,7 +100,7 @@ mennesket, aldri av en agent.
 | WP-91 | CI-nervesystemet (403/push-auth/skill-write) — beskyttede stier | 0G | – | ✅ merget (#301, eier-instruert) — rotårsak A+B: claude-code-action bytter GITHUB_TOKEN med OIDC-app-token (mangler actions:write, trekkes tilbake etter steget) ⇒ eskalering via sentinel + eget steg m/ ekte token + escalation-failed-Issue-alarm; loggcommit re-peker origin; C: skill-write-«blokkering» avlivet som vandrehistorie (denials var Bash-kall, Edit var alltid tillatt) — prompter presisert. VERIFISERES i drift: neste scout/coverage-critic/self-repair-kjøringer (ingen escalation-failed-Issue + logg-commits lander + skill-writes committes) |
 | WP-92 | Relevans-gaten (chess/esport + iOS-låssteg) | 0G | – | ⬜ |
 | WP-93 | Vaktene (grader/gap-detektor/kalibrering) | 0G | – | ⬜ |
-| WP-94 | Drifts-småplukk (kvote-gate/validate-degradering/venue/UCL) | 0G | – | ⬜ |
+| WP-94 | Drifts-småplukk (kvote-gate/validate-degradering/venue/UCL) | 0G | – | 🔬 PR åpen — kvote-gate-ferskhet + validate-degradering + UCL-placeholder-regel (venue-synk er WP-93/verify.md sitt territorium, ikke med her) |
 
 ---
 
@@ -951,12 +951,32 @@ menneskelig merge.
 - **Aksept:** rubrikk-test som beviser Corales-klassen fanges; gap-test for
   Gstaad-klassen; cyclingstage-reliability normaliseres.
 
-### WP-94 · Drifts-småplukk
+### WP-94 · Drifts-småplukk — 🔬 PR åpen
 - **Innhold:** kvote-gate: fersk sjekk før kritisk-tier-kall + grasiøst
   «skippet: kvote» i stedet for hard feil; validate-events-feil degraderer
   (behold forrige gyldige data + alarm) i stedet for å fryse timen; verify-
   kontrakten synker `venue` med verifisert summary; UCL tracked-placeholder-
   regel (hver alwaysTrack-turnering har entry).
+- **Levert i denne PR-en:** (1) `usage-gate.js` henter selv en fersk
+  ratelimit-avlesning (gjenbruker `check-usage.js`) når den cachede
+  `usage-state.json`-snapshoten er eldre enn ~10 min, med fail-open bevart og
+  `source` (fresh/cached-fresh/cached-stale-fetch-unavailable/none) logget i
+  gate-outputen — NB: live-lesningen trenger `CLAUDE_CODE_OAUTH_TOKEN` i
+  akkurat det workflow-steget, som i dag kun `usage-monitor.yml` har; de
+  kritiske agent-workflowene (research/verify/scout) må selv eksponere den til
+  usage-gate-steget for at fresh-veien faktisk skal slå inn — det er en
+  `.github/workflows/**`-endring (beskyttet sti), ikke gjort her, degraderer nå
+  trygt til det gamle cached/fail-open-oppførselen. (2) `build-events.js`
+  validerer selv (gjenbruker `validate-events.js` sin nye eksporterte
+  `validateEvents()`) FØR den skriver `events.json`; ved brudd beholdes forrige
+  gyldige fil urørt + `docs/data/build-alert.json` skrives (ok:true/false,
+  persistent helse-signal, ikke bare en engangs-feillogg) — scriptet exit(0)
+  uansett, så pipeline-jobben (og det påfølgende harde `validate-events.js`-
+  steget, som da re-validerer den BEHOLDTE gode filen) fortsetter uavbrutt. (3)
+  `research.md` Steg 1 presisert: hver `alwaysTrack.tournaments`-oppføring
+  krever en tracked.json-entry, av-sesong-placeholder inkludert. **Ikke i
+  denne PR-en:** `venue`/summary-synk i verify-kontrakten — det er
+  `verify.md`, WP-93 sitt territorium (parallell nabo, ikke rørt her).
 - **Aksept:** npm grønn; simulert rød kvote gir skip-not-fail; simulert
   validate-brudd publiserer forrige data med alarm.
 

--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -39,6 +39,20 @@ tracked.json. For each broad item in `interests[]`, write 1–5 concrete tracked
 entries (e.g. "Norske utøvere" → research who's competing this week).
 Drop expired entries. Every entry must have a `reason` you can defend.
 
+**Every `alwaysTrack.tournaments` entry needs a tracked.json entry — no silent
+gaps.** Check each one by name (in `tournaments` or, for a league, `leagues`)
+before moving on. If it's genuinely off-season with nothing concrete to track
+yet (e.g. UEFA Champions League group stage hasn't started), write an explicit
+**placeholder entry** anyway rather than leaving it absent — an entry that says
+"off-season, følger med" with a real `reason` (why it's dormant + when it
+resumes, e.g. group-stage draw / qualifying rounds) is the honest signal;
+silently having no entry at all reads as "nobody checked" and is exactly the
+kind of creeping gap coverage-critic can't distinguish from a missed event. A
+placeholder still needs `addedAt`/`addedBy`/`evidence` like any other entry —
+cite whatever confirms the dormant state (last season's final, or the next
+season's fixture-list-not-yet-published date) — and gets upgraded to a real
+entry (fixtures, tracked matches) the moment the tournament actually starts.
+
 ### Step 2 — Find what static APIs miss (PRIMARY VALUE)
 
 **Fan out with parallel subagents.** Delegate one scout subagent per active

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -8,6 +8,7 @@ import { writeManifest } from "./build-manifest.js";
 import { readIosCommit, buildAppVersion } from "./lib/app-version.js";
 import { fileURLToPath } from "url";
 import { writeEntities } from "./build-entities.js";
+import { validateEvents, loadEventSchema } from "./validate-events.js";
 
 const dataDir = rootDataPath();
 const configDir =
@@ -596,7 +597,72 @@ for (const e of kept) {
 	// same hash, same id across consecutive builds.
 	e.id = computeEventId(e.sport, e.title, e.time);
 }
-fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(kept, null, 2));
+// WP-94: validate the array in-process BEFORE writing it, and degrade instead
+// of freezing the hourly pipeline on a violation. static-pipeline.yml runs
+// `node scripts/validate-events.js` as its own hard step right after this
+// script — a schema/contract break there used to fail that step and abort the
+// whole job (no coverage-gaps, no calibration, no ICS, no commit/deploy for
+// that hour — see PLAN.md FASE 0G finding). That workflow file is protected
+// and out of scope here, so the fix happens on THIS side of the boundary:
+// reuse validate-events.js's own rules on the array we're about to publish; on
+// a hard error, keep the previous (already-validated) events.json on disk
+// untouched and write docs/data/build-alert.json instead of the new file.
+// This script still exits 0 either way, so the pipeline continues — and the
+// downstream validate-events.js step then re-checks the RETAINED, still-good
+// file and passes. build-alert.json is a persistent health signal (written on
+// every run, ok: true/false) rather than a one-shot failure log, so a fixed
+// build clears the alarm automatically on the next successful pass.
+const eventSchema = loadEventSchema();
+// Validate the ROUND-TRIPPED JSON, not the raw JS array: pushEvent() sets
+// several fields unconditionally to `ev.field || null`-style expressions, and
+// a few (`venue`, `meta`) straight to `ev.venue`/`ev.meta` — which is `undefined`
+// when the source data doesn't have them. JSON.stringify silently drops
+// undefined-valued keys, so that's what validate-events.js's own (file-based)
+// CLI run always saw; validating the pre-serialize object directly would see
+// literal `undefined` properties the schema doesn't expect and false-positive.
+const serialized = JSON.stringify(kept, null, 2);
+const { errors: hardErrorCount, messages: validationMessages } = validateEvents(JSON.parse(serialized), eventSchema);
+const eventsPath = path.join(dataDir, "events.json");
+const alertPath = path.join(dataDir, "build-alert.json");
+const hadPreviousGood = Array.isArray(previousEvents);
+
+if (hardErrorCount > 0) {
+	console.error(`build-events: ${hardErrorCount} validation error(s) in the freshly built array — NOT publishing it.`);
+	for (const m of validationMessages.slice(0, 20)) console.error("  " + m);
+	if (hadPreviousGood) {
+		console.error(`build-events: keeping the previous events.json (${previousEvents.length} event(s)) untouched.`);
+	} else {
+		// No previous good file to fall back on (e.g. the very first build) —
+		// nothing better is available, so publish anyway; the alarm still
+		// records the violation for a human/self-repair to pick up.
+		fs.writeFileSync(eventsPath, serialized);
+		console.error("build-events: no previous events.json to retain — published the flawed array anyway (nothing better available).");
+	}
+	fs.writeFileSync(
+		alertPath,
+		JSON.stringify(
+			{
+				ok: false,
+				checkedAt: new Date().toISOString(),
+				errorCount: hardErrorCount,
+				attemptedEventCount: kept.length,
+				retained: hadPreviousGood,
+				retainedEventCount: hadPreviousGood ? previousEvents.length : kept.length,
+				sampleErrors: validationMessages.slice(0, 10),
+			},
+			null,
+			2
+		)
+	);
+} else {
+	fs.writeFileSync(eventsPath, serialized);
+	// Refresh the healthy marker every good run, so a resolved alarm doesn't
+	// linger — the file always reflects the CURRENT state, not just failures.
+	fs.writeFileSync(
+		alertPath,
+		JSON.stringify({ ok: true, checkedAt: new Date().toISOString(), eventCount: kept.length }, null, 2)
+	);
+}
 console.log(
 	`Aggregated ${kept.length} events (${mustWatchCount} must-watch; filtered ${all.length - kept.length} past/irrelevant, of which ${droppedIrrelevant} off-interest) into events.json`
 );

--- a/scripts/check-usage.js
+++ b/scripts/check-usage.js
@@ -143,7 +143,7 @@ export function appendUsageHistory(state, dir = rootDataPath()) {
 		.filter(Boolean);
 }
 
-async function fetchUsageHeaders(token) {
+export async function fetchUsageHeaders(token) {
 	const res = await fetch("https://api.anthropic.com/v1/messages", {
 		method: "POST",
 		headers: {

--- a/scripts/usage-gate.js
+++ b/scripts/usage-gate.js
@@ -2,40 +2,108 @@
 /**
  * Governor gate: decide whether an agent should run, from docs/data/usage-state.json.
  *   node scripts/usage-gate.js <critical|optional>
- * Writes `run=true|false` to $GITHUB_OUTPUT (for a workflow step `if:`).
+ * Writes `run=true|false` (+ `source=`) to $GITHUB_OUTPUT (for a workflow step `if:`).
  *
- * FAIL-OPEN by design: missing, unparsed, or stale (>3h) state → run. The
+ * FAIL-OPEN by design: missing, unusable, or too-stale (>3h) state → run. The
  * governor must never block work because of its own gaps — it only throttles on
  * fresh, confident quota data.
  *   - skipAll (session near-exhausted / rejected) → skip every tier.
  *   - skipNiceToHave (amber/red) → skip only the "optional" tier.
+ *
+ * Freshness (WP-94): usage-monitor.yml only refreshes usage-state.json hourly, so a
+ * critical-tier agent could previously make a run/skip call on a reading up to ~1h
+ * stale — in the red windows this was built to fix, that meant hard-failing (or
+ * running straight into a rejected quota) instead of skipping gracefully. If the
+ * cached snapshot is older than FRESH_MS (~10min), the gate now attempts ONE live
+ * reading itself (reusing check-usage.js's header call) before deciding, and falls
+ * back to the cached snapshot (if not stale beyond STALE_MS) or fail-open if that
+ * also fails/is unavailable. The decision always reports which source it used:
+ * fresh | cached-fresh | cached-stale-fetch-unavailable | none.
+ *
+ * NB: the live read here needs CLAUDE_CODE_OAUTH_TOKEN in this step's env. Today
+ * only usage-monitor.yml's step exports it; the agent workflows (research/verify/
+ * scout) do not pass it to the usage-gate step, so `fetchFresh` is a no-op there
+ * until a workflow change adds it — `.github/workflows/**` is a protected path,
+ * out of scope for this change (see PR notes). Until then this degrades exactly
+ * to the previous cached/fail-open behaviour, which is safe.
  */
 import fs from "fs";
 import path from "path";
-import { rootDataPath, readJsonIfExists } from "./lib/helpers.js";
+import { pathToFileURL } from "url";
+import { rootDataPath, readJsonIfExists, iso } from "./lib/helpers.js";
+import { fetchUsageHeaders, usageStateFromHeaders } from "./check-usage.js";
 
-const STALE_MS = 3 * 60 * 60 * 1000;
-const tier = (process.argv[2] || "critical").toLowerCase();
-const state = readJsonIfExists(path.join(rootDataPath(), "usage-state.json"));
+export const FRESH_MS = 10 * 60 * 1000; // cached snapshot younger than this needs no live check
+export const STALE_MS = 3 * 60 * 60 * 1000; // cached snapshot older than this is unusable (fail-open)
 
-let run = true;
-let reason = "no usage-state (fail-open)";
-if (state && state.parsed && state.checkedAt) {
-	const ageMs = Date.now() - Date.parse(state.checkedAt);
-	if (!(ageMs >= 0) || ageMs > STALE_MS) {
-		run = true;
-		reason = `state stale/invalid (fail-open)`;
-	} else if (state.skipAll) {
-		run = false;
-		reason = `quota ${state.unifiedStatus || state.status} · session ${state.session?.percentUsed ?? "?"}%`;
-	} else if (tier === "optional" && state.skipNiceToHave) {
-		run = false;
-		reason = `conserving (${state.status}) · week ${state.week?.percentUsed ?? "?"}%`;
-	} else {
-		run = true;
-		reason = `${state.status} · session ${state.session?.percentUsed ?? "?"}% week ${state.week?.percentUsed ?? "?"}%`;
+/**
+ * Pick the state to decide on: the cache if it's fresh enough, otherwise a live
+ * reading (via the injected `fetchFresh`), otherwise the cache if it's at least
+ * not stale, otherwise nothing (fail-open). Pure apart from the injected fetch —
+ * testable with a stub `fetchFresh` and no real network/fs/clock.
+ */
+export async function resolveEffectiveState({ cached, now = Date.now(), fetchFresh } = {}) {
+	const ageMs = cached && cached.checkedAt ? now - Date.parse(cached.checkedAt) : null;
+	const cachedUsable = !!(cached && cached.parsed && cached.checkedAt && ageMs != null && ageMs >= 0);
+
+	if (cachedUsable && ageMs <= FRESH_MS) {
+		return { state: cached, source: "cached-fresh", ageMs };
+	}
+
+	let fresh = null;
+	if (fetchFresh) {
+		try {
+			fresh = await fetchFresh();
+		} catch {
+			fresh = null;
+		}
+	}
+	if (fresh && fresh.parsed) {
+		return { state: fresh, source: "fresh", ageMs: 0 };
+	}
+
+	if (cachedUsable && ageMs <= STALE_MS) {
+		return { state: cached, source: "cached-stale-fetch-unavailable", ageMs };
+	}
+	return { state: null, source: "none", ageMs };
+}
+
+/** Turn a resolved state (or null, meaning fail-open) into a run/skip decision. */
+export function decideFromState(state, tier) {
+	if (!state) return { run: true, reason: "no usable usage-state (fail-open)" };
+	if (state.skipAll) {
+		return { run: false, reason: `quota ${state.unifiedStatus || state.status} · session ${state.session?.percentUsed ?? "?"}%` };
+	}
+	if (tier === "optional" && state.skipNiceToHave) {
+		return { run: false, reason: `conserving (${state.status}) · week ${state.week?.percentUsed ?? "?"}%` };
+	}
+	return { run: true, reason: `${state.status} · session ${state.session?.percentUsed ?? "?"}% week ${state.week?.percentUsed ?? "?"}%` };
+}
+
+async function main() {
+	const tier = (process.argv[2] || "critical").toLowerCase();
+	const cached = readJsonIfExists(path.join(rootDataPath(), "usage-state.json"));
+	const now = Date.now();
+
+	const token = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+	const fetchFresh = token
+		? async () => {
+				const { status, headers } = await fetchUsageHeaders(token);
+				if (status === 429) headers["anthropic-ratelimit-unified-status"] = "rejected";
+				return usageStateFromHeaders(headers, iso(now));
+			}
+		: null;
+
+	const { state, source, ageMs } = await resolveEffectiveState({ cached, now, fetchFresh });
+	const { run, reason } = decideFromState(state, tier);
+	const ageNote = ageMs == null ? "" : `, snapshot age ${Math.round(ageMs / 60000)}m`;
+
+	console.log(`usage-gate[${tier}]: run=${run} — ${reason} [source=${source}${ageNote}]`);
+	if (process.env.GITHUB_OUTPUT) {
+		fs.appendFileSync(process.env.GITHUB_OUTPUT, `run=${run}\nsource=${source}\n`);
 	}
 }
 
-console.log(`usage-gate[${tier}]: run=${run} — ${reason}`);
-if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `run=${run}\n`);
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+	main();
+}

--- a/scripts/validate-events.js
+++ b/scripts/validate-events.js
@@ -1,124 +1,157 @@
 #!/usr/bin/env node
 import fs from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { rootDataPath } from "./lib/helpers.js";
 import { validateAgainstSchema } from "./lib/validate-schema.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const GRACE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days — matches build-events.js day navigator history window
-const dataDir = rootDataPath();
-const schemaPath = path.join(__dirname, "config", "events.schema.json");
-const eventSchema = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
-const file = path.join(dataDir, "events.json");
-if (!fs.existsSync(file)) {
-	console.error("events.json not found. Run build-events.js first.");
-	process.exit(1);
-}
-const raw = fs.readFileSync(file, "utf-8");
-let events;
-try {
-	events = JSON.parse(raw);
-} catch (e) {
-	console.error("Invalid JSON:", e.message);
-	process.exit(1);
-}
-if (!Array.isArray(events)) {
-	console.error("events.json root must be an array");
-	process.exit(1);
+export const GRACE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14 days — matches build-events.js day navigator history window
+export const SCHEMA_PATH = path.join(__dirname, "config", "events.schema.json");
+
+let _schemaCache = null;
+/** Load (and cache) the events schema — shared by this CLI and build-events.js's pre-write gate. */
+export function loadEventSchema() {
+	if (!_schemaCache) _schemaCache = JSON.parse(fs.readFileSync(SCHEMA_PATH, "utf-8"));
+	return _schemaCache;
 }
 
-let errors = 0;
-let streamingMissing = 0;
-const now = Date.now() - GRACE_WINDOW_MS; // allow tiny grace window
-const seenKeys = new Set();
-for (const ev of events) {
-	const key = ev.sport + ev.tournament + ev.title + ev.time;
-	if (seenKeys.has(key)) {
-		console.warn("Duplicate event:", key);
-	}
-	seenKeys.add(key);
-	if (!ev.time) {
-		console.warn("Missing time for", key);
-		errors++;
-		continue;
-	}
-	const ts = Date.parse(ev.time);
-	if (isNaN(ts)) {
-		console.warn("Invalid time format for", key, ev.time);
-		errors++;
-	}
-	const endTs = ev.endTime ? Date.parse(ev.endTime) : ts;
-	if (endTs < now) {
-		console.warn("Past event found (will fail):", key, ev.time);
-		errors++;
-	}
-	if (!ev.title) {
-		console.warn("Missing title for", key);
-		errors++;
-	}
-	if (!ev.sport) {
-		console.warn("Missing sport for", key);
-		errors++;
-	}
-	// Validate enrichment fields if present
-	if (ev.importance != null) {
-		if (typeof ev.importance !== "number" || ev.importance < 1 || ev.importance > 5) {
-			console.warn("Invalid importance (must be 1-5) for", key, ev.importance);
+/**
+ * Core validation, pure: no filesystem writes, no process.exit. Used by this
+ * CLI (validating events.json on disk) AND by build-events.js's in-process
+ * pre-write gate (WP-94) — build-events runs this on the array it is ABOUT TO
+ * write, before touching the file, so a schema violation can be caught and
+ * degraded instead of freezing the whole hourly pipeline (see build-events.js
+ * for the retain-previous-good-data + build-alert.json behaviour).
+ *
+ * Returns { errors, streamingMissing, enrichedCount, messages } — `errors` is
+ * the hard-error count (a caller treats > 0 as "do not publish this array");
+ * `messages` are the human-readable warn/violation lines, in the same wording
+ * this script has always printed.
+ */
+export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
+	const messages = [];
+	let errors = 0;
+	let streamingMissing = 0;
+	const cutoff = now - GRACE_WINDOW_MS; // allow tiny grace window
+	const seenKeys = new Set();
+	for (const ev of events) {
+		const key = ev.sport + ev.tournament + ev.title + ev.time;
+		if (seenKeys.has(key)) {
+			messages.push(`Duplicate event: ${key}`);
+		}
+		seenKeys.add(key);
+		if (!ev.time) {
+			messages.push(`Missing time for ${key}`);
+			errors++;
+			continue;
+		}
+		const ts = Date.parse(ev.time);
+		if (isNaN(ts)) {
+			messages.push(`Invalid time format for ${key} ${ev.time}`);
 			errors++;
 		}
-	}
-	if (ev.norwegianRelevance != null) {
-		if (typeof ev.norwegianRelevance !== "number" || ev.norwegianRelevance < 1 || ev.norwegianRelevance > 5) {
-			console.warn("Invalid norwegianRelevance (must be 1-5) for", key, ev.norwegianRelevance);
+		const endTs = ev.endTime ? Date.parse(ev.endTime) : ts;
+		if (endTs < cutoff) {
+			messages.push(`Past event found (will fail): ${key} ${ev.time}`);
 			errors++;
 		}
-	}
-	if (ev.tags != null && !Array.isArray(ev.tags)) {
-		console.warn("Invalid tags (must be array) for", key);
-		errors++;
-	}
-	// AI-research contract: confidence levels and evidence requirements
-	if (ev.source === "ai-research") {
-		if (!["high", "medium", "low"].includes(ev.confidence)) {
-			console.warn("AI-research event missing valid confidence for", key, ev.confidence);
+		if (!ev.title) {
+			messages.push(`Missing title for ${key}`);
 			errors++;
 		}
-		if (ev.confidence === "high" && (!Array.isArray(ev.evidence) || ev.evidence.length < 2)) {
-			console.warn("AI-research event with high confidence needs 2+ evidence URLs for", key);
+		if (!ev.sport) {
+			messages.push(`Missing sport for ${key}`);
 			errors++;
 		}
-		// Streaming contract (soft): "hvor kan jeg se det" should be answered for
-		// upcoming near-term events. Warning only — the research grader enforces harder.
-		const ts2 = Date.parse(ev.time);
-		const nowMs = Date.now();
-		if (!Number.isNaN(ts2) && ts2 > nowMs - 4 * 60 * 60 * 1000 && ts2 < nowMs + 7 * 24 * 60 * 60 * 1000) {
-			if (!Array.isArray(ev.streaming) || ev.streaming.length === 0) {
-				streamingMissing++;
+		// Validate enrichment fields if present
+		if (ev.importance != null) {
+			if (typeof ev.importance !== "number" || ev.importance < 1 || ev.importance > 5) {
+				messages.push(`Invalid importance (must be 1-5) for ${key} ${ev.importance}`);
+				errors++;
+			}
+		}
+		if (ev.norwegianRelevance != null) {
+			if (typeof ev.norwegianRelevance !== "number" || ev.norwegianRelevance < 1 || ev.norwegianRelevance > 5) {
+				messages.push(`Invalid norwegianRelevance (must be 1-5) for ${key} ${ev.norwegianRelevance}`);
+				errors++;
+			}
+		}
+		if (ev.tags != null && !Array.isArray(ev.tags)) {
+			messages.push(`Invalid tags (must be array) for ${key}`);
+			errors++;
+		}
+		// AI-research contract: confidence levels and evidence requirements
+		if (ev.source === "ai-research") {
+			if (!["high", "medium", "low"].includes(ev.confidence)) {
+				messages.push(`AI-research event missing valid confidence for ${key} ${ev.confidence}`);
+				errors++;
+			}
+			if (ev.confidence === "high" && (!Array.isArray(ev.evidence) || ev.evidence.length < 2)) {
+				messages.push(`AI-research event with high confidence needs 2+ evidence URLs for ${key}`);
+				errors++;
+			}
+			// Streaming contract (soft): "hvor kan jeg se det" should be answered for
+			// upcoming near-term events. Warning only — the research grader enforces harder.
+			const ts2 = Date.parse(ev.time);
+			if (!Number.isNaN(ts2) && ts2 > now - 4 * 60 * 60 * 1000 && ts2 < now + 7 * 24 * 60 * 60 * 1000) {
+				if (!Array.isArray(ev.streaming) || ev.streaming.length === 0) {
+					streamingMissing++;
+				}
+			}
+		}
+		// Formal schema check (scripts/config/events.schema.json) — catches shape
+		// drift (wrong types, bad enums) that the ad-hoc checks above don't cover.
+		const schemaErrors = validateAgainstSchema(ev, eventSchema, eventSchema);
+		if (schemaErrors.length) {
+			for (const msg of schemaErrors) messages.push(`Schema violation for ${key}:${msg}`);
+			errors += schemaErrors.length;
+		}
+		// Timezone bleed check: endTime crossing midnight in CET but not UTC
+		if (ev.endTime) {
+			const endUTC = new Date(ev.endTime);
+			const endCET = new Date(endUTC.getTime() + 3600000); // UTC+1
+			const endUTCDay = endUTC.toISOString().slice(0, 10);
+			const endCETDay = endCET.toISOString().slice(0, 10);
+			if (endUTCDay !== endCETDay) {
+				messages.push(`Timezone bleed: ${key} endTime ${ev.endTime} crosses midnight in CET (${endCETDay})`);
 			}
 		}
 	}
-	// Formal schema check (scripts/config/events.schema.json) — catches shape
-	// drift (wrong types, bad enums) that the ad-hoc checks above don't cover.
-	const schemaErrors = validateAgainstSchema(ev, eventSchema, eventSchema);
-	if (schemaErrors.length) {
-		for (const msg of schemaErrors) console.warn(`Schema violation for ${key}:${msg}`);
-		errors += schemaErrors.length;
-	}
-	// Timezone bleed check: endTime crossing midnight in CET but not UTC
-	if (ev.endTime) {
-		const endUTC = new Date(ev.endTime);
-		const endCET = new Date(endUTC.getTime() + 3600000); // UTC+1
-		const endUTCDay = endUTC.toISOString().slice(0, 10);
-		const endCETDay = endCET.toISOString().slice(0, 10);
-		if (endUTCDay !== endCETDay) {
-			console.warn(`Timezone bleed: ${key} endTime ${ev.endTime} crosses midnight in CET (${endCETDay})`);
-		}
-	}
+	const enrichedCount = events.filter((e) => e.importance != null).length;
+	return { errors, streamingMissing, enrichedCount, messages };
 }
-let enrichedCount = events.filter(e => e.importance != null).length;
-if (streamingMissing > 0) {
-	console.warn(`Streaming info missing on ${streamingMissing} near-term AI-research event(s) — "hvor kan jeg se det" unanswered.`);
+
+function main() {
+	const dataDir = rootDataPath();
+	const eventSchema = loadEventSchema();
+	const file = path.join(dataDir, "events.json");
+	if (!fs.existsSync(file)) {
+		console.error("events.json not found. Run build-events.js first.");
+		process.exit(1);
+	}
+	const raw = fs.readFileSync(file, "utf-8");
+	let events;
+	try {
+		events = JSON.parse(raw);
+	} catch (e) {
+		console.error("Invalid JSON:", e.message);
+		process.exit(1);
+	}
+	if (!Array.isArray(events)) {
+		console.error("events.json root must be an array");
+		process.exit(1);
+	}
+
+	const { errors, streamingMissing, enrichedCount, messages } = validateEvents(events, eventSchema);
+	for (const m of messages) console.warn(m);
+	if (streamingMissing > 0) {
+		console.warn(`Streaming info missing on ${streamingMissing} near-term AI-research event(s) — "hvor kan jeg se det" unanswered.`);
+	}
+	console.log(`Validated ${events.length} events with ${errors} error(s). ${enrichedCount} enriched.`);
+	if (errors) process.exit(1);
 }
-console.log(`Validated ${events.length} events with ${errors} error(s). ${enrichedCount} enriched.`);
-if (errors) process.exit(1);
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+	main();
+}

--- a/tests/build-events-degrade.test.js
+++ b/tests/build-events-degrade.test.js
@@ -1,0 +1,112 @@
+// WP-94: build-events.js validates in-process before writing events.json, so a
+// schema/contract violation degrades gracefully instead of freezing the hourly
+// static-pipeline (the "13. juli" incident — validate-events.js hard-failing the
+// separate CLI step aborted the whole job, publishing NOTHING for that hour).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+let dataDir, configDir;
+const future = (days) => new Date(Date.now() + days * 86400000).toISOString();
+
+function runBuild(env = {}) {
+	execFileSync("node", ["scripts/build-events.js"], {
+		env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir, SPORTSYNC_CONFIG_DIR: configDir, ...env },
+	});
+}
+
+beforeEach(() => {
+	dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ss-degrade-"));
+	configDir = fs.mkdtempSync(path.join(os.tmpdir(), "ss-degrade-cfg-"));
+});
+
+afterEach(() => {
+	fs.rmSync(dataDir, { recursive: true, force: true });
+	fs.rmSync(configDir, { recursive: true, force: true });
+});
+
+describe("build-events validate-degrade (WP-94)", () => {
+	it("keeps the previous good events.json + writes an ok:false alarm when the fresh build is invalid", () => {
+		// Previous good data already on disk (as if a prior successful hourly run wrote it).
+		const goodPrevious = [{ sport: "golf", title: "Genesis Scottish Open", time: future(2), id: "abc123" }];
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(goodPrevious, null, 2));
+
+		// A curated config event with an out-of-range importance — a hard validation
+		// error (ad-hoc rule, not just the formal schema) with no static fetcher involved.
+		fs.writeFileSync(
+			path.join(configDir, "broken.json"),
+			JSON.stringify({ sport: "chess", name: "Bad Config", events: [{ title: "Broken Event", time: future(1), importance: 99 }] })
+		);
+
+		runBuild();
+
+		const eventsAfter = JSON.parse(fs.readFileSync(path.join(dataDir, "events.json"), "utf-8"));
+		expect(eventsAfter).toEqual(goodPrevious); // untouched — the broken build was NOT published
+
+		const alert = JSON.parse(fs.readFileSync(path.join(dataDir, "build-alert.json"), "utf-8"));
+		expect(alert.ok).toBe(false);
+		expect(alert.errorCount).toBeGreaterThan(0);
+		expect(alert.retained).toBe(true);
+		expect(alert.retainedEventCount).toBe(goodPrevious.length);
+		expect(Array.isArray(alert.sampleErrors)).toBe(true);
+		expect(alert.sampleErrors.length).toBeGreaterThan(0);
+	});
+
+	it("publishes anyway (best-effort) when there is no previous good data to fall back on, but still alarms", () => {
+		// No pre-existing events.json in dataDir at all.
+		fs.writeFileSync(
+			path.join(configDir, "broken.json"),
+			JSON.stringify({ sport: "chess", name: "Bad Config", events: [{ title: "Broken Event", time: future(1), importance: 99 }] })
+		);
+
+		runBuild();
+
+		const eventsAfter = JSON.parse(fs.readFileSync(path.join(dataDir, "events.json"), "utf-8"));
+		expect(eventsAfter.some((e) => e.title === "Broken Event")).toBe(true);
+
+		const alert = JSON.parse(fs.readFileSync(path.join(dataDir, "build-alert.json"), "utf-8"));
+		expect(alert.ok).toBe(false);
+		expect(alert.retained).toBe(false);
+	});
+
+	it("exits 0 on a build-time violation — the pipeline job must not abort here", () => {
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([{ sport: "golf", title: "Open", time: future(2) }], null, 2));
+		fs.writeFileSync(
+			path.join(configDir, "broken.json"),
+			JSON.stringify({ sport: "chess", name: "Bad Config", events: [{ title: "Broken Event", time: future(1), importance: 99 }] })
+		);
+		expect(() => runBuild()).not.toThrow();
+	});
+
+	it("the downstream validate-events.js CLI step then passes, re-checking the RETAINED good file", () => {
+		const goodPrevious = [{ sport: "golf", title: "Open", time: future(2) }];
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(goodPrevious, null, 2));
+		fs.writeFileSync(
+			path.join(configDir, "broken.json"),
+			JSON.stringify({ sport: "chess", name: "Bad Config", events: [{ title: "Broken Event", time: future(1), importance: 99 }] })
+		);
+
+		runBuild();
+		expect(() =>
+			execFileSync("node", ["scripts/validate-events.js"], {
+				env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir },
+			})
+		).not.toThrow();
+	});
+
+	it("writes an ok:true alarm (clearing any previous alert) on a clean build", () => {
+		fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify([], null, 2));
+		fs.writeFileSync(path.join(dataDir, "build-alert.json"), JSON.stringify({ ok: false, checkedAt: "2020-01-01T00:00:00Z", errorCount: 3 }, null, 2));
+		fs.writeFileSync(
+			path.join(dataDir, "golf.json"),
+			JSON.stringify({ tournaments: [{ name: "PGA Tour", events: [{ title: "Open", time: future(2) }] }] })
+		);
+
+		runBuild();
+
+		const alert = JSON.parse(fs.readFileSync(path.join(dataDir, "build-alert.json"), "utf-8"));
+		expect(alert.ok).toBe(true);
+	});
+});

--- a/tests/build-manifest.test.js
+++ b/tests/build-manifest.test.js
@@ -256,9 +256,16 @@ describe("build-events.js integration (WP-03)", () => {
 		execFileSync("node", ["scripts/build-events.js"], { env }); // re-reads its own events.json output, rebuilds
 		const second = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
 
-		const { generatedAt: g1, ...rest1 } = first;
-		const { generatedAt: g2, ...rest2 } = second;
-		expect(rest1).toEqual(rest2);
+		// build-alert.json (WP-94) carries its own per-run `checkedAt` timestamp —
+		// like manifest.generatedAt, it legitimately differs run-to-run even when
+		// nothing else changed, so its entry is excluded the same way.
+		const stripVolatile = (m) => {
+			const { generatedAt, ...rest } = m;
+			const files = { ...rest.files };
+			delete files["build-alert.json"];
+			return { ...rest, files };
+		};
+		expect(stripVolatile(first)).toEqual(stripVolatile(second));
 
 		fs.rmSync(dataDir, { recursive: true, force: true });
 		fs.rmSync(configDir, { recursive: true, force: true });

--- a/tests/usage-gate.test.js
+++ b/tests/usage-gate.test.js
@@ -1,0 +1,123 @@
+// usage-gate.js — freshness-aware decision logic (WP-94).
+import { describe, it, expect, vi } from "vitest";
+import { resolveEffectiveState, decideFromState, FRESH_MS, STALE_MS } from "../scripts/usage-gate.js";
+
+const NOW = Date.parse("2026-07-18T12:00:00Z");
+const greenState = (checkedAt) => ({
+	checkedAt,
+	parsed: true,
+	unifiedStatus: "allowed",
+	session: { percentUsed: 20 },
+	week: { percentUsed: 40 },
+	status: "green",
+	skipAll: false,
+	skipNiceToHave: false,
+});
+const redState = (checkedAt) => ({
+	checkedAt,
+	parsed: true,
+	unifiedStatus: "rejected",
+	session: { percentUsed: 96 },
+	week: { percentUsed: 96 },
+	status: "red",
+	skipAll: true,
+	skipNiceToHave: true,
+});
+
+describe("resolveEffectiveState", () => {
+	it("uses the cache untouched when it's fresh (<= FRESH_MS old) — never calls fetchFresh", async () => {
+		const cached = greenState(new Date(NOW - 5 * 60 * 1000).toISOString()); // 5 min old
+		const fetchFresh = vi.fn();
+		const { state, source, ageMs } = await resolveEffectiveState({ cached, now: NOW, fetchFresh });
+		expect(source).toBe("cached-fresh");
+		expect(state).toBe(cached);
+		expect(ageMs).toBe(5 * 60 * 1000);
+		expect(fetchFresh).not.toHaveBeenCalled();
+	});
+
+	it("fetches fresh when the cache is older than FRESH_MS and uses the fresh reading", async () => {
+		const cached = greenState(new Date(NOW - 20 * 60 * 1000).toISOString()); // 20 min old
+		const fresh = redState(new Date(NOW).toISOString());
+		const fetchFresh = vi.fn().mockResolvedValue(fresh);
+		const { state, source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh });
+		expect(fetchFresh).toHaveBeenCalledTimes(1);
+		expect(source).toBe("fresh");
+		expect(state).toBe(fresh);
+	});
+
+	it("falls back to the (still non-stale) cache when the live fetch is unavailable/fails", async () => {
+		const cached = greenState(new Date(NOW - 20 * 60 * 1000).toISOString()); // 20 min old, within STALE_MS
+		const fetchFresh = vi.fn().mockRejectedValue(new Error("no token"));
+		const { state, source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh });
+		expect(source).toBe("cached-stale-fetch-unavailable");
+		expect(state).toBe(cached);
+	});
+
+	it("falls back to the cache when fetchFresh is not provided at all (no token) and cache is not stale", async () => {
+		const cached = greenState(new Date(NOW - 20 * 60 * 1000).toISOString());
+		const { state, source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh: null });
+		expect(source).toBe("cached-stale-fetch-unavailable");
+		expect(state).toBe(cached);
+	});
+
+	it("fails open (state: null) when cache is stale beyond STALE_MS and fetch is unavailable", async () => {
+		const cached = greenState(new Date(NOW - (STALE_MS + 60_000)).toISOString());
+		const { state, source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh: null });
+		expect(state).toBe(null);
+		expect(source).toBe("none");
+	});
+
+	it("fails open (state: null) when there is no cache at all and no fetch", async () => {
+		const { state, source } = await resolveEffectiveState({ cached: null, now: NOW, fetchFresh: null });
+		expect(state).toBe(null);
+		expect(source).toBe("none");
+	});
+
+	it("still attempts a fresh fetch when there is no cache at all", async () => {
+		const fresh = greenState(new Date(NOW).toISOString());
+		const fetchFresh = vi.fn().mockResolvedValue(fresh);
+		const { state, source } = await resolveEffectiveState({ cached: null, now: NOW, fetchFresh });
+		expect(fetchFresh).toHaveBeenCalledTimes(1);
+		expect(source).toBe("fresh");
+		expect(state).toBe(fresh);
+	});
+
+	it("ignores an unparsed fresh reading and falls back to cache", async () => {
+		const cached = greenState(new Date(NOW - 20 * 60 * 1000).toISOString());
+		const fetchFresh = vi.fn().mockResolvedValue({ parsed: false });
+		const { state, source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh });
+		expect(source).toBe("cached-stale-fetch-unavailable");
+		expect(state).toBe(cached);
+	});
+
+	it("treats a boundary exactly at FRESH_MS as fresh (no fetch)", async () => {
+		const cached = greenState(new Date(NOW - FRESH_MS).toISOString());
+		const fetchFresh = vi.fn();
+		const { source } = await resolveEffectiveState({ cached, now: NOW, fetchFresh });
+		expect(source).toBe("cached-fresh");
+		expect(fetchFresh).not.toHaveBeenCalled();
+	});
+});
+
+describe("decideFromState", () => {
+	it("fail-open (run=true) when state is null", () => {
+		expect(decideFromState(null, "critical")).toEqual({ run: true, reason: "no usable usage-state (fail-open)" });
+	});
+
+	it("skips every tier when skipAll is set", () => {
+		const s = redState("2026-07-18T12:00:00Z");
+		expect(decideFromState(s, "critical").run).toBe(false);
+		expect(decideFromState(s, "optional").run).toBe(false);
+	});
+
+	it("skipNiceToHave only skips the optional tier, not critical", () => {
+		const s = { ...greenState("x"), status: "amber", skipNiceToHave: true };
+		expect(decideFromState(s, "critical").run).toBe(true);
+		expect(decideFromState(s, "optional").run).toBe(false);
+	});
+
+	it("runs when green", () => {
+		const s = greenState("2026-07-18T12:00:00Z");
+		expect(decideFromState(s, "critical")).toEqual({ run: true, reason: "green · session 20% week 40%" });
+	});
+});


### PR DESCRIPTION
## Sammendrag

Tre drifts-fikser fra FASE 0G-motor-audit-en (PLAN.md), avgrenset til det ikke-beskyttede scriptlaget:

1. **Kvote-gate ferskhet** (`scripts/usage-gate.js`): hvis den cachede `usage-state.json`-snapshoten er eldre enn ~10 min, henter gaten selv en fersk ratelimit-avlesning (gjenbruker `check-usage.js` sin header-logikk, nå eksportert som `fetchUsageHeaders`). Fail-open er bevart (ingen data/token ⇒ kjør); beslutningen logger alltid hvilken kilde den bygget på (`fresh` / `cached-fresh` / `cached-stale-fetch-unavailable` / `none`).
   - **Viktig avgrensning:** live-lesningen trenger `CLAUDE_CODE_OAUTH_TOKEN` i selve usage-gate-stegets miljø. I dag eksponerer kun `usage-monitor.yml` den variabelen; research/verify/scout-workflowene gjør det ikke til usage-gate-steget sitt. Å koble det inn er en `.github/workflows/**`-endring — beskyttet sti, ikke gjort her. Inntil videre degraderer koden trygt til den gamle cached/fail-open-oppførselen (ingen regresjon, men fresh-veien slår ikke inn før en fremtidig, menneske-godkjent workflow-endring legger token til det steget).

2. **Validate-degradering** (`scripts/build-events.js` + `scripts/validate-events.js`): `validate-events.js` sin kjernelogikk er nå eksportert (`validateEvents()`), og `build-events.js` kjører den PÅ ARRAYET DEN ER I FERD MED Å SKRIVE, før filen skrives. Ved brudd: forrige gyldige `events.json` beholdes urørt, og et persistent helse-signal `docs/data/build-alert.json` (`ok: true/false`, ikke bare en engangs-feillogg) skrives i stedet. Scriptet exit(0) uansett — så pipeline-jobben, og det påfølgende harde `validate-events.js`-steget (som da re-validerer den BEHOLDTE gode filen), fortsetter uavbrutt i stedet for å fryse hele timen slik 13. juli-hendelsen gjorde. **Ingen workflow-endring nødvendig** — degraderingen skjer utelukkende ved at build-events.js gjør jobben selv før den skriver.
   - Fant og fikset en ekte diskrepans underveis: validering må kjøre på den RUNDTRIPPEDE (JSON.stringify→parse) representasjonen, ikke det rå JS-objektet — `pushEvent()` setter enkelte felt (`venue`, `meta`) til bokstavelig `undefined` når kilden mangler dem, og JSON.stringify dropper slike nøkler stille; å validere rå-objektet ga falske positiver skjemaet aldri ville sett fra disk.
   - `docs/data/build-alert.json` er whitelistet i `.gitignore` (auto-oppdaget av `build-manifest.js`, ingen endring der trengtes).

3. **UCL tracked-placeholder-regel** (`scripts/agents/research.md` Steg 1): presisert at HVER `alwaysTrack.tournaments`-oppføring skal ha minst én tracked.json-entry — en eksplisitt av-sesong-placeholder med begrunnelse hvis det ikke er noe konkret å spore ennå. Lukker det stille UCL-hullet auditen fant (PL/La Liga hadde entries under `leagues`, UEFA Champions League hadde ingen entry i det hele tatt). Selve tracked.json skrives av research-agenten på neste kjøring, ikke av meg.

**Bevisst utelatt** fra WP-94-scopet i denne PR-en: verify-agentens `venue`/summary-synk — det er `verify.md`, WP-93 sitt parallelle territorium, ikke rørt her (union ved PLAN.md-radkonflikt, jf. `wp-flow`-skillen).

## Verifisering
- `npx vitest run --maxWorkers=1`: **40 filer / 506 tester, alle grønne** (inkl. 2 nye testfiler: `tests/usage-gate.test.js`, `tests/build-events-degrade.test.js`)
- `node scripts/build-events.js && node scripts/validate-events.js` på ekte data: rent, 0 feil
- Simulert skjemabrudd (`tests/build-events-degrade.test.js`): bekrefter forrige gyldige `events.json` overlever urørt, `build-alert.json` skrives med `ok:false` + `retained:true` + feilprøver, exit-kode 0, og det påfølgende `validate-events.js`-steget passerer på den beholdte filen
- `tests/usage-gate.test.js`: mocket klokke/snapshot dekker cached-fresh (ingen fetch), fetch-utløst refresh, fetch-feil-fallback-til-cache, full fail-open (ingen cache + ingen fetch), samt grensetilfellet nøyaktig ved FRESH_MS

## Test plan
- [x] `npm test` grønt
- [x] `node scripts/build-events.js && node scripts/validate-events.js` rent på ekte data
- [x] Simulert-brudd-test beviser degraderingen (forrige data + alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)