### PR TITLE
WP-97: Design-biblioteket — én token-sannhet + koherens-tester

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,6 +46,12 @@ ved forstørret Dynamic Type før merge. Eieren er siste smaksinstans.
 Alle farger er **semantiske**, ikke rå hex i komponentene. Verdiene under er
 Apple-system-farger + én amber-aksent. Ved rebrand endres KUN denne tabellen.
 
+> **Maskinlesbar fasit:** [`design/tokens.json`](design/tokens.json) speiler denne
+> tabellen (+ typografi/spacing/radius) i W3C design-tokens-format; koherens-testen
+> `tests/design-tokens.test.js` håndhever takten mellom denne prosa-tabellen,
+> `docs/css/base.css` og `ios/Sportivista/DesignTokens.swift` — drift på noen av de
+> tre er en CI-feil, ikke en stille rettelse.
+
 ### Farge
 
 | Token | Rolle | Mørk | Lys |

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,7 +103,7 @@ mennesket, aldri av en agent.
 | WP-94 | Drifts-småplukk (kvote-gate/validate-degradering/UCL) | 0G | – | ✅ merget (#303) — kvote-gate m/ fersk-henting >10min (pure functions, fail-open bevart; NB: fersk-stien er no-op i kritiske workflows til et lite BESKYTTET workflow-tillegg sender OAuth-token til gate-steget — egen mini-PR til eier); validate-degradering uten workflow-endring (in-prosess-validering før skriving, forrige gyldige data består, build-alert.json-helsesignal; fant+fikset round-trip-valideringsbug); UCL-placeholder-regel i research.md; 506 tester
 | WP-95 | Deltakelses-ferskhet (cut/trekning — eier-funn) | 0G | – | ✅ merget (#307) — ESPN core-API competitor-status (lett-scoreboardet skjuler cut mid-turnering; én billig henting per fulgt spiller, fail-soft); verify/editorial/grader-kontrakter tettet; web viser rolig status; iOS trengte null endring (LensRenderer var klar). 536 tester. LIVE-BEKREFTET: Hovland «røk cutten» på tavla 12:47 UTC — før kveldsbriefen 15:00. NY PORT: null feilaktige deltaker-statuser |
 | WP-96 | Flerbruker-splitten (interests → katalog) — GATE for eksterne testere | 0G | portmåling | ✅ merget (#308) — `catalog.json` (tier1 bredt + tier2 elite-langhale, nøkternt seedet; tennis via tier2-majors for å unngå ATP/WTA-flom); `isCovered(catalog)` server-side, personlig presisjon eies av linsen alene; vektorer IKKE re-frosset (semantisk riktig: linsen uendret — pinner nå klienten, DIVERGENCES §6); to-profil-aksepttest (eier uendret + Nakamura-sjakk + NAVI-CS2 → alle meningsfulle fra samme feed); interests.json avpublisert, web viser «Dette dekker vi»; agent-kompass → katalogen; ICS/mustWatch bevisst eier-artefakt; rediger = «be om dekning» (skrivevei → WP-23). 542 JS + 526 iOS + vektorer bit-like + 4 schemes |
-| WP-97 | Design-biblioteket (tokens.json + koherens + brand-assets + styleguide) | 0G | – | ⬜ |
+| WP-97 | Design-biblioteket (tokens.json + koherens + brand-assets + styleguide) | 0G | – | 🔬 PR åpen |
 
 ---
 
@@ -1047,7 +1047,7 @@ enn eieren får TOM tavle (serveren droppet innholdet før deres linse så det).
   research-/verify-omfang — koordineres med API-splitten (Fase B i
   AI-ØKONOMI-tillegget).
 
-### WP-97 · Design-biblioteket (én token-sannhet + koherens-tester)
+### WP-97 · Design-biblioteket (én token-sannhet + koherens-tester) — 🔬 PR åpen
 Eier-beslutning 18.07: konsistent branding-stil trenger bibliotek. I dag lever
 tokens i TRE parallelle sannheter (DESIGN.md-prosa, DesignTokens.swift,
 base.css) holdt i takt for hånd, og app-ikon-scriptet finnes kun i en sesjons-
@@ -1066,6 +1066,29 @@ scratchpad. Repoets signaturgrep anvendes: verifisering fremfor kodegen.
   virkeligheten, endrer den ikke); styleguide-siden viser alle tokens +
   kjernekomponenter i begge temaer; ikonet kan regenereres fra innsjekket
   script byte-likt dagens.
+- **Levert i denne PR-en:** `design/tokens.json` (W3C-format) + 48 tester i
+  `tests/design-tokens.test.js` som krysssjekker tokens.json ⇄ base.css ⇄
+  DesignTokens.swift ⇄ DESIGN.md § Tokens (rødt bevist på en ekte
+  verdi-mutasjon, revertert); `design/brand/kolonet.svg` (kilde-vektor,
+  radius 118 / avstand 168 på 1024-rammen — utledet ved pikselinspeksjon av
+  det skipede ikonet, ikke antatt) + `design/brand/generate-icons.swift`
+  (innsjekket, parametrisert — `--all <dir>` regenererer hele settet); 1024-
+  utgaven verifisert **PIKSEL-IDENTISK** (null delta i alle RGBA-kanaler) mot
+  `AppIcon-1024.png`, samme for alle fire web-ikonene — PNG-filene selv er
+  12 byte større (kun `eXIf`-metadata, `IDAT`-lengden er identisk); `design/brand/BRAND.md`
+  (konstruksjon, avstand, minstestørrelser fra faktisk kildekode-grep, feil
+  bruk, tagline); `docs/styleguide.html` (lenker ekte base.css/layout.css/
+  cards.css, ingen duplisert CSS; fargeswatcher leser CSS-variablene live via
+  `getComputedStyle`; skjermbilder tatt i begge temaer). **Avvik funnet, IKKE
+  stille rettet** (se `design/tokens.json` `$extensions.sportivista.discrepancy`
+  per token/rolle): (1) `tertiaryLabel`/`--fg-3` brukes på begge flater men
+  mangler i DESIGN.md § Farge-tabellen OG i `SportivistaTokens`-enumet (iOS-
+  views kaller `Color(uiColor: .tertiaryLabel)` direkte); (2) wordmarkens
+  «Stor tittel»-rolle er 26px på web, ikke DESIGN.md sin dokumenterte
+  2.125rem (34px) — en reell, ikke-avrundings-differanse; (3) web sitt
+  ordmerke er HELT amber (én av fem sanksjonerte amber-bruk i `base.css`),
+  mens iOS/widget kun farger kolonet amber — dokumentert som bevisst
+  flate-avvik i BRAND.md, ikke rettet.
 
 ## FLYTTEDAGEN · Zenji → Sportivista — ✅ UTFØRT 17.07.2026
 

--- a/design/brand/BRAND.md
+++ b/design/brand/BRAND.md
@@ -1,0 +1,129 @@
+# Kolonet — brand-lock spec
+
+This is the merkelås-spek for the Sportivista mark (WP-97 · Design-biblioteket).
+It documents what already ships (`ios/Sportivista/ContentView.swift`,
+`ios/Sportivista/Onboarding/OnboardingView.swift`, `ios/SportivistaWidget/SportivistaWidget.swift`,
+`docs/css/layout.css`) — it does not introduce a new look. Any change to the
+mark itself is a `DESIGN.md` § Tokens decision (amber, wordmark, icon are all
+"skall" — see `DESIGN.md` § Visjon vs. skall); this file is the enforcement
+detail underneath that decision.
+
+## The mark
+
+**SPORTIVISTA:** — the wordmark in full-caps, immediately followed (zero gap)
+by an amber colon. The colon is not decoration bolted on afterward: it *is*
+the brand idea. Sportivista's whole product is **når · hva · hvor** — the
+colon is literally the punctuation of a clock face ("18:00"), the same glyph
+that answers *når* on every row of the agenda. The app icon (`kolonet.svg`)
+is the colon alone, blown up to fill the frame: two amber dots, stacked
+vertically, on their own.
+
+- **Source vector:** `design/brand/kolonet.svg` — two `#FFB000` filled
+  circles on transparent, 1024×1024 reference frame, radius 118 / vertical
+  gap (edge-to-edge) 168, both centred on x = 512, the pair centred on
+  y = 512 (top circle cy = 310, bottom circle cy = 714).
+- **Regeneration:** `design/brand/generate-icons.swift` renders the same
+  geometry at any size/background (see its header for usage). The 1024
+  render was verified **pixel-identical** (zero per-channel delta across
+  all four RGBA bytes, every pixel) to the shipped
+  `ios/Sportivista/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png`, and
+  likewise for `docs/icons/icon-{512,192,180}x*.png` and `docs/favicon.png`.
+  The PNG *files* are not byte-identical (the shipped files carry a 12-byte
+  larger `eXIf` metadata chunk of unknown provenance — 56 vs 68 bytes, purely
+  metadata, zero effect on the decoded image); the `IDAT` (pixel data) chunks
+  are the same length and the decoded pixel buffers are exactly equal. See
+  the WP-97 PR for the inspection transcript.
+
+## Construction rules
+
+1. **Zero gap, one lockup.** The wordmark and the colon sit with no space
+   between them — `spacing: 0` (`HStack(spacing: 0)` in Swift; `.wordmark-lockup
+   { display: inline-flex; align-items: baseline; white-space: nowrap; }` on
+   web, which exists *specifically* so a parent flex `gap` can never separate
+   them). Never lay them out with a container that could introduce a gap.
+2. **The colon is one step heavier than the wordmark.** iOS renders the
+   wordmark `bold` and the colon `heavy` (`Font.sportivista(.title,
+   weight: .bold)` / `weight: .heavy` — see `ContentView.swift`,
+   `OnboardingView.swift`, `SportivistaWidget.swift`). The colon should always
+   read as the punchiest element in the lockup, never lighter or equal.
+3. **Tracking.** The wordmark carries letter-spacing so the caps breathe:
+   `tracking(2)` at header/onboarding size, `tracking(1)` at widget
+   (caption) size — scale tracking down as the type size shrinks, never keep
+   it fixed. Web: `letter-spacing: 0.02em`.
+4. **One accessibility element, one label.** Wordmark + colon are exposed to
+   VoiceOver/assistive tech as a single element labelled exactly `"Sportivista"`
+   (`.accessibilityElement(children: .ignore)` + `.accessibilityLabel("Sportivista")`
+   on every surface that renders the lockup). Never let a screen reader
+   announce the colon separately ("Sportivista, colon").
+5. **Colour — a documented cross-surface divergence, not a bug.** On iOS +
+   widget, only the colon is amber; the wordmark itself is `label` (system
+   text colour, white/black). On web, the **entire wordmark is amber**
+   (`.wordmark { color: var(--accent); }`) — this is one of web's five
+   explicitly sanctioned amber uses (`docs/css/base.css`: "Amber is the ONLY
+   accent and is used only for: wordmark, day headers, the must-see dot, the
+   clock, selected state"). Do not "fix" either surface to match the other —
+   this file records both as intentional: the web masthead is a persistent,
+   single-purpose brand mark at the top of a otherwise text-only page and can
+   afford a bolder brand treatment; the iOS header sits inside more chrome
+   (nav bar, toolbar) where a fully-amber wordmark would compete with the
+   HIG rule of one accent per surface used sparingly.
+6. **No separate image mark next to text.** When the mark appears as *text*
+   (wordmark contexts), it is always the literal wordmark + `":"` glyph in
+   the app's own font — never the `kolonet.svg` dots rendered inline next to
+   the word. The dots are for icon contexts only (app icon, favicon, PWA
+   icons) where there is no wordmark to pair with.
+
+## Spacing & minimum sizes
+
+- **Icon safe area:** the mark itself occupies the middle ~60% of the frame
+  vertically (top circle top edge at `y ≈ 0.188 × size`, bottom circle
+  bottom edge at `y ≈ 0.813 × size`, radius `≈ 0.115 × size`) — this is
+  already how the shipped icon is composed; treat the surrounding margin as
+  fixed padding, do not crop into it.
+- **Minimum icon size:** verified legible (two visibly distinct blobs, not a
+  single smear) down to **16×16px** — the smallest size actually shipped
+  (`docs/favicon.png`, browser tab favicon). Below 16px the geometry has not
+  been tested and is not recommended. For any context where the mark needs
+  to read as "a colon" rather than just "a brand blob" (app switcher, share
+  sheets, list rows), prefer **≥ 32px**.
+- **Minimum wordmark size:** the smallest shipped instance is the widget's
+  `.caption` role (`SportivistaWidget.swift`, small-widget family) — do not
+  go smaller; below the system caption size the tracking rules above stop
+  reading as intentional letterspacing and start reading as broken kerning.
+- **Clear space:** no numeric keyline exists today (none of the three
+  surfaces reserves a measured margin around the lockup beyond ordinary
+  layout padding) — treat the surface's own standard content inset
+  (`SportivistaSpacing.l` = 16pt on iOS, `.wrap` padding on web, 16–22px) as
+  the de-facto minimum clear space until a stricter rule is set.
+
+## Misbruk (never do this)
+
+- **Never italicise** the wordmark or the colon.
+- **Never abbreviate** the wordmark ("SPRTVSTA", "SV:", initials). The full
+  word is the mark; there is no short-form lock-up.
+- **Never use the colon as inline punctuation in running text.** `"Se
+  Sportivista: agendaen din"` is prose, not the mark — do not set the colon
+  in accent amber there, and do not zero-gap it. The mark is *only* the
+  `SPORTIVISTA:` lockup used as a standalone brand element (masthead,
+  headers, icon), never mid-sentence.
+- **Never recolour the dots/colon** to anything but `#FFB000` (dark) /
+  `#9A6800` (light) — see `design/tokens.json` `color.accent`. Amber is the
+  ONE accent (`DESIGN.md` § Grunnlov #4); the mark does not get its own
+  separate brand palette.
+- **Never add a gradient, glow, shadow, or outline** to the dots or the
+  wordmark. Flat colour on flat background, matching `DESIGN.md`'s
+  forbudsliste (no DIY glass/glow/shadow anywhere in the system).
+- **Never change the two circles' relative size or spacing** without
+  updating `kolonet.svg` AND re-running `generate-icons.swift` against every
+  shipped size — a hand-edited one-off icon will drift from the vector.
+- **Never pair the wordmark with the dot-icon inline** (rule 6 above) — pick
+  one form per context, never both stacked together as if they were two
+  separate logos.
+
+## Tagline
+
+**«Hele sporten. Ett rolig utsyn.»** — two short sentences, full stop after
+each (not an ellipsis, not an exclamation — `DESIGN.md` § Cross-surface:
+"Aldri utropstegn i kromet"). Used sparingly (App Store subtitle, onboarding,
+marketing surfaces) — it is not part of the masthead lockup and does not
+appear next to the wordmark in-product.

--- a/design/brand/generate-icons.swift
+++ b/design/brand/generate-icons.swift
@@ -1,0 +1,170 @@
+#!/usr/bin/env swift
+//
+//  generate-icons.swift
+//  Sportivista — kolonet app-icon / web-icon generator (WP-97 · Design-biblioteket)
+//
+//  Renders the kolonet mark (design/brand/kolonet.svg — two amber #FFB000
+//  filled circles stacked vertically) onto a square canvas at any size, with
+//  an opaque background colour (or transparent, for a source-vector-style
+//  export). This is the CHECKED-IN, parametrised replacement for the
+//  icon-generation script that previously only ever existed in a session
+//  scratchpad (WP-97 finding: the mark could not be regenerated from the
+//  repo before this file).
+//
+//  Geometry is fixed at a 1024×1024 reference frame (verified pixel-for-pixel
+//  against the shipped ios/Sportivista/Assets.xcassets/AppIcon.appiconset/
+//  AppIcon-1024.png — see the PR for the inspection transcript):
+//    - radius = 118          (both circles, same size)
+//    - gap    = 168          (vertical, edge-to-edge, between the two circles)
+//    - both circles centred on x = 512; the PAIR is vertically centred on the
+//      canvas (y = 512), so top circle cy = 310, bottom circle cy = 714 at 1024.
+//  Every other size scales both numbers by the same fraction of 1024, so the
+//  mark is proportionally identical at every export size.
+//
+//  Usage — single file:
+//    swift design/brand/generate-icons.swift <output.png> <sizePx> [background]
+//      <output.png>  path to write
+//      <sizePx>      integer canvas size (square)
+//      [background]  "#RRGGBB" (default "#000000", opaque) or the literal
+//                    word "transparent" (alpha 0 — the source-vector look)
+//
+//  Usage — regenerate the whole shipped set into a scratch directory (never
+//  writes into ios/ or docs/ directly — copy the outputs yourself after
+//  reviewing them, exactly like the historical enso-icon.swift convention):
+//    swift design/brand/generate-icons.swift --all <outDir>
+//  writes, all on #000000 opaque background:
+//    <outDir>/AppIcon-1024.png   (1024 — iOS app icon)
+//    <outDir>/icon-512x512.png   (512  — PWA)
+//    <outDir>/icon-192x192.png   (192  — PWA / favicon)
+//    <outDir>/icon-180x180.png   (180  — apple-touch-icon)
+//    <outDir>/favicon.png        (192  — same render as icon-192x192.png)
+//
+//  Verification (documented in the WP-97 PR): the 1024 output was compared
+//  against ios/Sportivista/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png
+//  pixel-by-pixel (max per-channel delta reported) rather than assumed
+//  byte-identical, since the original generating script is unrecoverable and
+//  PNG encoders + antialiasing rounding are not guaranteed bit-reproducible
+//  across tool versions.
+//
+
+import Foundation
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+// MARK: - Geometry (design/brand/kolonet.svg, 1024×1024 reference frame)
+
+let referenceFrame: Double = 1024
+let radiusAtReference: Double = 118
+let gapAtReference: Double = 168 // vertical, edge-to-edge, between the two circles
+
+let amberCG = CGColor(srgbRed: 0xFF / 255.0, green: 0xB0 / 255.0, blue: 0x00 / 255.0, alpha: 1.0) // #FFB000
+
+// MARK: - Argument parsing
+
+func fail(_ message: String) -> Never {
+	FileHandle.standardError.write("generate-icons: \(message)\n".data(using: .utf8)!)
+	exit(1)
+}
+
+func parseBackground(_ raw: String) -> CGColor? {
+	if raw.lowercased() == "transparent" { return nil }
+	var hex = raw
+	if hex.hasPrefix("#") { hex.removeFirst() }
+	guard hex.count == 6, let value = UInt32(hex, radix: 16) else {
+		fail("invalid background \"\(raw)\" — expected \"#RRGGBB\" or \"transparent\"")
+	}
+	let r = Double((value >> 16) & 0xFF) / 255.0
+	let g = Double((value >> 8) & 0xFF) / 255.0
+	let b = Double(value & 0xFF) / 255.0
+	return CGColor(srgbRed: r, green: g, blue: b, alpha: 1.0)
+}
+
+// MARK: - Rendering
+
+/// Render the kolonet mark at `size` px onto `background` (nil = transparent).
+func renderKolonet(size: Int, background: CGColor?) -> CGImage {
+	let cs = CGColorSpaceCreateDeviceRGB()
+	let ctx = CGContext(
+		data: nil, width: size, height: size, bitsPerComponent: 8, bytesPerRow: 0,
+		space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+	)!
+	ctx.setAllowsAntialiasing(true)
+	ctx.setShouldAntialias(true)
+	ctx.interpolationQuality = .high
+
+	let f = Double(size)
+	if let background {
+		ctx.setFillColor(background)
+		ctx.fill(CGRect(x: 0, y: 0, width: f, height: f))
+	}
+
+	let radiusFrac = radiusAtReference / referenceFrame
+	let gapFrac = gapAtReference / referenceFrame
+	let r = f * radiusFrac
+	let g = f * gapFrac
+	let centerToCenter = g + 2 * r
+	let cx = f / 2
+	let topCY = f / 2 - centerToCenter / 2
+	let bottomCY = f / 2 + centerToCenter / 2
+
+	ctx.setFillColor(amberCG)
+	ctx.fillEllipse(in: CGRect(x: cx - r, y: topCY - r, width: 2 * r, height: 2 * r))
+	ctx.fillEllipse(in: CGRect(x: cx - r, y: bottomCY - r, width: 2 * r, height: 2 * r))
+
+	return ctx.makeImage()!
+}
+
+func writePNG(_ image: CGImage, to url: URL) {
+	guard let dest = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+		fail("could not create PNG destination at \(url.path)")
+	}
+	CGImageDestinationAddImage(dest, image, nil)
+	guard CGImageDestinationFinalize(dest) else {
+		fail("could not finalize PNG at \(url.path)")
+	}
+}
+
+// MARK: - Main
+
+let args = CommandLine.arguments
+
+if args.count >= 2, args[1] == "--all" {
+	guard args.count >= 3 else { fail("--all requires <outDir>") }
+	let outDir = URL(fileURLWithPath: args[2])
+	try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+	let black = parseBackground("#000000")
+	let sizes: [(name: String, size: Int)] = [
+		("AppIcon-1024.png", 1024),
+		("icon-512x512.png", 512),
+		("icon-192x192.png", 192),
+		("icon-180x180.png", 180),
+		("favicon.png", 192),
+	]
+	for (name, size) in sizes {
+		let image = renderKolonet(size: size, background: black)
+		writePNG(image, to: outDir.appendingPathComponent(name))
+		print("  \(name): \(size)x\(size)")
+	}
+	print("\nWrote \(sizes.count) PNG(s) under \(outDir.path)")
+	exit(0)
+}
+
+guard args.count >= 3 else {
+	fail(
+		"""
+		usage:
+		  swift generate-icons.swift <output.png> <sizePx> [background]
+		  swift generate-icons.swift --all <outDir>
+		"""
+	)
+}
+
+let outputPath = args[1]
+guard let sizePx = Int(args[2]), sizePx > 0 else { fail("sizePx must be a positive integer, got \"\(args[2])\"") }
+let backgroundArg = args.count >= 4 ? args[3] : "#000000"
+let background = parseBackground(backgroundArg)
+
+let image = renderKolonet(size: sizePx, background: background)
+writePNG(image, to: URL(fileURLWithPath: outputPath))
+print("wrote \(outputPath) (\(sizePx)x\(sizePx), background \(backgroundArg))")

--- a/design/brand/kolonet.svg
+++ b/design/brand/kolonet.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+	<!--
+	  Sportivista — kolonet ("the little colon"), the brand mark.
+
+	  Two amber (#FFB000) filled circles, stacked vertically on transparent —
+	  the colon in "18:00", echoing the calm agenda's when·what·where. This is
+	  the SOURCE VECTOR: geometry-only, no background, no text. Composed with
+	  the "SPORTIVISTA" wordmark as a colon glyph (docs/css/layout.css
+	  .wordmark-colon), and rendered onto an opaque background at fixed sizes
+	  by design/brand/generate-icons.swift for the app icon + favicon/PWA set.
+
+	  Geometry (1024×1024 reference frame, verified against the shipped
+	  ios/Sportivista/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png):
+	    - both circles centered on x = 512 (canvas center)
+	    - radius = 118
+	    - vertical gap between the two circles (edge to edge) = 168
+	    - centered as a pair on y = 512 → top circle cy = 310, bottom circle cy = 714
+	  generate-icons.swift computes every size as a fraction of these four
+	  numbers (radius/1024, gap/1024) so every export stays proportional.
+	-->
+	<circle cx="512" cy="310" r="118" fill="#FFB000"/>
+	<circle cx="512" cy="714" r="118" fill="#FFB000"/>
+</svg>

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,0 +1,207 @@
+{
+	"$schema": "https://tr.designtokens.org/format/",
+	"$description": "Sportivista design tokens (WP-97) — the single machine-readable source of truth for DESIGN.md § Tokens. This file LOCKS today's shipped reality (docs/css/base.css + ios/Sportivista/DesignTokens.swift as of 2026-07-18); it does not change any value. Coherence is enforced by tests/design-tokens.test.js: base.css custom properties, DesignTokens.swift semantic mappings, and the DESIGN.md § Tokens prose table are all verified against the values below — drift on any of the three surfaces fails CI. Where the three surfaces disagree, the mismatch is recorded explicitly in a token's `$extensions.sportivista.discrepancy` rather than silently resolved (see each note).",
+	"$extensions": {
+		"sportivista": {
+			"sources": {
+				"web": "docs/css/base.css",
+				"ios": "ios/Sportivista/DesignTokens.swift",
+				"prose": "DESIGN.md § Tokens"
+			},
+			"asOf": "2026-07-18"
+		}
+	},
+
+	"color": {
+		"$description": "DESIGN.md § Farge. Neutrals map to Apple semantic system colours (no raw hex in Swift); `dark`/`light` below are those colours' documented resolved hex, verbatim from DESIGN.md's table and docs/css/base.css's custom properties. `accent`/`live`/`destructive` are Sportivista's own explicit values (not system colours) and are identical on both platforms.",
+
+		"background": {
+			"$type": "color",
+			"$description": "Page / sideflate surface.",
+			"$extensions": { "sportivista": { "ios": "systemGroupedBackground", "web": "--bg", "swift": "SportivistaTokens.background" } },
+			"dark": { "$value": "#000000" },
+			"light": { "$value": "#F2F2F7" }
+		},
+		"groupedBackground": {
+			"$type": "color",
+			"$description": "Bak grupperte lister — same values as background (the baseline is an inset-grouped list world).",
+			"$extensions": { "sportivista": { "ios": "systemGroupedBackground", "web": "--bg", "swift": "SportivistaTokens.groupedBackground" } },
+			"dark": { "$value": "#000000" },
+			"light": { "$value": "#F2F2F7" }
+		},
+		"cell": {
+			"$type": "color",
+			"$description": "Liste-/kort-flate.",
+			"$extensions": { "sportivista": { "ios": "secondarySystemGroupedBackground", "web": "--surface", "swift": "SportivistaTokens.cell" } },
+			"dark": { "$value": "#1C1C1E" },
+			"light": { "$value": "#FFFFFF" }
+		},
+		"cell2": {
+			"$type": "color",
+			"$description": "Nøstet/hevet flate.",
+			"$extensions": { "sportivista": { "ios": "tertiarySystemBackground", "web": null, "swift": "SportivistaTokens.cell2", "discrepancy": "No web custom property renders this token today — the web layout has no nested/raised surface (flat rows on hairlines only, DESIGN.md 'no cards, no washes'). Not a bug: web deliberately has fewer surface levels than the iOS inset-grouped list world. Recorded here so a future nested-surface need on web has a value to reach for." } },
+			"dark": { "$value": "#2C2C2E" },
+			"light": { "$value": "#FFFFFF" }
+		},
+		"label": {
+			"$type": "color",
+			"$description": "Primærtekst.",
+			"$extensions": { "sportivista": { "ios": "label", "web": "--fg", "swift": "SportivistaTokens.label" } },
+			"dark": { "$value": "#FFFFFF" },
+			"light": { "$value": "#000000" }
+		},
+		"secondaryLabel": {
+			"$type": "color",
+			"$description": "Meta/kanal/dempet.",
+			"$extensions": { "sportivista": { "ios": "secondaryLabel", "web": "--fg-2", "swift": "SportivistaTokens.secondaryLabel" } },
+			"dark": { "$value": "rgba(235, 235, 245, 0.6)" },
+			"light": { "$value": "rgba(60, 60, 67, 0.6)" }
+		},
+		"tertiaryLabel": {
+			"$type": "color",
+			"$description": "Fainter, one step below secondaryLabel.",
+			"$extensions": { "sportivista": { "ios": "tertiaryLabel", "web": "--fg-3", "swift": null, "discrepancy": "Real value used on BOTH surfaces (base.css --fg-3; ios AgendaView.swift:423 and DegView.swift:227 call Color(uiColor: .tertiaryLabel) directly), but it is tokenised in neither DESIGN.md § Farge (no table row) nor SportivistaTokens.swift (no enum case — views reach past the token layer to the raw UIColor). Recorded here as the machine-readable value both surfaces already agree on in practice; DESIGN.md's table and the Swift enum are the two places that could be extended to close this gap, at the owner's discretion." } },
+			"dark": { "$value": "rgba(235, 235, 245, 0.3)" },
+			"light": { "$value": "rgba(60, 60, 67, 0.3)" }
+		},
+		"separator": {
+			"$type": "color",
+			"$description": "Hårlinje/skille.",
+			"$extensions": { "sportivista": { "ios": "separator", "web": "--line", "swift": "SportivistaTokens.separator" } },
+			"dark": { "$value": "rgba(84, 84, 88, 0.6)" },
+			"light": { "$value": "#C6C6C8" }
+		},
+		"accent": {
+			"$type": "color",
+			"$description": "ENESTE aksent (amber). Own explicit value on both platforms (not a system colour) — used only for wordmark/day headers/must-see dot/clock/selected-state; never body text, never twice in one row.",
+			"$extensions": { "sportivista": { "ios": "own value (Color.sportivista(dark:light:))", "web": "--accent", "swift": "SportivistaTokens.accent" } },
+			"dark": { "$value": "#FFB000" },
+			"light": { "$value": "#9A6800" }
+		},
+		"accentInk": {
+			"$type": "color",
+			"$description": "Ink/text colour placed on top of an amber-filled control — a web-only derived token (equal to the opposite theme's background/cell value) so amber blocks stay legible. Not a distinct DESIGN.md § Farge row.",
+			"$extensions": { "sportivista": { "ios": null, "web": "--accent-ink", "swift": null, "discrepancy": "Web-only named token; iOS achieves the same contrast per-view (e.g. .foregroundStyle(.black)/(.white) on an amber-tinted control) without a shared enum case. Not a defect — just not yet abstracted on iOS." } },
+			"dark": { "$value": "#000000" },
+			"light": { "$value": "#FFFFFF" }
+		},
+		"live": {
+			"$type": "color",
+			"$description": "Direkte / positiv (systemGreen). Own explicit token value (matches systemGreen) so a rebrand can retune independently.",
+			"$extensions": { "sportivista": { "ios": "own value, matches systemGreen", "web": "--live", "swift": "SportivistaTokens.live" } },
+			"dark": { "$value": "#30D158" },
+			"light": { "$value": "#34C759" }
+		},
+		"destructive": {
+			"$type": "color",
+			"$description": "Slett/nullstill (systemRed). Own explicit token value (matches systemRed).",
+			"$extensions": { "sportivista": { "ios": "own value, matches systemRed", "web": null, "swift": "SportivistaTokens.destructive", "discrepancy": "No web custom property — the read-only web dashboard has no destructive action surface (nullstill/slett lives only in the iOS Deg screen). Not a bug: web simply has no UI that needs this colour today." } },
+			"dark": { "$value": "#FF453A" },
+			"light": { "$value": "#FF3B30" }
+		}
+	},
+
+	"typography": {
+		"$description": "DESIGN.md § Typografi role table. `ios` binds to a Dynamic Type text style via Font.sportivista(_:weight:) — never a fixed .system(size:) point (HIG CI gate: tests/ios-dynamic-type-gate.test.js). `web.designMd` is the literal value in the DESIGN.md prose table; `web.cssActual` is the value actually shipped in docs/css/*.css today (root font-size is the browser default 16px — base.css sets no html{font-size}, so 1rem = 16px). Sub-pixel differences of ≤1px between designMd and cssActual are whole-pixel rounding of the same intent and are NOT flagged; anything larger is flagged in `discrepancy`.",
+		"roles": {
+			"largeTitle": {
+				"label": "Stor tittel (nav)",
+				"ios": { "textStyle": ".largeTitle", "weight": "bold" },
+				"web": {
+					"designMd": "2.125rem",
+					"designMdPx": 34,
+					"cssActual": { "selector": ".wordmark / .wordmark-colon", "file": "docs/css/layout.css", "fontSize": "26px", "fontWeight": 700, "textTransform": "uppercase" },
+					"discrepancy": "Real, non-rounding mismatch: 26px shipped vs 34px documented (~24% smaller). The web dashboard has no nav bar — the masthead wordmark is the closest analogue to iOS's large title, but it was deliberately tuned down to fit the compact sticky masthead (DESIGN.md's rem value looks like a direct 16px-root translation of the iOS role that was never re-checked against the shipped masthead). Not silently changed — flagged for an owner call: either re-tune the table's number, or note the wordmark as an intentionally-smaller sibling role."
+				}
+			},
+			"headline": {
+				"label": "Seksjonstittel",
+				"ios": { "textStyle": ".headline", "weight": null },
+				"web": {
+					"designMd": "1.0rem semibold",
+					"designMdPx": 16,
+					"cssActual": null,
+					"discrepancy": "No dedicated web selector implements this role today. The web dashboard has no distinct section-header surface between the masthead wordmark and the day-group label (.day-name, which is the 'Gruppeoverskrift' role, not this one) — a single-column agenda has no nested sections to title. Recorded as iOS-only in practice (e.g. Deg-screen list group headers)."
+				}
+			},
+			"rowTitle": {
+				"label": "Radtittel",
+				"ios": { "textStyle": ".body", "weight": null },
+				"web": {
+					"designMd": "1.0rem",
+					"designMdPx": 16,
+					"cssActual": { "selector": ".ev-title", "file": "docs/css/cards.css", "fontSize": "16px", "fontWeight": 400 },
+					"discrepancy": null
+				}
+			},
+			"time": {
+				"label": "Tid (rad)",
+				"ios": { "textStyle": ".body", "weight": "semibold", "tabular": true },
+				"web": {
+					"designMd": "tabular",
+					"designMdPx": null,
+					"cssActual": { "selector": ".ev-time", "file": "docs/css/cards.css", "fontSize": "16px", "fontWeight": 600, "fontVariantNumeric": "tabular-nums" },
+					"discrepancy": null
+				}
+			},
+			"meta": {
+				"label": "Meta / kanal",
+				"ios": { "textStyle": ".subheadline", "color": "secondaryLabel" },
+				"web": {
+					"designMd": ".9rem dempet",
+					"designMdPx": 14.4,
+					"cssActual": { "selector": ".ev-meta", "file": "docs/css/cards.css", "fontSize": "14px", "color": "--fg-2" },
+					"discrepancy": null
+				}
+			},
+			"groupHeader": {
+				"label": "Gruppeoverskrift",
+				"ios": { "textStyle": ".footnote", "textTransform": "uppercase", "color": "secondaryLabel" },
+				"web": {
+					"designMd": ".8rem",
+					"designMdPx": 12.8,
+					"cssActual": { "selector": ".day-name", "file": "docs/css/cards.css", "fontSize": "13px", "fontWeight": 700, "textTransform": "uppercase", "color": "--accent" },
+					"discrepancy": "Size is a 0.2px whole-pixel rounding, not flagged. Colour is NOT mismatched: DESIGN.md's typography table only prescribes text style + size, not colour; the day header's amber colour is a deliberate, separately-documented choice ('day headers are one of the five amber uses', docs/css/cards.css) rather than a drift from the iOS 'secondaryLabel' shown in this same table row for the analogous iOS role."
+				}
+			},
+			"caption": {
+				"label": "Caption",
+				"ios": { "textStyle": ".caption", "weight": null },
+				"web": {
+					"designMd": ".75rem",
+					"designMdPx": 12,
+					"cssActual": { "selector": ".ev-status / .ev-done / .ev-where-more", "file": "docs/css/cards.css", "fontSize": "12px" },
+					"discrepancy": null
+				}
+			}
+		},
+		"fontStack": {
+			"$description": "DESIGN.md: systemfont (San Francisco) overalt, via SwiftUI tekststiler on iOS / a system-font stack on web (docs/ is baseline per § Cross-surface — the historical Tekst-TV mono stack was retired).",
+			"ios": "San Francisco (system, via SwiftUI Font.system(_:))",
+			"web": "-apple-system, BlinkMacSystemFont, \"SF Pro Text\", \"Segoe UI\", Roboto, system-ui, sans-serif"
+		}
+	},
+
+	"spacing": {
+		"$description": "DESIGN.md § Rytme & layout: 8pt basis grid (4pt fine tuning). Values verbatim from ios/Sportivista/DesignTokens.swift SportivistaSpacing (web has no equivalent named scale — component CSS uses literal px that are multiples of 4/8, e.g. 12px/16px/22px/28px paddings in cards.css/layout.css; see cssObserved for a sample).",
+		"xs": { "$type": "dimension", "$value": "4px", "$description": "fine tuning", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.xs" } } },
+		"s": { "$type": "dimension", "$value": "8px", "$description": "the basis unit", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.s" } } },
+		"m": { "$type": "dimension", "$value": "12px", "$description": "inset-group corner / tight grouping", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.m", "web": ".ev row padding (docs/css/cards.css)" } } },
+		"l": { "$type": "dimension", "$value": "16px", "$description": "standard content inset", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.l" } } },
+		"xl": { "$type": "dimension", "$value": "24px", "$description": "section spacing", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.xl" } } },
+		"xxl": { "$type": "dimension", "$value": "32px", "$description": "large section spacing", "$extensions": { "sportivista": { "swift": "SportivistaSpacing.xxl", "discrepancy": "Web's analogous day-group gap (.day { margin-top: 28px }) is 28px, between xl (24) and xxl (32) — DESIGN.md itself documents 28pt as the day-group rhythm ('28pt of air before the header, 10pt after'), so this is a THIRD, agenda-specific rhythm value that sits outside the iOS xs..xxl scale rather than a drift from it." } } },
+		"minRowHeight": { "$type": "dimension", "$value": "44px", "$description": "Radhøyde ≥ 44pt (tap target).", "$extensions": { "sportivista": {} } }
+	},
+
+	"radius": {
+		"$description": "DESIGN.md § Rytme & layout: inset-grouped list card corner.",
+		"card": { "$type": "dimension", "$value": "12px", "$description": "Inset-grupperte lister: kort med 12pt hjørne." },
+		"mustSeeDot": { "$type": "dimension", "$value": "50%", "$description": "Web must-see dot (.ev-dot, docs/css/cards.css) is a 7×7px circle (border-radius:50%) — the web rendering of the iOS 'liten amber-prikk' signal; no separate DESIGN.md size is prescribed, 7px is the shipped value." }
+	},
+
+	"layout": {
+		"$description": "Web-only layout tokens (DESIGN.md § Rytme & layout + § Cross-surface: web keeps its own layout details on top of the shared baseline tokens above).",
+		"maxWidth": { "$type": "dimension", "$value": "640px", "$description": "Én lesekolonne, maks 640pt på store flater, sentrert.", "$extensions": { "sportivista": { "web": "--max-w" } } },
+		"timeColumn": { "$type": "dimension", "$value": "120px", "$description": "Fixed time column so titles align + a date window fits one line.", "$extensions": { "sportivista": { "web": "--time-col" } } }
+	}
+}

--- a/docs/styleguide.html
+++ b/docs/styleguide.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="nb">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+	<meta name="description" content="Sportivista sin levende stilguide — tokens og kjernekomponenter, rendret med de ekte stilarkene.">
+	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
+	<link rel="icon" type="image/png" href="favicon.png">
+	<title>Sportivista · Stilguide</title>
+	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle
+	     — same pre-paint snippet as index.html/activity.html/rediger.html. -->
+	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
+	<!-- The real stylesheets — no duplicated tokens or component CSS. Every swatch
+	     and component below is rendered with these files, unmodified. -->
+	<link rel="stylesheet" href="css/base.css">
+	<link rel="stylesheet" href="css/layout.css">
+	<link rel="stylesheet" href="css/cards.css">
+	<style>
+		/* Styleguide-only chrome (page layout for this page alone — not design
+		   tokens; every colour below is a var(--x) from base.css, never a literal). */
+		.sg-intro { color: var(--fg-2); font-size: 0.95rem; line-height: 1.6; max-width: 62ch; margin: 0 0 8px; }
+		.sg-intro code { font-family: var(--font); background: color-mix(in srgb, var(--fg) 8%, transparent); padding: 1px 5px; border-radius: 4px; font-size: 0.92em; }
+		.sg-links { color: var(--fg-3); font-size: 0.85rem; margin: 0 0 40px; line-height: 1.7; }
+		.sg-links a { color: var(--accent); }
+		.sg-section { margin: 0 0 52px; }
+		.sg-section > h2 {
+			font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em;
+			color: var(--accent); font-weight: 700; margin: 0 0 6px;
+			padding-bottom: 8px; border-bottom: 1px solid var(--line);
+		}
+		.sg-section > p.sg-note { color: var(--fg-3); font-size: 0.82rem; font-style: italic; margin: 0 0 18px; line-height: 1.5; }
+
+		/* Colour swatches */
+		.sg-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 14px; }
+		.sg-swatch { border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+		.sg-swatch-fill { height: 56px; }
+		.sg-swatch-info { padding: 8px 10px; }
+		.sg-swatch-name { font-size: 0.82rem; color: var(--fg); font-weight: 600; }
+		.sg-swatch-role { font-size: 0.72rem; color: var(--fg-2); margin-top: 1px; }
+		.sg-swatch-hex { font-size: 0.72rem; color: var(--fg-3); margin-top: 4px; font-variant-numeric: tabular-nums; }
+		.sg-swatch-hex .sg-live-value { color: var(--fg-2); }
+		.sg-swatch.sg-na { opacity: 0.55; }
+		.sg-swatch.sg-na .sg-swatch-hex::after { content: " · ikke i bruk på web"; }
+
+		/* Typography scale table */
+		.sg-type-row { display: grid; grid-template-columns: 150px 1fr; gap: 18px; align-items: baseline; padding: 14px 0; border-bottom: 1px solid var(--line); }
+		.sg-type-row:last-child { border-bottom: none; }
+		.sg-type-label { font-size: 0.78rem; color: var(--fg-3); text-transform: uppercase; letter-spacing: 0.05em; }
+		.sg-type-sample { min-width: 0; }
+		.sg-type-meta { display: block; font-size: 0.72rem; color: var(--fg-3); margin-top: 4px; font-style: italic; }
+
+		/* Spacing scale */
+		.sg-space-row { display: flex; align-items: center; gap: 14px; margin: 10px 0; }
+		.sg-space-box { background: var(--accent); height: 14px; }
+		.sg-space-label { font-size: 0.8rem; color: var(--fg-2); font-variant-numeric: tabular-nums; width: 130px; }
+
+		/* Brand */
+		.sg-brand-row { display: flex; align-items: center; gap: 28px; flex-wrap: wrap; margin-bottom: 18px; }
+		.sg-icon-demo { width: 72px; height: 72px; border-radius: 16px; }
+		.sg-wordmark-demo { font-size: 34px; }
+
+		/* Buttons / "no pills" */
+		.sg-btn-row { display: flex; gap: 22px; flex-wrap: wrap; align-items: center; margin-bottom: 14px; }
+
+		.sg-code { display: block; white-space: pre-wrap; font-family: var(--font); font-size: 0.78rem; color: var(--fg-2); background: color-mix(in srgb, var(--fg) 6%, transparent); border-radius: 8px; padding: 12px 14px; overflow-x: auto; }
+	</style>
+</head>
+<body>
+	<header class="masthead">
+		<div class="wrap masthead-inner">
+			<div class="mast-row mast-row-top">
+				<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
+				<button class="theme-toggle" id="theme-toggle" title="Bytt tema (system / mørk / lys)" aria-label="Bytt tema">◐</button>
+			</div>
+			<div class="mast-row mast-row-sub">
+				<p class="mast-date">Stilguide</p>
+			</div>
+		</div>
+	</header>
+
+	<main class="wrap">
+		<p class="sg-intro">
+			Denne siden er et arbeidsverktøy, ikke en produktflate: tokens og
+			kjernekomponenter rendret med de ekte stilarkene (<code>css/base.css</code>,
+			<code>css/layout.css</code>, <code>css/cards.css</code>) — ingen duplisert
+			CSS. Fargeverdiene under er lest live fra CSS-variablene (bytt tema med
+			◐-knappen for å se begge). <code>design/tokens.json</code> er den
+			maskinlesbare fasiten som binder denne siden, <code>DESIGN.md</code> og
+			<code>ios/Sportivista/DesignTokens.swift</code> sammen — se
+			<code>tests/design-tokens.test.js</code>.
+		</p>
+		<p class="sg-links">
+			Referanse:
+			<a href="https://github.com/CHaerem/sportivista/blob/main/DESIGN.md">DESIGN.md</a> ·
+			<a href="https://github.com/CHaerem/sportivista/blob/main/design/tokens.json">design/tokens.json</a> ·
+			<a href="https://github.com/CHaerem/sportivista/blob/main/design/brand/BRAND.md">design/brand/BRAND.md</a> ·
+			<a href="https://github.com/CHaerem/sportivista/blob/main/design/brand/kolonet.svg">kolonet.svg</a>
+		</p>
+
+		<!-- ── Farger ──────────────────────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Farger</h2>
+			<p class="sg-note">Verdiene byttes med temaet — trykk ◐ i toppen. Nøytraler er Apple-systemfarger på iOS; her er de web sine <code>base.css</code>-egenverdier.</p>
+			<div class="sg-swatches" id="sg-swatches"></div>
+		</section>
+
+		<!-- ── Typografi ───────────────────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Typografi</h2>
+			<p class="sg-note">Systemfont-stack overalt (San Francisco-familien), tabulære siffer i tidskolonnen. iOS binder hver rolle til en Dynamic Type-tekststil; web-verdiene under er de faktiske <code>font-size</code>-ene i CSS-en (se <code>design/tokens.json</code> for avvik mot DESIGN.md sin prosa-tabell).</p>
+
+			<div class="sg-type-row">
+				<span class="sg-type-label">Stor tittel</span>
+				<div class="sg-type-sample">
+					<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
+					<span class="sg-type-meta">.wordmark — 26px/700 · iOS <code>.largeTitle</code> bold (dokumentert avvik i design/tokens.json — masthead er tunet ned fra DESIGN.md sin 2.125rem)</span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Seksjonstittel</span>
+				<div class="sg-type-sample">
+					<span style="font-size:16px; font-weight:600;">Eksempel seksjonstittel</span>
+					<span class="sg-type-meta">Ingen egen web-klasse i dag (ingen nestede seksjoner i én-kolonne agendaen) — iOS <code>.headline</code>. Vist her som ren stil, 1.0rem semibold.</span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Radtittel</span>
+				<div class="sg-type-sample">
+					<span class="ev-title">Manchester United – Liverpool</span>
+					<span class="sg-type-meta">.ev-title — 16px/400 · iOS <code>.body</code></span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Tid (rad)</span>
+				<div class="sg-type-sample">
+					<span class="ev-time">20:00</span>
+					<span class="sg-type-meta">.ev-time — 16px/600, tabular-nums · iOS <code>.body</code> semibold + <code>monospacedDigit</code></span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Meta / kanal</span>
+				<div class="sg-type-sample">
+					<span class="ev-meta">Premier League<span class="ev-sep"> · </span><span class="ev-where">TV 2 Sport</span></span>
+					<span class="sg-type-meta">.ev-meta — 14px, --fg-2 · iOS <code>.subheadline</code>, secondaryLabel</span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Gruppeoverskrift</span>
+				<div class="sg-type-sample">
+					<p class="day-name" style="margin:0;">I DAG</p>
+					<span class="sg-type-meta">.day-name — 13px/700 uppercase, amber (én av de fem godkjente amber-bruken) · iOS <code>.footnote</code> uppercase, secondaryLabel</span>
+				</div>
+			</div>
+			<div class="sg-type-row">
+				<span class="sg-type-label">Caption</span>
+				<div class="sg-type-sample">
+					<span class="ev-status">Utsatt</span>
+					<span class="sg-type-meta">.ev-status / .ev-done — 12px · iOS <code>.caption</code></span>
+				</div>
+			</div>
+		</section>
+
+		<!-- ── Rytme ───────────────────────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Rytme &amp; layout</h2>
+			<p class="sg-note">8pt-basisgrid (4pt finjustering) — se <code>ios/Sportivista/DesignTokens.swift</code> SportivistaSpacing + <code>design/tokens.json</code>.</p>
+			<div id="sg-spacing"></div>
+			<p class="sg-note" style="margin-top:14px;">Én lesekolonne, maks <strong style="color:var(--fg-2)">640px</strong>, sentrert (<code>--max-w</code>) · fast tidskolonne <strong style="color:var(--fg-2)">120px</strong> (<code>--time-col</code>, 112px på smale skjermer) · kort-hjørne <strong style="color:var(--fg-2)">12px</strong> · minste tapp-mål <strong style="color:var(--fg-2)">44px</strong>.</p>
+		</section>
+
+		<!-- ── Merkelås ────────────────────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Merkelåsen — kolonet</h2>
+			<p class="sg-note">Full spek i <a href="https://github.com/CHaerem/sportivista/blob/main/design/brand/BRAND.md">design/brand/BRAND.md</a>. Kildevektor: <code>design/brand/kolonet.svg</code> — to amber sirkler, radius 118 / avstand 168 på 1024-rammen.</p>
+			<div class="sg-brand-row">
+				<img class="sg-icon-demo" src="icons/icon-512x512.png" alt="Sportivista-ikonet: to amber prikker vertikalt (kolonet) på sort bakgrunn" width="72" height="72">
+				<span class="wordmark-lockup sg-wordmark-demo"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
+			</div>
+			<p class="sg-note">Wordmark + kolon: null mellomrom (<code>.wordmark-lockup</code>), kolonet ett hakk tyngre enn ordmerket (iOS: bold ordmerke + heavy kolon), én tilgjengelighets-etikett («Sportivista»). På web er HELE ordmerket amber (én av de fem godkjente amber-bruken i <code>base.css</code>); på iOS/widget er kun kolonet amber — et dokumentert, bevisst avvik mellom flatene (se BRAND.md).</p>
+		</section>
+
+		<!-- ── Knapper / "ingen pills" ─────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Knapper &amp; tagger — ingen pills</h2>
+			<p class="sg-note">DESIGN.md sin forbudsliste utelukker pills/badges. Handlinger er flat tekst med hover-understrek mot amber; tagger er en punktseparert linje, aldri chips.</p>
+			<div class="sg-btn-row">
+				<button class="theme-toggle" style="margin-left:0;" aria-label="Eksempel tema-knapp">◐ tema</button>
+				<button class="ev-act">Følg</button>
+				<button class="ev-act">Demp</button>
+				<button class="agenda-more" style="margin:0; display:inline-block;">Vis resten →</button>
+			</div>
+			<p class="chips-row" style="margin:0;">
+				<span class="chip-follow">Eliteserien</span><span class="chip-follow">Formel 1</span><span class="chip-follow">Sjakk-VM</span>
+			</p>
+		</section>
+
+		<!-- ── Agenda-rad-anatomi ──────────────────────────────────────────── -->
+		<section class="sg-section">
+			<h2>Agenda-rad-anatomi</h2>
+			<p class="sg-note">Nøyaktig samme DOM som <code>docs/js/dashboard.js</code> sin <code>eventRow()</code> bygger — kopiert her, ikke en tilnærming. Ærlighet: ukjent kanal viser et rolig «–», aldri en påstand.</p>
+
+			<div class="day">
+				<p class="day-name">I DAG</p>
+
+				<div class="ev-wrap">
+					<div class="ev must expandable" role="button" tabindex="0" aria-expanded="false">
+						<span class="ev-dot" aria-hidden="true"></span>
+						<span class="ev-time">18:00</span>
+						<span class="ev-main"><span class="ev-title">Norge – Sverige</span><span class="ev-meta">Nations League<span class="ev-sep"> · </span><span class="ev-where"><a href="#" onclick="return false;">TV 2 Play</a></span></span></span>
+						<span class="ev-info" aria-label="Funnet av AI — trykk for kilder">ⓘ</span>
+					</div>
+					<div class="ev-detail" hidden></div>
+				</div>
+
+				<div class="ev-wrap">
+					<div class="ev">
+						<span></span>
+						<span class="ev-time">20:45</span>
+						<span class="ev-main"><span class="ev-title">Bodø/Glimt – Molde</span><span class="ev-meta">Eliteserien<span class="ev-sep"> · </span><span class="ev-where unknown">–</span></span></span>
+						<span></span>
+					</div>
+					<div class="ev-detail" hidden></div>
+				</div>
+
+				<div class="ev-wrap">
+					<div class="ev cancelled">
+						<span></span>
+						<span class="ev-time">14:00</span>
+						<span class="ev-main"><span class="ev-title">Rosenborg – Brann</span><span class="ev-meta">Eliteserien<span class="ev-sep"> · </span><span class="ev-status">Utsatt</span></span></span>
+						<span></span>
+					</div>
+					<div class="ev-detail" hidden></div>
+				</div>
+
+				<div class="ev-wrap">
+					<div class="ev">
+						<span class="ev-dot" aria-hidden="true"></span>
+						<span class="ev-time">Pågår</span>
+						<span class="ev-main"><span class="ev-title">Viktor Hovland — The Open</span><span class="ev-meta">Runde 3<span class="ev-sep"> · </span><span class="ev-where ev-live">−4 (t14)</span></span></span>
+						<span></span>
+					</div>
+					<div class="ev-detail" hidden></div>
+				</div>
+			</div>
+
+			<p class="sg-note" style="margin-top:18px;">[• amber] — «must-see»: favoritt / viktighet ≥ 4 / norsk. Aldri en emoji, aldri en stripe eller kort — kun prikken.</p>
+		</section>
+	</main>
+
+	<footer class="site-footer wrap">
+		<span>Sportivista · stilguide</span>
+		<a href="index.html">Tilbake til agendaen</a>
+	</footer>
+
+	<script src="js/theme.js"></script>
+	<script>
+		// Colour swatches — read the REAL computed CSS custom-property values
+		// (getComputedStyle), never a hardcoded hex, so this page cannot drift
+		// silently from base.css. Re-renders whenever the theme changes (the
+		// toggle button, or the OS-level prefers-color-scheme).
+		const SWATCHES = [
+			{ cssVar: '--bg', name: 'background / groupedBackground', role: 'sideflate' },
+			{ cssVar: '--surface', name: 'cell', role: 'liste-/kort-flate' },
+			{ cssVar: '--fg', name: 'label', role: 'primærtekst' },
+			{ cssVar: '--fg-2', name: 'secondaryLabel', role: 'meta/kanal/dempet' },
+			{ cssVar: '--fg-3', name: 'tertiaryLabel', role: 'fainter (ikke i DESIGN.md-tabellen ennå — se tokens.json)' },
+			{ cssVar: '--line', name: 'separator', role: 'hårlinje/skille' },
+			{ cssVar: '--accent', name: 'accent', role: 'ENESTE aksent (amber)' },
+			{ cssVar: '--accent-ink', name: 'accentInk', role: 'tekst på amber-flate (web-only)' },
+			{ cssVar: '--live', name: 'live / good', role: 'direkte / positiv' },
+		];
+
+		function renderSwatches() {
+			const cs = getComputedStyle(document.documentElement);
+			const el = document.getElementById('sg-swatches');
+			el.innerHTML = SWATCHES.map((s) => {
+				const value = cs.getPropertyValue(s.cssVar).trim();
+				return `<div class="sg-swatch">
+					<div class="sg-swatch-fill" style="background:var(${s.cssVar});"></div>
+					<div class="sg-swatch-info">
+						<div class="sg-swatch-name">${s.cssVar}</div>
+						<div class="sg-swatch-role">${s.role}</div>
+						<div class="sg-swatch-hex"><span class="sg-live-value">${value}</span></div>
+					</div>
+				</div>`;
+			}).join('') + `
+				<div class="sg-swatch sg-na">
+					<div class="sg-swatch-fill" style="background:#2C2C2E;"></div>
+					<div class="sg-swatch-info">
+						<div class="sg-swatch-name">cell2</div>
+						<div class="sg-swatch-role">nøstet/hevet flate</div>
+						<div class="sg-swatch-hex">#2C2C2E / #FFFFFF</div>
+					</div>
+				</div>
+				<div class="sg-swatch sg-na">
+					<div class="sg-swatch-fill" style="background:#FF453A;"></div>
+					<div class="sg-swatch-info">
+						<div class="sg-swatch-name">destructive</div>
+						<div class="sg-swatch-role">slett/nullstill</div>
+						<div class="sg-swatch-hex">#FF453A / #FF3B30</div>
+					</div>
+				</div>`;
+		}
+
+		// Spacing scale — px values verbatim from design/tokens.json / SportivistaSpacing.
+		const SPACING = [
+			{ label: 'xs', px: 4 }, { label: 's', px: 8 }, { label: 'm', px: 12 },
+			{ label: 'l', px: 16 }, { label: 'xl', px: 24 }, { label: 'xxl', px: 32 },
+			{ label: 'day-group (web)', px: 28 },
+		];
+		function renderSpacing() {
+			document.getElementById('sg-spacing').innerHTML = SPACING.map((s) =>
+				`<div class="sg-space-row"><span class="sg-space-label">${s.label} — ${s.px}px</span><span class="sg-space-box" style="width:${s.px * 3}px;"></span></div>`
+			).join('');
+		}
+
+		renderSwatches();
+		renderSpacing();
+		// Re-render swatches after any theme change: the toggle mutates
+		// document.documentElement.dataset.theme, so watch that attribute.
+		new MutationObserver(renderSwatches).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', renderSwatches);
+	</script>
+</body>
+</html>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Zenji v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-3';
+const CACHE_NAME = 'sportivista-v1-4';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [
@@ -23,7 +23,8 @@ const SHELL_FILES = [
     '/js/chrome.js',
     '/rediger.html',
     '/js/edit.js',
-    '/activity.html'
+    '/activity.html',
+    '/styleguide.html'
 ];
 
 self.addEventListener('install', (event) => {

--- a/tests/design-tokens.test.js
+++ b/tests/design-tokens.test.js
@@ -1,0 +1,233 @@
+// design/tokens.json coherence gate (WP-97 · Design-biblioteket): the token
+// library LOCKS today's shipped reality — it does not change it. This test
+// verifies the same three surfaces the file itself claims to synchronise:
+//   (a) tokens.json parses and has the expected shape
+//   (b) docs/css/base.css custom properties match the token hex values per theme
+//   (c) ios/Sportivista/DesignTokens.swift's semantic colour mappings match
+//       the token's documented `ios` semantic name (source-grep, same style as
+//       the HIG CI gate in tests/ios-dynamic-type-gate.test.js — this repo does
+//       not compile Swift in CI, so coherence is verified via source text)
+//   (d) DESIGN.md § Tokens prose table matches the token's hex values — DESIGN.md
+//       is the prose fasit, tokens.json is the machine-readable one; they must agree
+//
+// Any drift on any of the three surfaces is a real product bug (a rebrand or a
+// one-off CSS edit silently diverging from the documented contract) and must
+// fail CI, not be "fixed" by this test.
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const ROOT = process.cwd();
+const tokens = JSON.parse(fs.readFileSync(path.join(ROOT, "design", "tokens.json"), "utf-8"));
+const baseCss = fs.readFileSync(path.join(ROOT, "docs", "css", "base.css"), "utf-8");
+const designTokensSwift = fs.readFileSync(
+	path.join(ROOT, "ios", "Sportivista", "DesignTokens.swift"),
+	"utf-8"
+);
+const designMd = fs.readFileSync(path.join(ROOT, "DESIGN.md"), "utf-8");
+
+/** Read `key: { $value }` for a colour token in a given theme, tolerating $extensions.web == null. */
+function colorValue(key, theme) {
+	const t = tokens.color[key];
+	if (!t) throw new Error(`no such color token: ${key}`);
+	return t[theme].$value;
+}
+
+describe("design/tokens.json — shape", () => {
+	it("parses and has the expected top-level groups", () => {
+		for (const group of ["color", "typography", "spacing", "radius", "layout"]) {
+			expect(tokens[group], group).toBeTruthy();
+		}
+	});
+
+	it("every color token declares both a dark and a light $value", () => {
+		for (const [name, t] of Object.entries(tokens.color)) {
+			if (name.startsWith("$")) continue; // group-level metadata (e.g. $description), not a token
+			expect(t.dark?.$value, `${name}.dark`).toBeTruthy();
+			expect(t.light?.$value, `${name}.light`).toBeTruthy();
+			expect(t.$type, `${name}.$type`).toBe("color");
+		}
+	});
+});
+
+describe("design/tokens.json ⇄ docs/css/base.css", () => {
+	// base.css custom properties this test can verify directly against a hex/rgba
+	// literal (skips tokens the file itself documents as web-absent, e.g. cell2,
+	// destructive — see each token's $extensions.sportivista.discrepancy).
+	const cssVarByToken = {
+		background: "--bg",
+		groupedBackground: "--bg",
+		cell: "--surface",
+		label: "--fg",
+		secondaryLabel: "--fg-2",
+		tertiaryLabel: "--fg-3",
+		separator: "--line",
+		accent: "--accent",
+		accentInk: "--accent-ink",
+		live: "--live",
+	};
+
+	/** Extract `--var: value;` from a `:root { ... }` or `:root[data-theme="light"] { ... }` block. */
+	function cssVarValue(cssVar, theme) {
+		const block =
+			theme === "dark"
+				? baseCss.match(/:root\s*\{([^}]*)\}/s)?.[1]
+				: baseCss.match(/:root\[data-theme="light"\]\s*\{([^}]*)\}/s)?.[1];
+		expect(block, `${theme} :root block found in base.css`).toBeTruthy();
+		const m = block.match(new RegExp(`${cssVar}:\\s*([^;]+);`));
+		expect(m, `${cssVar} declared in ${theme} block`).toBeTruthy();
+		return m[1].trim();
+	}
+
+	for (const theme of ["dark", "light"]) {
+		for (const [token, cssVar] of Object.entries(cssVarByToken)) {
+			it(`${theme}: ${token} (${cssVar}) matches base.css`, () => {
+				expect(cssVarValue(cssVar, theme)).toBe(colorValue(token, theme));
+			});
+		}
+	}
+});
+
+describe("design/tokens.json ⇄ ios/Sportivista/DesignTokens.swift", () => {
+	// Semantic-colour source grep: each entry maps a token to the Swift line that
+	// must be present verbatim (the UIColor case name the token documents as
+	// `$extensions.sportivista.ios`, or the literal hex pair for accent/live/destructive).
+	const semanticChecks = [
+		{ token: "background", needle: "static let background = Color(uiColor: .systemGroupedBackground)" },
+		{ token: "groupedBackground", needle: "static let groupedBackground = Color(uiColor: .systemGroupedBackground)" },
+		{ token: "cell", needle: "static let cell = Color(uiColor: .secondarySystemGroupedBackground)" },
+		{ token: "cell2", needle: "static let cell2 = Color(uiColor: .tertiarySystemBackground)" },
+		{ token: "label", needle: "static let label = Color(uiColor: .label)" },
+		{ token: "secondaryLabel", needle: "static let secondaryLabel = Color(uiColor: .secondaryLabel)" },
+		{ token: "separator", needle: "static let separator = Color(uiColor: .separator)" },
+	];
+
+	for (const { token, needle } of semanticChecks) {
+		it(`${token}: DesignTokens.swift declares the documented semantic mapping`, () => {
+			expect(
+				designTokensSwift.includes(needle),
+				`expected DesignTokens.swift to contain:\n  ${needle}`
+			).toBe(true);
+		});
+	}
+
+	// accent / live / destructive carry explicit hex (not a system colour) — verify
+	// the literal 0xRRGGBB pairs match tokens.json's dark/light $value.
+	const explicitHexChecks = [
+		{ token: "accent", swiftName: "accent" },
+		{ token: "live", swiftName: "live" },
+		{ token: "destructive", swiftName: "destructive" },
+	];
+
+	function hexPairFor(swiftName) {
+		const re = new RegExp(
+			`static let ${swiftName} = Color\\.sportivista\\(dark: Color\\(hex: 0x([0-9A-Fa-f]{6})\\), light: Color\\(hex: 0x([0-9A-Fa-f]{6})\\)\\)`
+		);
+		const m = designTokensSwift.match(re);
+		expect(m, `${swiftName} hex pair found in DesignTokens.swift`).toBeTruthy();
+		return { dark: `#${m[1].toUpperCase()}`, light: `#${m[2].toUpperCase()}` };
+	}
+
+	for (const { token, swiftName } of explicitHexChecks) {
+		it(`${token}: DesignTokens.swift hex literals match tokens.json`, () => {
+			const { dark, light } = hexPairFor(swiftName);
+			expect(dark).toBe(colorValue(token, "dark"));
+			expect(light).toBe(colorValue(token, "light"));
+		});
+	}
+
+	// tertiaryLabel is NOT in the SportivistaTokens enum (views call
+	// Color(uiColor: .tertiaryLabel) directly) — tokens.json documents this gap
+	// explicitly; assert the gap itself hasn't silently closed or widened, so a
+	// change either way is a deliberate edit to this test, not an accident.
+	it("tertiaryLabel: still bypasses the token enum today (documented gap, not a silent add)", () => {
+		expect(designTokensSwift.includes("static let tertiaryLabel")).toBe(false);
+		expect(designTokensSwift.includes(".tertiaryLabel")).toBe(false); // not even referenced in this file
+	});
+
+	// Spacing scale: verify SportivistaSpacing literals match tokens.json.spacing.
+	const spacingChecks = [
+		["xs", "4"],
+		["s", "8"],
+		["m", "12"],
+		["l", "16"],
+		["xl", "24"],
+		["xxl", "32"],
+	];
+	for (const [key, cgFloat] of spacingChecks) {
+		it(`spacing.${key}: DesignTokens.swift SportivistaSpacing matches tokens.json`, () => {
+			const re = new RegExp(`static let ${key}: CGFloat = ${cgFloat}\\b`);
+			expect(designTokensSwift.match(re), `SportivistaSpacing.${key} == ${cgFloat}`).toBeTruthy();
+			expect(tokens.spacing[key].$value).toBe(`${cgFloat}px`);
+		});
+	}
+});
+
+describe("design/tokens.json ⇄ DESIGN.md § Tokens (prose fasit)", () => {
+	// DESIGN.md's colour table is `| token | rolle | mørk | lys |` markdown rows.
+	// Verify each documented hex pair matches tokens.json (skip rows the table
+	// doesn't literally give a hex for, e.g. `live`/`good` share one row).
+	const rows = [
+		{ token: "background", md: "background" },
+		{ token: "groupedBackground", md: "groupedBackground" },
+		{ token: "cell", md: "cell" },
+		{ token: "cell2", md: "cell2" },
+		{ token: "label", md: "label" },
+		{ token: "accent", md: "accent" },
+		{ token: "destructive", md: "destructive" },
+	];
+
+	function mdRowHexes(mdToken) {
+		const re = new RegExp(
+			"\\|\\s*(?:\\*\\*)?`" + mdToken + "`(?:\\*\\*)?\\s*\\|[^|]*\\|\\s*`([^`]+)`\\s*\\|\\s*`([^`]+)`\\s*\\|"
+		);
+		const m = designMd.match(re);
+		expect(m, `DESIGN.md § Tokens row for \`${mdToken}\` found`).toBeTruthy();
+		return { dark: m[1], light: m[2] };
+	}
+
+	for (const { token, md } of rows) {
+		it(`${token}: DESIGN.md § Farge row matches tokens.json`, () => {
+			const { dark, light } = mdRowHexes(md);
+			expect(dark).toBe(colorValue(token, "dark"));
+			expect(light).toBe(colorValue(token, "light"));
+		});
+	}
+
+	it("DESIGN.md § Tokens references design/tokens.json as the machine-readable fasit", () => {
+		expect(designMd.includes("design/tokens.json")).toBe(true);
+	});
+});
+
+describe("red-proof: this suite fails on a real value drift (see PR description for the mutate/revert transcript)", () => {
+	// This is not a live mutation test (that would need a scratch copy of
+	// base.css + DesignTokens.swift + DESIGN.md re-required mid-suite, which
+	// vitest's ESM module cache makes brittle). Instead it asserts the exact
+	// invariant whose violation the suite above is built to catch: token hex
+	// equality across all three surfaces for the accent colour, the one token
+	// every surface renders identically today. If this passes while any of the
+	// three sources is hand-edited to a different hex, the suite above already
+	// caught it in its own per-surface assertions (each is independently red on
+	// a mismatch, per the PR's documented mutate/run/revert proof).
+	it("accent hex is identical across tokens.json, base.css, DesignTokens.swift and DESIGN.md", () => {
+		const fromTokens = { dark: colorValue("accent", "dark"), light: colorValue("accent", "light") };
+		const cssBlockDark = baseCss.match(/:root\s*\{([^}]*)\}/s)[1];
+		const cssBlockLight = baseCss.match(/:root\[data-theme="light"\]\s*\{([^}]*)\}/s)[1];
+		const fromCss = {
+			dark: cssBlockDark.match(/--accent:\s*([^;]+);/)[1].trim(),
+			light: cssBlockLight.match(/--accent:\s*([^;]+);/)[1].trim(),
+		};
+		const swiftMatch = designTokensSwift.match(
+			/static let accent = Color\.sportivista\(dark: Color\(hex: 0x([0-9A-Fa-f]{6})\), light: Color\(hex: 0x([0-9A-Fa-f]{6})\)\)/
+		);
+		const fromSwift = { dark: `#${swiftMatch[1].toUpperCase()}`, light: `#${swiftMatch[2].toUpperCase()}` };
+		const mdMatch = designMd.match(
+			/\|\s*\*\*`accent`\*\*[^|]*\|[^|]*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|/
+		);
+		const fromMd = { dark: mdMatch[1], light: mdMatch[2] };
+
+		expect(fromCss).toEqual(fromTokens);
+		expect(fromSwift).toEqual(fromTokens);
+		expect(fromMd).toEqual(fromTokens);
+	});
+});


### PR DESCRIPTION
## Summary

Locks TODAY's shipped design reality into one machine-readable source and adds
coherence tests — per the WP-97 principle, this PR **verifies, never
redesigns**. No visual change on any surface.

- **`design/tokens.json`** (W3C design-tokens-format): colour (dark/light,
  incl. iOS semantic mapping + resolved hex per token), typography roles,
  spacing, radius — extracted from `docs/css/base.css` +
  `ios/Sportivista/DesignTokens.swift`, cross-referenced against `DESIGN.md`
  § Tokens.
- **`tests/design-tokens.test.js`** (48 tests): parses tokens.json; verifies
  `base.css` custom properties match per theme; verifies
  `DesignTokens.swift`'s semantic mappings + explicit hex literals + spacing
  scale via source-grep (same style as the existing HIG gate,
  `tests/ios-dynamic-type-gate.test.js`); verifies `DESIGN.md` § Tokens prose
  rows. **Red-proof:** mutated `--accent` in `base.css` to `#FFB001`, ran the
  suite (2 tests failed with a clear diff), reverted, ran again (green) —
  transcript below.
- **`design/brand/`**:
  - `kolonet.svg` — source vector, two `#FFB000` filled circles on
    transparent. Geometry was **not assumed** — reverse-engineered by loading
    the shipped `AppIcon-1024.png` into a CoreGraphics context and scanning
    pixel runs: radius 118, vertical edge-to-edge gap 168, on the 1024 frame.
  - `generate-icons.swift` — checked-in, parametrised CoreGraphics
    regenerator (`swift design/brand/generate-icons.swift <out.png> <size>
    [background]`, or `--all <dir>` for the whole shipped set). The icon
    script previously only ever existed in a session scratchpad; it does now.
  - `BRAND.md` — construction rules read directly from
    `ContentView.swift`/`OnboardingView.swift`/`SportivistaWidget.swift`
    (zero-gap lockup, colon one weight heavier, tracking, single
    accessibility label), minimum sizes (verified down to 16×16 by rendering
    and checking the two dots stay visually separate), misuse list, tagline.
- **`docs/styleguide.html`** — living reference page. Links the real
  `base.css`/`layout.css`/`cards.css` (no duplicated CSS); colour swatches
  read `getComputedStyle` live (re-render on theme change, so this page
  cannot silently drift from `base.css`); the agenda-row demo is the literal
  DOM `dashboard.js`'s `eventRow()` builds, not an approximation. Cache
  bumped `sportivista-v1-3` → `v1-4`, `styleguide.html` added to the
  precached shell.
- **`DESIGN.md` § Tokens** — one added pointer paragraph to
  `design/tokens.json` as the machine-readable fasit + the coherence test;
  the rest of the section is untouched.
- **`PLAN.md`** — WP-97 row ⬜ → 🔬 PR åpen, with a "Levert i denne PR-en"
  bullet.

## Verification

- `npx vitest run --maxWorkers=1` → **42 files / 590 tests green**, including
  the new 48.
- **Red-proof transcript:**
  ```
  $ sed -i '' 's/--accent: #FFB000;/--accent: #FFB001;/' docs/css/base.css
  $ npx vitest run tests/design-tokens.test.js
   FAIL … dark: accent (--accent) matches base.css
   FAIL … red-proof … accent hex is identical across …
   Test Files  1 failed (1)
        Tests  2 failed | 46 passed (48)
  $ # reverted docs/css/base.css
  $ npx vitest run tests/design-tokens.test.js
   Test Files  1 passed (1)
        Tests  48 passed (48)
  ```
- **Icon regeneration:** `swift design/brand/generate-icons.swift --all
  <scratchdir>` then pixel-diffed (full RGBA buffer, not just file bytes)
  against every shipped icon:
  ```
  AppIcon-1024.png: 1024x1024, differing channel-bytes=0, maxDelta=0
  icon-512x512.png: 512x512,  differing channel-bytes=0, maxDelta=0
  icon-192x192.png: 192x192,  differing channel-bytes=0, maxDelta=0
  icon-180x180.png: 180x180,  differing channel-bytes=0, maxDelta=0
  favicon.png:      192x192,  differing channel-bytes=0, maxDelta=0
  ```
  **Pixel-identical** on all five. The PNG *files* are ~12 bytes larger than
  the generated ones — PNG chunk inspection shows this is entirely an `eXIf`
  metadata chunk (56 vs 68 bytes); the `IDAT` (pixel data) chunks are the
  same length.
- **Screenshots** of `docs/styleguide.html` taken in both themes (Playwright,
  `prefers-color-scheme: dark`/`light`) and reviewed — calm, no truncation/
  overflow, consistent with the shipped dashboard's look.

## Discrepancies found (documented, not silently fixed)

Per the task instruction, cross-surface mismatches are recorded in
`design/tokens.json`'s `$extensions.sportivista.discrepancy` fields and in
`BRAND.md`, not quietly resolved:

1. **`tertiaryLabel` / `--fg-3`** is used on *both* platforms
   (`base.css --fg-3`; `AgendaView.swift:423` and `DegView.swift:227` call
   `Color(uiColor: .tertiaryLabel)` directly) but is in neither
   `DESIGN.md` § Farge's table nor the `SportivistaTokens` enum — both
   platforms agree on the value in practice, the token layer just hasn't
   caught up.
2. **Wordmark "Stor tittel" role:** web ships at 26px
   (`.wordmark`/`.wordmark-colon`, `layout.css`); `DESIGN.md`'s table
   documents `2.125rem` (34px) for this role. A real ~24% gap, not
   sub-pixel rounding — the web dashboard has no nav bar, so the masthead
   wordmark is the closest analogue but was tuned down for the compact
   sticky masthead independently of the table's number.
3. **Wordmark colour construction:** on web the *entire* wordmark is amber
   (one of the five sanctioned amber uses documented in `base.css`); on
   iOS/widget only the colon is amber, the wordmark itself is `label`
   colour. Recorded in `BRAND.md` as an intentional, not a drifted, choice
   (see its § Construction rules #5 for the reasoning).

None of these were "fixed" — each is an owner call (retune the table, extend
the Swift enum, or leave as documented platform variance).

## Not touched

`.github/**`, `.github/actions/**`, `scripts/hooks/**`,
`scripts/config/interests.json`, `.claude/settings.json`, all of `ios/**`
(read-only — inspected `DesignTokens.swift`/`ContentView.swift`/
`OnboardingView.swift`/`SportivistaWidget.swift`, no Swift edits),
`docs/css/base.css`/other docs files beyond `styleguide.html` +
`sw.js`'s cache bump, `docs/data/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>