### PR TITLE
WP-98: Brand-harmonisering + skjermkatalog

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -62,6 +62,7 @@ Apple-system-farger + én amber-aksent. Ved rebrand endres KUN denne tabellen.
 | `cell2` | nøstet/hevet flate | `#2C2C2E` | `#FFFFFF` |
 | `label` | primærtekst | `#FFFFFF` | `#000000` |
 | `secondaryLabel` | meta/kanal/dempet | `rgba(235,235,245,.6)` | `rgba(60,60,67,.6)` |
+| `tertiaryLabel` | fainter, ett hakk under dempet | `rgba(235, 235, 245, 0.3)` | `rgba(60, 60, 67, 0.3)` |
 | `separator` | hårlinje/skille | `rgba(84,84,88,.6)` | `#C6C6C8` |
 | **`accent`** | **ENESTE aksent (amber)** | `#FFB000` | `#9A6800` |
 | `live` / `good` | direkte / positiv (systemGreen) | `#30D158` | `#34C759` |
@@ -84,7 +85,7 @@ Apple-system-farger + én amber-aksent. Ved rebrand endres KUN denne tabellen.
 
 | Rolle | Tekststil (iOS) | Web |
 |---|---|---|
-| Stor tittel (nav) | `.largeTitle` bold | `2.125rem` |
+| Ordmerke (masthead) | `.title` bold | `1.75rem` |
 | Seksjonstittel | `.headline` | `1.0rem` semibold |
 | Radtittel | `.body` | `1.0rem` |
 | Tid (rad) | `.body` semibold + `monospacedDigit` | tabular |

