### PR TITLE
Gate: OAuth-token til usage-gate-steget (fersk kvote-avlesning) — 9 workflows

### DIFF
--- a/.github/workflows/coverage-critic-agent.yml
+++ b/.github/workflows/coverage-critic-agent.yml
@@ -25,6 +25,11 @@ jobs:
           node-version: "22"
       - id: usage
         run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/editorial-agent.yml
+++ b/.github/workflows/editorial-agent.yml
@@ -40,7 +40,12 @@ jobs:
             echo "mode=evening" >> $GITHUB_OUTPUT
           fi
       - id: usage
-        run: node scripts/usage-gate.js optional # editorial is a nice-to-have — skip it first under quota pressure
+        run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # editorial is a nice-to-have — skip it first under quota pressure
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/improve-agent.yml
+++ b/.github/workflows/improve-agent.yml
@@ -36,6 +36,11 @@ jobs:
       - run: npm ci
       - id: usage
         run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/research-agent.yml
+++ b/.github/workflows/research-agent.yml
@@ -39,6 +39,11 @@ jobs:
       # no-op, not a failure.
       - id: usage
         run: node scripts/usage-gate.js critical
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       # Model strategy (Fable 5 is ~2x the price of Opus 4.8 and is not the default
       # upgrade path — Anthropic reserves it for the most demanding long-horizon work):

--- a/.github/workflows/scout-agent.yml
+++ b/.github/workflows/scout-agent.yml
@@ -24,7 +24,12 @@ jobs:
         with:
           node-version: "22"
       - id: usage
-        run: node scripts/usage-gate.js critical # skips only if quota is near-exhausted
+        run: node scripts/usage-gate.js critical
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # skips only if quota is near-exhausted
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/self-repair-agent.yml
+++ b/.github/workflows/self-repair-agent.yml
@@ -36,6 +36,11 @@ jobs:
       - run: npm ci
       - id: usage
         run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         env:

--- a/.github/workflows/ui-fix-agent.yml
+++ b/.github/workflows/ui-fix-agent.yml
@@ -36,7 +36,12 @@ jobs:
           node-version: "22"
       - run: npm ci
       - id: usage
-        run: node scripts/usage-gate.js optional # a nice-to-have — skip under quota pressure
+        run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # a nice-to-have — skip under quota pressure
       - run: npx playwright install --with-deps chromium # for before/after screenshots
         if: steps.usage.outputs.run == 'true'
       - if: steps.usage.outputs.run == 'true'

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -24,6 +24,11 @@ jobs:
       - run: npm ci
       - id: usage
         run: node scripts/usage-gate.js critical
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - if: steps.usage.outputs.run == 'true'
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/visual-qa-agent.yml
+++ b/.github/workflows/visual-qa-agent.yml
@@ -24,6 +24,11 @@ jobs:
       - run: npm ci
       - id: usage
         run: node scripts/usage-gate.js optional
+        env:
+          # WP-94-oppfølger: gate-steget kan nå hente FERSK kvote-avlesning
+          # (usage-gate.js >10min-stien) i stedet for å stole på inntil 1t gammel
+          # snapshot — tokenet er samme secret usage-monitor bruker, read-only kall.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       - run: npx playwright install --with-deps chromium # needed for screenshots
         if: steps.usage.outputs.run == 'true'
       - if: steps.usage.outputs.run == 'true'


### PR DESCRIPTION
WP-94-oppfølgeren: uten dette er fersk-hentings-stien i `usage-gate.js` en no-op i agent-workflowene (dokumentert i #303). Én identisk env-blokk per gate-steg, samme secret som usage-monitor, read-only kall. `tests/workflows.test.js` grønn.

**Beskyttet sti** — venter på eier-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)