--- a/PLAN.md
+++ b/PLAN.md
@@ -104,6 +104,7 @@ mennesket, aldri av en agent.
 | WP-95 | Deltakelses-ferskhet (cut/trekning — eier-funn) | 0G | – | ✅ merget (#307) — ESPN core-API competitor-status (lett-scoreboardet skjuler cut mid-turnering; én billig henting per fulgt spiller, fail-soft); verify/editorial/grader-kontrakter tettet; web viser rolig status; iOS trengte null endring (LensRenderer var klar). 536 tester. LIVE-BEKREFTET: Hovland «røk cutten» på tavla 12:47 UTC — før kveldsbriefen 15:00. NY PORT: null feilaktige deltaker-statuser |
 | WP-96 | Flerbruker-splitten (interests → katalog) — GATE for eksterne testere | 0G | portmåling | ✅ merget (#308) — `catalog.json` (tier1 bredt + tier2 elite-langhale, nøkternt seedet; tennis via tier2-majors for å unngå ATP/WTA-flom); `isCovered(catalog)` server-side, personlig presisjon eies av linsen alene; vektorer IKKE re-frosset (semantisk riktig: linsen uendret — pinner nå klienten, DIVERGENCES §6); to-profil-aksepttest (eier uendret + Nakamura-sjakk + NAVI-CS2 → alle meningsfulle fra samme feed); interests.json avpublisert, web viser «Dette dekker vi»; agent-kompass → katalogen; ICS/mustWatch bevisst eier-artefakt; rediger = «be om dekning» (skrivevei → WP-23). 542 JS + 526 iOS + vektorer bit-like + 4 schemes |
 | WP-97 | Design-biblioteket (tokens.json + koherens + brand-assets + styleguide) | 0G | – | ✅ merget (#309) — tokens.json (W3C) + 48 koherens-tester m/ rød-bevis; kolonet.svg pikselskannet fra shipped ikon; generate-icons.swift piksel-identisk verifisert; BRAND.md fra faktisk kilde; styleguide.html fra ekte CSS begge temaer; 590 tester. TRE AVVIK DOKUMENTERT (ikke stille fikset): (1) tertiaryLabel brukt men udokumentert/utenom token-enum; (2) web-wordmark 26px vs DESIGN.md 34px; (3) web-wordmark helamber vs iOS' label+amber-kolon-merkelås — web avviker fra godkjent merkelås. Oppfølger: harmoniser de tre |
+| WP-98 | Brand-harmonisering + skjermkatalog | 0G | WP-97 | 🔬 PR åpen |
 
 ---
 
@@ -1089,6 +1090,51 @@ scratchpad. Repoets signaturgrep anvendes: verifisering fremfor kodegen.
   ordmerke er HELT amber (én av fem sanksjonerte amber-bruk i `base.css`),
   mens iOS/widget kun farger kolonet amber — dokumentert som bevisst
   flate-avvik i BRAND.md, ikke rettet.
+
+### WP-98 · Brand-harmonisering + skjermkatalog — 🔬 PR åpen
+Oppfølger til WP-97: løser de tre dokumenterte avvikene (fasit: det som
+shipper på iOS er den eier-godkjente merkelåsen) + bygger en innsjekket
+skjermkatalog-generator som Claude Design kan bruke (iOS-skjermer kan ikke
+web-captures).
+- **Innhold:** (1) `docs/css/layout.css` `.wordmark` fra hel-amber til
+  `var(--fg)` (label), kun `.wordmark-colon` amber — matcher iOS/widgets
+  merkelås (`ContentView.swift`/`OnboardingView.swift`/`SportivistaWidget.swift`);
+  (2) wordmark-størrelsen 26px → 28px (~1.75rem) — matcher iOS' faktisk
+  shippede `.title` bold (~28pt), IKKE den tabell-dokumenterte, aldri wired
+  opp `.largeTitle`/2.125rem (ingen skjerm i appen bruker native large-title
+  nav — `.navigationBarTitleDisplayMode(.inline)` overalt); DESIGN.md-tabellens
+  rad omdøpt «Stor tittel (nav)» → «Ordmerke (masthead)» + tokens.json + Swift-
+  kommentaren rettet til samme sannhet; (3) `tertiaryLabel` inn i systemet:
+  ny token i `design/tokens.json` (discrepancy fjernet, historikk-notat i
+  `$description` i stedet), ny rad i DESIGN.md § Farge, `SportivistaTokens.tertiaryLabel`
+  i `DesignTokens.swift`, migrerte `AgendaView.swift:423` + `DegView.swift:227`
+  fra rå `Color(uiColor: .tertiaryLabel)`; `tests/design-tokens.test.js` utvidet
+  (semantisk mapping + DESIGN.md-rad + migrerings-grep på begge kallsteder);
+  BRAND.md § Construction rule 5 omskrevet (harmonisert, ikke lenger «bevisst
+  avvik»); `docs/styleguide.html` + `base.css`/`layout.css`-kommentarer rettet
+  til «wordmark colon» i femer-listen over amber-bruk. (2) `design/screens/generate.sh`
+  (innsjekket, kjørbar) — bygger `Sportivista`-scheme (Debug, eksplisitt
+  `-derivedDataPath`), booter «iPhone 17», installerer FERSKT (avinstallerer
+  først), looper alle 17 `SPORTIVISTA_DEMO`-moduser × begge temaer
+  (`simctl ui appearance`) → 34 PNG-er i en OUTPUT-katalog (default
+  `/tmp/sportivista-screens/`, aldri innsjekket); `design/screens/README.md`
+  forklarer bruken mot Claude Design + moduskatalogen.
+- **Ikke-mål:** relevans-/feed-logikk (urørt — token-migreringen er ren
+  stil); web-reskin utover merkelås-fiksen (den generelle Tekst-TV → baseline
+  web-reskinen er en egen, senere WP); iOS-komponentgalleri.
+- **Aksept:** `npx vitest run --maxWorkers=1` grønn (594 tester, inkl. 52 i
+  det utvidede design-tokens-testsettet) — ingen gjenstående discrepancy-unntak
+  trengs for grønt (testene sjekker verdier, ikke feltet, men de tre feltene
+  er nå fjernet fra tokens.json siden avvikene er løst); `xcodegen generate` +
+  full unit-suite (526 tester) + alle 4 schemes (`Sportivista`,
+  `SportivistaDeviceDev`, `SportivistaUITests`, `SportivistaWidgetExtension`)
+  bygger grønt; skjermkatalog-scriptet kjørt og minst 4 skjermer på tvers av
+  moduser/temaer visuelt inspisert (riktig skjerm, riktig tema, ingen
+  home-screen-feilskudd).
+- **Levert i denne PR-en:** se commit-diff — CSS-fiksen er en synlig endring
+  på live-siten (meningen: retter drift mot godkjent design), øvrig er
+  dokumentasjons-/token-/test-harmonisering + det nye, innsjekkede
+  skjerm-scriptet.
 
 ## FLYTTEDAGEN · Zenji → Sportivista — ✅ UTFØRT 17.07.2026
 

--- a/design/brand/BRAND.md
+++ b/design/brand/BRAND.md
@@ -55,18 +55,18 @@ vertically, on their own.
    (`.accessibilityElement(children: .ignore)` + `.accessibilityLabel("Sportivista")`
    on every surface that renders the lockup). Never let a screen reader
    announce the colon separately ("Sportivista, colon").
-5. **Colour — a documented cross-surface divergence, not a bug.** On iOS +
-   widget, only the colon is amber; the wordmark itself is `label` (system
-   text colour, white/black). On web, the **entire wordmark is amber**
-   (`.wordmark { color: var(--accent); }`) — this is one of web's five
+5. **Colour — one lock, both surfaces (harmonised WP-98).** The wordmark
+   itself is `label` (system text colour, white/black); only the colon is
+   amber. This is now identical on iOS, widget, AND web
+   (`.wordmark { color: var(--fg); }` / `.wordmark-colon { color: var(--accent);
+   }`, `docs/css/layout.css`) — the wordmark colon is one of web's five
    explicitly sanctioned amber uses (`docs/css/base.css`: "Amber is the ONLY
-   accent and is used only for: wordmark, day headers, the must-see dot, the
-   clock, selected state"). Do not "fix" either surface to match the other —
-   this file records both as intentional: the web masthead is a persistent,
-   single-purpose brand mark at the top of a otherwise text-only page and can
-   afford a bolder brand treatment; the iOS header sits inside more chrome
-   (nav bar, toolbar) where a fully-amber wordmark would compete with the
-   HIG rule of one accent per surface used sparingly.
+   accent and is used only for: the wordmark colon, day headers, the must-see
+   dot, the clock, selected state"). Before WP-98, web shipped the entire
+   wordmark in amber — a drift from the owner-approved lock the iOS/widget
+   surfaces always used, not an intentional platform variance. It was
+   corrected, not left as documented divergence: the shipped-iOS lock is the
+   fasit (see `design/tokens.json` and the WP-98 PR).
 6. **No separate image mark next to text.** When the mark appears as *text*
    (wordmark contexts), it is always the literal wordmark + `":"` glyph in
    the app's own font — never the `kolonet.svg` dots rendered inline next to

--- a/design/screens/README.md
+++ b/design/screens/README.md
@@ -1,0 +1,82 @@
+# Screen catalog (WP-98)
+
+Input material for Claude Design: a full set of real, rendered Sportivista
+iOS screens, both system appearances. iOS screens cannot be produced from web
+captures (SwiftUI renders nothing a browser can screenshot) — this is the only
+way to hand Claude Design the actual shipped UI rather than a description of
+it.
+
+## Generating
+
+```bash
+design/screens/generate.sh [output-dir]     # default output-dir: /tmp/sportivista-screens/
+```
+
+Requires Xcode + a booted-capable "iPhone 17" simulator (or set
+`SPORTIVISTA_SCREENS_SIMULATOR` to another available simulator name). The
+script builds the `Sportivista` scheme (Debug — the screenshot harness is
+`#if DEBUG`-only), boots the simulator, installs a fresh copy of the app
+(uninstalling any existing install first, so the icon/state is clean), and
+loops every deterministic `SPORTIVISTA_DEMO` mode across both themes
+(`xcrun simctl ui appearance dark|light`), settling ~6s per screen before
+capturing.
+
+## What gets captured
+
+One PNG per `(mode, theme)` pair — 17 modes × 2 themes = 34 screenshots,
+named `<mode>-<theme>.png`:
+
+| Mode | Screen |
+|---|---|
+| `uitest` | The XCUITest harness's deterministic seeded agenda (real board content, no network) |
+| `lens` | Agenda through a seeded interest lens (athlete-centred rows) |
+| `filter` | Agenda with an active presentation filter ("VISER: GOLF") |
+| `share` | Profile share sheet (QR + link) with a seeded non-empty profile |
+| `deg` | The Deg (Profile/Settings) screen with a seeded profile + memory |
+| `memory` | "Hva jeg vet om deg" (What I know about you) page |
+| `spoiler` | A spoiler-masked event detail sheet |
+| `onboarding-welcome` | Onboarding: welcome step |
+| `onboarding-converse` | Onboarding: converse step, with a pending follow-diff (FORSLAG block) |
+| `onboarding-quickpicks` | Onboarding: quick-picks step (a starter pack toggled on) |
+| `onboarding-landing` | Onboarding: landing step, overlay still up |
+| `onboarding-landed` | Post-onboarding: overlay dismissed, the real filled agenda underneath |
+| `reset-entry` | Deg screen with a seeded profile (entry point toward Nullstill) |
+| `reset-confirm` | Same Deg entry point — the env-only harness doesn't drive the extra tap into the nested Nullstill confirmation row, so this mode is currently indistinguishable from `reset-entry` in a screenshot (see `ContentView.swift`'s `mode.hasPrefix("reset")` branch: both cases just `showDeg = true`) |
+| `reset-onboarding` | The real reset flow re-raising onboarding |
+| `diff` | Assistant result sheet: a grounded follow proposal (diff) |
+| `answer` | Assistant result sheet: an answer with agenda rows |
+
+The complete, authoritative mode list lives in
+`ios/Sportivista/ContentView.swift`'s `.task` demo-seeding switch,
+`onboardingInitialStep`, and `ios/Sportivista/Demo/*.swift` — re-derive it
+from there if the app grows new modes; do not extend this list independently.
+
+## Screenshots are never checked in
+
+The PNGs are throwaway working material for a design review — regenerate
+them whenever the review needs fresh screens, hand the output directory to
+Claude Design, then discard it. Nothing under `/tmp/sportivista-screens/` (or
+whatever `output-dir` you pass) is part of the repo, and this directory has no
+`.gitignore` entry for images because none should ever land here to begin
+with.
+
+## Verifying a run
+
+Look at a handful of screenshots across different modes and both themes
+before trusting a batch:
+
+- Right screen for the mode (e.g. `deg-dark.png` actually shows the Deg
+  screen, not a stale agenda).
+- Right theme (dark = near-black system background, light = grouped light).
+- No home-screen/springboard captures (a mistimed launch can catch the icon
+  grid instead of the app — the ~6s settle + terminate-before-launch guards
+  against this, but a slow Mac under parallel load can still catch it).
+
+**Known artifact (app bug, not a script bug — logged for follow-up, not fixed
+here):** `onboarding-landing`/`onboarding-landed` reproducibly show the
+multi-day golf rows ("The Open", "Corales Puntacana Championship") with their
+date range and title text overlapping in the `I DAG` group, in both themes,
+even at a much longer (12s) settle — so it is a genuine `AgendaView` row-height
+layout issue with this seeded state, not a screenshot-timing flake. Worth a
+follow-up (visual-qa/ui-fix territory), out of scope for the brand-
+harmonisation + catalog-tooling work this script was built for.

--- a/design/screens/generate.sh
+++ b/design/screens/generate.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# design/screens/generate.sh — WP-98 screen catalog for Claude Design.
+#
+# iOS screens cannot be produced from web captures (SwiftUI is not the DOM),
+# so this is the input material Claude Design needs to reason about the real
+# shipped app: it builds the Sportivista scheme, boots a simulator, installs
+# it fresh, and loops every `SPORTIVISTA_DEMO` deterministic-screenshot mode
+# (see `ios/Sportivista/Demo/` + `ios/Sportivista/ContentView.swift`) across
+# both system appearances, capturing one PNG per (mode, theme) pair.
+#
+# PNGs are NEVER checked in (see README.md next to this script) — this script
+# is the checked-in, re-runnable generator; its output is throwaway working
+# material for a design review, not a repo artifact.
+#
+# Usage:
+#   design/screens/generate.sh [output-dir]
+#     output-dir  defaults to /tmp/sportivista-screens/
+#
+# Env overrides:
+#   SPORTIVISTA_SCREENS_SIMULATOR   simulator name (default: "iPhone 17")
+#
+set -euo pipefail
+
+SIMULATOR_NAME="${SPORTIVISTA_SCREENS_SIMULATOR:-iPhone 17}"
+OUTPUT_DIR="${1:-/tmp/sportivista-screens}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/../../ios" && pwd)"
+# Explicit derived-data path — NEVER glob ~/Library/DerivedData for the built
+# .app. Each `xcodegen generate` can change the project's hash and produce a
+# NEW DerivedData directory; a glob (`ls DerivedData/Sportivista-*`) can
+# silently pick up a stale product from a previous project generation. See
+# the ios-dev skill's "Flere DerivedData-kataloger" pitfall.
+DERIVED_DATA="$IOS_DIR/build/DerivedData-screens"
+BUNDLE_ID="app.sportivista.ios"
+SCHEME="Sportivista"
+APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphonesimulator/Sportivista.app"
+
+# The complete set of deterministic `SPORTIVISTA_DEMO` modes, discovered by
+# reading ios/Sportivista/ContentView.swift's `.task` demo-seeding switch +
+# `onboardingInitialStep` + `ios/Sportivista/Demo/*.swift`. Two onboarding
+# modes look similar but differ in a load-bearing way: "onboarding-landing"
+# raises the onboarding overlay AT the landing step; "onboarding-landed"
+# suppresses the overlay entirely and shows the real, filled agenda behind it
+# (the state right after a user finishes onboarding) — both are real, distinct
+# screens and both are captured.
+MODES=(
+	uitest
+	lens
+	filter
+	share
+	deg
+	memory
+	spoiler
+	onboarding-welcome
+	onboarding-converse
+	onboarding-quickpicks
+	onboarding-landing
+	onboarding-landed
+	reset-entry
+	reset-confirm
+	reset-onboarding
+	diff
+	answer
+)
+THEMES=(dark light)
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "==> xcodegen generate"
+(cd "$IOS_DIR" && xcodegen generate)
+
+echo "==> Resolving simulator UDID for \"$SIMULATOR_NAME\""
+SIM_LINE=$(xcrun simctl list devices available | grep -E "^\s+${SIMULATOR_NAME} \(" | head -1 || true)
+if [ -z "$SIM_LINE" ]; then
+	echo "error: no available simulator named \"$SIMULATOR_NAME\". Available devices:" >&2
+	xcrun simctl list devices available >&2
+	exit 1
+fi
+SIM_UDID=$(echo "$SIM_LINE" | grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}')
+echo "    $SIMULATOR_NAME -> $SIM_UDID"
+
+echo "==> Booting simulator (blocks until fully booted; no-op if already booted)"
+xcrun simctl bootstatus "$SIM_UDID" -b
+open -a Simulator --args -CurrentDeviceUDID "$SIM_UDID" >/dev/null 2>&1 || true
+sleep 3
+
+echo "==> Building $SCHEME (Debug — the SPORTIVISTA_DEMO harness is #if DEBUG-only)"
+xcodebuild build \
+	-project "$IOS_DIR/Sportivista.xcodeproj" \
+	-scheme "$SCHEME" \
+	-configuration Debug \
+	-destination "platform=iOS Simulator,id=$SIM_UDID" \
+	-derivedDataPath "$DERIVED_DATA" \
+	CODE_SIGNING_ALLOWED=NO \
+	ONLY_ACTIVE_ARCH=YES
+
+if [ ! -d "$APP_PATH" ]; then
+	echo "error: expected build product not found at $APP_PATH" >&2
+	exit 1
+fi
+
+echo "==> Uninstalling any existing $BUNDLE_ID (fresh icon/state)"
+xcrun simctl uninstall "$SIM_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+
+echo "==> Installing $APP_PATH"
+xcrun simctl install "$SIM_UDID" "$APP_PATH"
+
+TOTAL=0
+for theme in "${THEMES[@]}"; do
+	echo "==> Theme: $theme"
+	xcrun simctl ui "$SIM_UDID" appearance "$theme"
+	sleep 1
+
+	for mode in "${MODES[@]}"; do
+		echo "    -> $mode ($theme)"
+		xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+		# SIMCTL_CHILD_ prefix is simctl's documented way to forward an
+		# environment variable into the launched process.
+		SIMCTL_CHILD_SPORTIVISTA_DEMO="$mode" xcrun simctl launch "$SIM_UDID" "$BUNDLE_ID" >/dev/null
+		# Settle: async cache/entity loads, sheet-presentation animation,
+		# and (for onboarding/diff/answer) the mock assistant's staged
+		# reveal all need a beat before the frame is final.
+		sleep 6
+		OUT="$OUTPUT_DIR/${mode}-${theme}.png"
+		xcrun simctl io "$SIM_UDID" screenshot "$OUT" >/dev/null
+		TOTAL=$((TOTAL + 1))
+	done
+done
+
+xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+
+echo "==> Done: $TOTAL screenshots (${#MODES[@]} modes × ${#THEMES[@]} themes) in $OUTPUT_DIR"

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -59,8 +59,8 @@
 		},
 		"tertiaryLabel": {
 			"$type": "color",
-			"$description": "Fainter, one step below secondaryLabel.",
-			"$extensions": { "sportivista": { "ios": "tertiaryLabel", "web": "--fg-3", "swift": null, "discrepancy": "Real value used on BOTH surfaces (base.css --fg-3; ios AgendaView.swift:423 and DegView.swift:227 call Color(uiColor: .tertiaryLabel) directly), but it is tokenised in neither DESIGN.md § Farge (no table row) nor SportivistaTokens.swift (no enum case — views reach past the token layer to the raw UIColor). Recorded here as the machine-readable value both surfaces already agree on in practice; DESIGN.md's table and the Swift enum are the two places that could be extended to close this gap, at the owner's discretion." } },
+			"$description": "Fainter, one step below secondaryLabel. Added to DESIGN.md § Farge and SportivistaTokens.swift in WP-98 (was previously used on both surfaces — base.css --fg-3; ios AgendaView.swift/DegView.swift — but tokenised in neither the prose table nor the Swift enum; both direct Color(uiColor: .tertiaryLabel) call sites now use SportivistaTokens.tertiaryLabel).",
+			"$extensions": { "sportivista": { "ios": "tertiaryLabel", "web": "--fg-3", "swift": "SportivistaTokens.tertiaryLabel" } },
 			"dark": { "$value": "rgba(235, 235, 245, 0.3)" },
 			"light": { "$value": "rgba(60, 60, 67, 0.3)" }
 		},
@@ -73,7 +73,7 @@
 		},
 		"accent": {
 			"$type": "color",
-			"$description": "ENESTE aksent (amber). Own explicit value on both platforms (not a system colour) — used only for wordmark/day headers/must-see dot/clock/selected-state; never body text, never twice in one row.",
+			"$description": "ENESTE aksent (amber). Own explicit value on both platforms (not a system colour) — used only for the wordmark colon/day headers/must-see dot/clock/selected-state; never body text, never twice in one row. WP-98: on web the wordmark itself is now label-coloured (only the colon is amber), matching the iOS/widget brand lock — see design/brand/BRAND.md.",
 			"$extensions": { "sportivista": { "ios": "own value (Color.sportivista(dark:light:))", "web": "--accent", "swift": "SportivistaTokens.accent" } },
 			"dark": { "$value": "#FFB000" },
 			"light": { "$value": "#9A6800" }
@@ -105,13 +105,14 @@
 		"$description": "DESIGN.md § Typografi role table. `ios` binds to a Dynamic Type text style via Font.sportivista(_:weight:) — never a fixed .system(size:) point (HIG CI gate: tests/ios-dynamic-type-gate.test.js). `web.designMd` is the literal value in the DESIGN.md prose table; `web.cssActual` is the value actually shipped in docs/css/*.css today (root font-size is the browser default 16px — base.css sets no html{font-size}, so 1rem = 16px). Sub-pixel differences of ≤1px between designMd and cssActual are whole-pixel rounding of the same intent and are NOT flagged; anything larger is flagged in `discrepancy`.",
 		"roles": {
 			"largeTitle": {
-				"label": "Stor tittel (nav)",
-				"ios": { "textStyle": ".largeTitle", "weight": "bold" },
+				"label": "Ordmerke (masthead)",
+				"$description": "WP-98: renamed from 'Stor tittel (nav)' — no surface in the app actually uses SwiftUI's native large-title nav bar (every NavigationStack ships .navigationBarTitleDisplayMode(.inline)); the role's real shipped referent on iOS has always been the masthead wordmark (ContentView.swift/OnboardingView.swift: Font.sportivista(.title, weight: .bold)). The table now names + sizes the role after what actually ships, not an aspirational .largeTitle that was never wired up.",
+				"ios": { "textStyle": ".title", "weight": "bold" },
 				"web": {
-					"designMd": "2.125rem",
-					"designMdPx": 34,
-					"cssActual": { "selector": ".wordmark / .wordmark-colon", "file": "docs/css/layout.css", "fontSize": "26px", "fontWeight": 700, "textTransform": "uppercase" },
-					"discrepancy": "Real, non-rounding mismatch: 26px shipped vs 34px documented (~24% smaller). The web dashboard has no nav bar — the masthead wordmark is the closest analogue to iOS's large title, but it was deliberately tuned down to fit the compact sticky masthead (DESIGN.md's rem value looks like a direct 16px-root translation of the iOS role that was never re-checked against the shipped masthead). Not silently changed — flagged for an owner call: either re-tune the table's number, or note the wordmark as an intentionally-smaller sibling role."
+					"designMd": "1.75rem",
+					"designMdPx": 28,
+					"cssActual": { "selector": ".wordmark / .wordmark-colon", "file": "docs/css/layout.css", "fontSize": "28px", "fontWeight": 700, "textTransform": "uppercase" },
+					"discrepancy": null
 				}
 			},
 			"headline": {

--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -5,9 +5,9 @@
    no second colour. */
 
 /* Token values are the DESIGN.md § Tokens table verbatim (Apple system colours + one
-   amber accent). Amber is the ONLY accent and is used only for: wordmark, day headers,
-   the must-see dot, the clock, selected state. Live is systemGreen, sparse. Separators
-   are the Apple hairline tokens. */
+   amber accent). Amber is the ONLY accent and is used only for: the wordmark colon,
+   day headers, the must-see dot, the clock, selected state. Live is systemGreen, sparse.
+   Separators are the Apple hairline tokens. */
 :root {
 	/* Dark — the baseline default (true-black "page", system cell for depth) */
 	--bg: #000000;

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -30,9 +30,9 @@
 .wordmark-lockup { display: inline-flex; align-items: baseline; white-space: nowrap; }
 .wordmark {
 	font-weight: 700;
-	font-size: 26px;
+	font-size: 28px;                /* ~1.75rem — WP-98: matches iOS's shipped .title bold */
 	letter-spacing: 0.02em;
-	color: var(--accent);          /* amber — the wordmark is one of the five amber uses */
+	color: var(--fg);                /* label — the brand lock: only the colon is amber (WP-98, matches iOS/widget) */
 	text-transform: uppercase;
 	line-height: 1;
 }
@@ -40,8 +40,8 @@
    the app icon (two amber dots stacked, like the colon in a 18:00 clock). */
 .wordmark-colon {
 	font-weight: 700;
-	font-size: 26px;
-	color: var(--accent);
+	font-size: 28px;
+	color: var(--accent);          /* amber — the wordmark colon is one of the five amber uses */
 	line-height: 1;
 }
 .mast-date {

--- a/docs/styleguide.html
+++ b/docs/styleguide.html
@@ -114,7 +114,7 @@
 				<span class="sg-type-label">Stor tittel</span>
 				<div class="sg-type-sample">
 					<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
-					<span class="sg-type-meta">.wordmark — 26px/700 · iOS <code>.largeTitle</code> bold (dokumentert avvik i design/tokens.json — masthead er tunet ned fra DESIGN.md sin 2.125rem)</span>
+					<span class="sg-type-meta">.wordmark — 28px/700 · iOS <code>.title</code> bold (harmonisert i WP-98 — shippet iOS er fasit, se design/tokens.json)</span>
 				</div>
 			</div>
 			<div class="sg-type-row">
@@ -177,7 +177,7 @@
 				<img class="sg-icon-demo" src="icons/icon-512x512.png" alt="Sportivista-ikonet: to amber prikker vertikalt (kolonet) på sort bakgrunn" width="72" height="72">
 				<span class="wordmark-lockup sg-wordmark-demo"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
 			</div>
-			<p class="sg-note">Wordmark + kolon: null mellomrom (<code>.wordmark-lockup</code>), kolonet ett hakk tyngre enn ordmerket (iOS: bold ordmerke + heavy kolon), én tilgjengelighets-etikett («Sportivista»). På web er HELE ordmerket amber (én av de fem godkjente amber-bruken i <code>base.css</code>); på iOS/widget er kun kolonet amber — et dokumentert, bevisst avvik mellom flatene (se BRAND.md).</p>
+			<p class="sg-note">Wordmark + kolon: null mellomrom (<code>.wordmark-lockup</code>), kolonet ett hakk tyngre enn ordmerket (iOS: bold ordmerke + heavy kolon), én tilgjengelighets-etikett («Sportivista»). Merkelåsen er nå lik på begge flater (harmonisert i WP-98): ordmerket i tekstfarge (<code>--fg</code> / <code>label</code>), kun kolonet amber (én av de fem godkjente amber-bruken i <code>base.css</code>) — se BRAND.md.</p>
 		</section>
 
 		<!-- ── Knapper / "ingen pills" ─────────────────────────────────────── -->
@@ -264,7 +264,7 @@
 			{ cssVar: '--surface', name: 'cell', role: 'liste-/kort-flate' },
 			{ cssVar: '--fg', name: 'label', role: 'primærtekst' },
 			{ cssVar: '--fg-2', name: 'secondaryLabel', role: 'meta/kanal/dempet' },
-			{ cssVar: '--fg-3', name: 'tertiaryLabel', role: 'fainter (ikke i DESIGN.md-tabellen ennå — se tokens.json)' },
+			{ cssVar: '--fg-3', name: 'tertiaryLabel', role: 'fainter, ett hakk under dempet' },
 			{ cssVar: '--line', name: 'separator', role: 'hårlinje/skille' },
 			{ cssVar: '--accent', name: 'accent', role: 'ENESTE aksent (amber)' },
 			{ cssVar: '--accent-ink', name: 'accentInk', role: 'tekst på amber-flate (web-only)' },

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Zenji v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-4';
+const CACHE_NAME = 'sportivista-v1-5';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/ios/Sportivista/Agenda/AgendaView.swift
+++ b/ios/Sportivista/Agenda/AgendaView.swift
@@ -420,7 +420,7 @@ private struct TrailingMarkers: View {
             }
             Image(systemName: "chevron.forward")
                 .font(.sportivista(.footnote, weight: .semibold))
-                .foregroundStyle(Color(uiColor: .tertiaryLabel))
+                .foregroundStyle(SportivistaTokens.tertiaryLabel)
                 .accessibilityHidden(true)
         }
         .padding(.top, 2)

--- a/ios/Sportivista/DesignTokens.swift
+++ b/ios/Sportivista/DesignTokens.swift
@@ -58,6 +58,11 @@ enum SportivistaTokens {
 	/// Meta / channel / muted text. `rgba(235,235,245,.6)` / `rgba(60,60,67,.6)`.
 	static let secondaryLabel = Color(uiColor: .secondaryLabel)
 
+	/// Fainter, one step below `secondaryLabel`. `rgba(235,235,245,.3)` / `rgba(60,60,67,.3)`.
+	/// Added WP-98 — previously used on both platforms (`AgendaView`/`DegView`) via a
+	/// direct `Color(uiColor: .tertiaryLabel)` call that bypassed the token layer.
+	static let tertiaryLabel = Color(uiColor: .tertiaryLabel)
+
 	/// Hairline / separator. `rgba(84,84,88,.6)` / `#C6C6C8`.
 	static let separator = Color(uiColor: .separator)
 
@@ -120,7 +125,7 @@ extension Font {
 	/// `weight` for semibold/bold roles.
 	///
 	/// Role → style map (DESIGN.md typography table):
-	///   • Stor tittel (nav) → `.largeTitle` bold
+	///   • Ordmerke (masthead) → `.title` bold
 	///   • Seksjonstittel    → `.headline`
 	///   • Radtittel / Tid   → `.body` (Tid also `sportivistaTabular`, semibold)
 	///   • Meta / kanal      → `.subheadline` (secondaryLabel)

--- a/ios/Sportivista/Profile/DegView.swift
+++ b/ios/Sportivista/Profile/DegView.swift
@@ -224,7 +224,7 @@ struct DegView: View {
             if chevron {
                 Image(systemName: "chevron.forward")
                     .font(.sportivista(.footnote, weight: .semibold))
-                    .foregroundStyle(Color(uiColor: .tertiaryLabel))
+                    .foregroundStyle(SportivistaTokens.tertiaryLabel)
             }
         }
         .contentShape(Rectangle())

--- a/tests/design-tokens.test.js
+++ b/tests/design-tokens.test.js
@@ -99,6 +99,7 @@ describe("design/tokens.json ⇄ ios/Sportivista/DesignTokens.swift", () => {
 		{ token: "cell2", needle: "static let cell2 = Color(uiColor: .tertiarySystemBackground)" },
 		{ token: "label", needle: "static let label = Color(uiColor: .label)" },
 		{ token: "secondaryLabel", needle: "static let secondaryLabel = Color(uiColor: .secondaryLabel)" },
+		{ token: "tertiaryLabel", needle: "static let tertiaryLabel = Color(uiColor: .tertiaryLabel)" },
 		{ token: "separator", needle: "static let separator = Color(uiColor: .separator)" },
 	];
 
@@ -136,14 +137,26 @@ describe("design/tokens.json ⇄ ios/Sportivista/DesignTokens.swift", () => {
 		});
 	}
 
-	// tertiaryLabel is NOT in the SportivistaTokens enum (views call
-	// Color(uiColor: .tertiaryLabel) directly) — tokens.json documents this gap
-	// explicitly; assert the gap itself hasn't silently closed or widened, so a
-	// change either way is a deliberate edit to this test, not an accident.
-	it("tertiaryLabel: still bypasses the token enum today (documented gap, not a silent add)", () => {
-		expect(designTokensSwift.includes("static let tertiaryLabel")).toBe(false);
-		expect(designTokensSwift.includes(".tertiaryLabel")).toBe(false); // not even referenced in this file
+	// tertiaryLabel joined the token enum in WP-98 (previously views called
+	// Color(uiColor: .tertiaryLabel) directly, bypassing the token layer — see
+	// tokens.json's tertiaryLabel $description for the history). Assert the gap
+	// stays closed: the enum declares it, and both known call sites (found via
+	// the WP-97 audit) now route through SportivistaTokens.tertiaryLabel rather
+	// than the raw UIColor.
+	it("tertiaryLabel: DesignTokens.swift declares the token (WP-98 — no longer bypassed)", () => {
+		expect(designTokensSwift.includes("static let tertiaryLabel = Color(uiColor: .tertiaryLabel)")).toBe(true);
 	});
+
+	for (const file of [
+		path.join(ROOT, "ios", "Sportivista", "Agenda", "AgendaView.swift"),
+		path.join(ROOT, "ios", "Sportivista", "Profile", "DegView.swift"),
+	]) {
+		it(`tertiaryLabel: ${path.relative(ROOT, file)} uses the token, not the raw UIColor`, () => {
+			const src = fs.readFileSync(file, "utf-8");
+			expect(src.includes("Color(uiColor: .tertiaryLabel)"), "no direct UIColor call left").toBe(false);
+			expect(src.includes("SportivistaTokens.tertiaryLabel"), "migrated to the token").toBe(true);
+		});
+	}
 
 	// Spacing scale: verify SportivistaSpacing literals match tokens.json.spacing.
 	const spacingChecks = [
@@ -173,6 +186,7 @@ describe("design/tokens.json ⇄ DESIGN.md § Tokens (prose fasit)", () => {
 		{ token: "cell", md: "cell" },
 		{ token: "cell2", md: "cell2" },
 		{ token: "label", md: "label" },
+		{ token: "tertiaryLabel", md: "tertiaryLabel" },
 		{ token: "accent", md: "accent" },
 		{ token: "destructive", md: "destructive" },
 	];


### PR DESCRIPTION
## Summary

Follow-up to WP-97 (#309) — resolves the three documented brand
discrepancies (fasit: **what ships on iOS is the owner-approved brand
lock**) and adds a checked-in screen-catalog generator as input material for
Claude Design (iOS screens can't be produced from web captures).

### Del 1 — the three discrepancies, resolved

1. **Web wordmark colour.** Web shipped the entire `SPORTIVISTA` wordmark in
   amber; iOS/widget have always used label colour + an amber colon only.
   `docs/css/layout.css`: `.wordmark` now `color: var(--fg)`, only
   `.wordmark-colon` stays amber. **Visible change on the live site** —
   that's the point, it corrects drift toward the approved lock, not a
   regression.
2. **Wordmark size.** 26px → 28px (~1.75rem), matching what iOS actually
   ships: `Font.sportivista(.title, weight: .bold)` (~28pt). DESIGN.md's
   typography table previously documented `.largeTitle` bold / `2.125rem` —
   a role no screen in the app ever wires up (every `NavigationStack` ships
   `.navigationBarTitleDisplayMode(.inline)`; there is no native large-title
   nav bar anywhere). Renamed the table row "Stor tittel (nav)" →
   "Ordmerke (masthead)" and corrected `DESIGN.md`, `design/tokens.json`,
   and the `DesignTokens.swift` doc-comment to the same real number.
3. **`tertiaryLabel`.** New row in `DESIGN.md` § Farge, new
   `SportivistaTokens.tertiaryLabel` case, migrated the two raw
   `Color(uiColor: .tertiaryLabel)` call sites (`AgendaView.swift:423`,
   `DegView.swift:227`) to the token. Extended
   `tests/design-tokens.test.js` (48 → 52 tests): semantic-mapping check,
   a DESIGN.md-row check, and a source-grep asserting both call sites now
   route through the token instead of the raw `UIColor`.

All three `design/tokens.json` `$extensions.sportivista.discrepancy` notes
are replaced with resolution notes (history kept, not deleted outright).
`design/brand/BRAND.md`'s colour-divergence construction rule (#5) is
rewritten from "documented divergence" to "one lock, both surfaces."

### Del 2 — screen catalog (`design/screens/`)

- **`generate.sh`** (checked in, executable) — builds the `Sportivista`
  scheme (Debug — the `SPORTIVISTA_DEMO` harness is `#if DEBUG`-only) with
  an **explicit `-derivedDataPath`** (never globs `~/Library/DerivedData` —
  the stale-directory trap), boots the "iPhone 17" simulator
  (`simctl bootstatus -b`), **uninstalls any existing app first** (fresh
  icon/state), then loops all **17** `SPORTIVISTA_DEMO` modes I found by
  reading `ContentView.swift`'s `.task` demo-seeding switch +
  `onboardingInitialStep` + `ios/Sportivista/Demo/*.swift` — across both
  themes (`simctl ui appearance dark|light`), `SIMCTL_CHILD_`-prefixed env,
  ~6s settle per screen → 34 PNGs in an output dir (arg, default
  `/tmp/sportivista-screens/`; **never checked in**).
- **`README.md`** documents the mode catalog for Claude Design, including
  two things I only learned by actually running it (kept honest rather than
  aspirational):
  - `reset-entry` and `reset-confirm` currently render the **same** screen —
    the env-only harness only reaches `showDeg = true` for both; a real
    confirmation screen needs an in-app tap the harness doesn't drive.
  - `onboarding-landing`/`onboarding-landed` reproducibly show the multi-day
    golf rows ("The Open", "Corales Puntacana Championship") with the date
    range and title **overlapping** in both themes, even at 12s settle (so
    not a screenshot-timing flake) — a real `AgendaView` row-layout issue
    with this seeded state. Logged as a follow-up (visual-qa/ui-fix
    territory), **not fixed here** — out of scope for brand harmonisation +
    catalog tooling.

## Verification

- `npx vitest run --maxWorkers=1` → **42 files / 594 tests green** (incl.
  the extended 52-test `design-tokens.test.js`).
- `cd ios && xcodegen generate` + full unit suite: **526 tests, 0
  failures** (`xcodebuild test -scheme Sportivista`).
- All 4 schemes build: `Sportivista`, `SportivistaDeviceDev`,
  `SportivistaUITests`, `SportivistaWidgetExtension`.
- `design/screens/generate.sh` run end-to-end → 34 screenshots; inspected 6
  across different modes/themes (`deg-dark`, `onboarding-welcome-dark`,
  `reset-confirm-dark`, `lens-light`, `onboarding-landed-light/dark`) —
  right screen, right theme, no home-screen/springboard misfires.
- Web screenshots of `index.html` + `styleguide.html`, both themes, before
  vs. after: wordmark went from fully-amber-uppercase to label-coloured with
  only the colon amber, at the new 28px size — matches the iOS/widget lock.
- `docs/sw.js` cache bumped `sportivista-v1-4` → `v1-5`.

## Not touched

`.github/**`, `.github/actions/**`, `scripts/hooks/**`,
`scripts/config/interests.json`, `.claude/settings.json` · relevance/feed
logic (the golden vectors are the judge — the `tertiaryLabel` migration is
pure styling, no semantic change) · `docs/data/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>