### PR TITLE
WP-99 · Tastatur-lukking + assistent-klarhet + golf-rad-layout

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -105,6 +105,7 @@ mennesket, aldri av en agent.
 | WP-96 | Flerbruker-splitten (interests → katalog) — GATE for eksterne testere | 0G | portmåling | ✅ merget (#308) — `catalog.json` (tier1 bredt + tier2 elite-langhale, nøkternt seedet; tennis via tier2-majors for å unngå ATP/WTA-flom); `isCovered(catalog)` server-side, personlig presisjon eies av linsen alene; vektorer IKKE re-frosset (semantisk riktig: linsen uendret — pinner nå klienten, DIVERGENCES §6); to-profil-aksepttest (eier uendret + Nakamura-sjakk + NAVI-CS2 → alle meningsfulle fra samme feed); interests.json avpublisert, web viser «Dette dekker vi»; agent-kompass → katalogen; ICS/mustWatch bevisst eier-artefakt; rediger = «be om dekning» (skrivevei → WP-23). 542 JS + 526 iOS + vektorer bit-like + 4 schemes |
 | WP-97 | Design-biblioteket (tokens.json + koherens + brand-assets + styleguide) | 0G | – | ✅ merget (#309) — tokens.json (W3C) + 48 koherens-tester m/ rød-bevis; kolonet.svg pikselskannet fra shipped ikon; generate-icons.swift piksel-identisk verifisert; BRAND.md fra faktisk kilde; styleguide.html fra ekte CSS begge temaer; 590 tester. TRE AVVIK DOKUMENTERT (ikke stille fikset): (1) tertiaryLabel brukt men udokumentert/utenom token-enum; (2) web-wordmark 26px vs DESIGN.md 34px; (3) web-wordmark helamber vs iOS' label+amber-kolon-merkelås — web avviker fra godkjent merkelås. Oppfølger: harmoniser de tre |
 | WP-98 | Brand-harmonisering + skjermkatalog | 0G | WP-97 | ✅ merget (#310) — web-merkelås rettet til godkjent (label+amber-kolon, 28px; DESIGN.md-rad korrigert: ingen skjerm bruker largeTitle); tertiaryLabel inn i token-systemet (enum+migrering+test 48→52); skjermkatalog: 17 demo-moduser × 2 temaer = 34 PNG on-demand (design/screens/generate.sh). TO NYE FUNN fra kjøringen: reset-entry/-confirm rendrer samme skjerm (harness-begrensning) + EKTE AgendaView-layoutbug (overlappende tekst i flerdags-golfrader, onboarding-landing/landed, begge temaer) — logget som oppfølger. 594 JS + 526 iOS grønne |
+| WP-99 | Tastatur-lukking + assistent-klarhet + agenda-layoutbug (eier-dogfooding) | 0G | WP-98 | 🔬 PR åpen — TRE eier-funn fra fysisk-iPhone-dogfooding: (1) tastaturet i kommandolinja kunne ikke lukkes — HIG-native fiks: `.scrollDismissesKeyboard(.interactively)` på agenda+Deg, tapp-utenfor (simultaneous gesture, stjeler ikke rad-tap), lukke-glyf (`keyboard.chevron.compact.down`) i tom-fokusert-hullet; (2) uklart hva chatten kan → stående FØRSTE «Hva kan du gjøre?»-pill som ruter til eksisterende hjelp-arm (WP-68), verifisert at fokus-forslag ikke er mock-only; (3) rotårsak flerdags-golf-overlapp: `TimeColumn` (fixedSize+minWidth 58) tapte bredde-forhandlingen mot grådig `RowBody` (maxWidth .infinity) → bred dato-vindu-tekst tegnet OVER tittelen — fikset med `.layoutPriority(1)` på tidskolonnen; deterministisk offline-repro (GolfBoardDemoSeed) for onboarding-landed/-landing. Vektorer urørt (ren layout). 4 nye UI-tester + 1 unit; før/etter-skjermbilder |
 
 ---
 
@@ -1135,6 +1136,45 @@ web-captures).
   på live-siten (meningen: retter drift mot godkjent design), øvrig er
   dokumentasjons-/token-/test-harmonisering + det nye, innsjekkede
   skjerm-scriptet.
+
+### WP-99 · Tastatur-lukking + assistent-klarhet + agenda-layoutbug — 🔬 PR åpen
+Eier-funn fra dogfooding på fysisk iPhone. Tre uavhengige feil, alle på
+assistent-/agenda-flaten, fikset minimalt og HIG-native.
+- **Funn 1 — tastaturet kunne ikke lukkes (kontraktsbrudd mot DESIGN § Hjelperen).**
+  Tre native lukke-veier lagt til: (a) `.scrollDismissesKeyboard(.interactively)`
+  på agendaens `List` (`AgendaView`) + Deg-lista (`DegView`) — dra for å lukke;
+  (b) tapp-utenfor: `.simultaneousGesture(TapGesture)` på `AgendaView` i
+  `ContentView` som resignerer `commandFocused` — SIMULTAN, så en rad-tapp fortsatt
+  åpner detaljen (bevist av ny UI-test); (c) en stille lukke-glyf
+  (`keyboard.chevron.compact.down`, ≥44pt, a11y «Lukk tastaturet») i
+  trailing-slotten når feltet er TOMT og fokusert — nettopp hullet eieren traff
+  (feltet-med-tekst har send, tenking har Avbryt).
+- **Funn 2 — uklart hva chatten kan.** En stående FØRSTE pill «Hva kan du gjøre?»
+  i fokus-forslagene (`CommandLineView.focusSuggestions`), som SUBMITTER
+  (`AssistantViewModel.askForHelp`) og ruter til den EKSISTERENDE hjelp-armen
+  (WP-68 `AssistantHelp`/`getHelp`; mock-answereren matcher «kan du») — ingen ny
+  intent-logikk. Verifisert at fokus-forslagsraden IKKE er mock-only: den leser
+  `viewModel.focusSuggestions` (ren computed prop) og vises på `focused &&
+  tom`, uavhengig av FM-tilgjengelighet.
+- **Funn 3 — flerdags-golf-rad-overlapp (WP-98-oppfølger).** Rotårsak: i
+  `EventRowView`/`SeriesRowView` tapte `TimeColumn` (`.fixedSize(horizontal:)` +
+  `.frame(minWidth: 58)`) bredde-forhandlingen mot en grådig `RowBody`
+  (`.frame(maxWidth: .infinity)`). En klokke («23:20») får plass i 58pt så alt
+  gikk bra; et bredt dato-VINDU («16.–19. juli») ble under-proposert bredde,
+  rammen klemte til 58pt mens den indre fixedSize-teksten tegnet sin fulle ~130pt
+  — altså OPPÅ (og delvis av venstre kant på) tittelen. Fiks: `.layoutPriority(1)`
+  på tidskolonnen så HStacken reserverer dens fulle bredde først. Ren layout —
+  gylne vektorer/`FeedCompiler` urørt. Ny `GolfBoardDemoSeed` gir deterministisk
+  OFFLINE-repro for `onboarding-landed`/`-landing` (før lente de seg på live-
+  tavlen → nettverksfritt skjermbilde fanget bare «Henter data …»).
+- **Ikke-mål/urørt:** beskyttede stier, relevans-/feed-logikk, `docs/**`,
+  FM-intent-tolkningen (hjelp-pillen bruker eksisterende arm).
+- **Aksept:** `xcodegen generate`; full unit-suite grønn (+ 1 ny:
+  `AssistantViewModelTests.test_askForHelp_*`); vektorer bit-like; alle 4
+  schemes bygger; `SportivistaUITests` grønn inkl. 4 nye flyter (tapp-agenda
+  lukker · rad-tapp åpner detalj under fokus · tom-fokusert lukke-glyf ·
+  hjelp-pill gir svar); før/etter-skjermbilder av golf-raden + fokusert
+  tilstand; `npx vitest run --maxWorkers=1` grønn (urørt web).
 
 ## FLYTTEDAGEN · Zenji → Sportivista — ✅ UTFØRT 17.07.2026
 

--- a/ios/Sportivista/Agenda/AgendaView.swift
+++ b/ios/Sportivista/Agenda/AgendaView.swift
@@ -95,6 +95,10 @@ struct AgendaView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
+        // WP-99: HIG keyboard avoidance — dragging the agenda dismisses the
+        // command line's keyboard interactively (DESIGN § Hjelperen: "scroll
+        // lukker tastaturet"). The command line rides above via safeAreaInset.
+        .scrollDismissesKeyboard(.interactively)
         .background(SportivistaTokens.background)
         .refreshable {
             await viewModel.refresh()
@@ -133,6 +137,10 @@ struct AgendaView: View {
         Text(label)
             .font(.sportivista(.footnote, weight: .semibold))
             .foregroundStyle(SportivistaTokens.secondaryLabel)
+            // WP-99: label-independent handle for UI tests — the label is
+            // time-of-day-dependent («I DAG» has no section late at night,
+            // when the seeded now+Nh events tip past midnight).
+            .accessibilityIdentifier("agenda.dayHeader")
     }
 
     // MARK: - Rows
@@ -240,7 +248,14 @@ struct EventRowView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             MustSeeDot(on: row.isMustSee)
+            // WP-99: the time column must win width negotiation. A multi-day
+            // WINDOW ("16.–19. juli") is far wider than a clock, and without a
+            // higher layout priority the flexible RowBody (maxWidth .infinity)
+            // squeezes the column below its intrinsic width — its fixed-size text
+            // then draws OVER (and off the left of) the title. Priority makes the
+            // HStack reserve the column's full width first, RowBody takes the rest.
             TimeColumn(text: row.timeLabel)
+                .layoutPriority(1)
             RowBody(title: row.title, meta: row.metaLabel, channel: row.channelLabel)
             TrailingMarkers(reminder: row.mustWatch, aiResearch: row.isAIResearch)
         }
@@ -256,7 +271,8 @@ struct SeriesRowView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             MustSeeDot(on: false) // series rows are never visually accented (FeedCompiler.isMustSee)
-            TimeColumn(text: row.timeLabel)
+            TimeColumn(text: row.timeLabel) // WP-99: see EventRowView — priority so a wide window never draws over the title
+                .layoutPriority(1)
             RowBody(title: row.summaryLabel, meta: nil, channel: row.channelLabel)
             TrailingMarkers(reminder: row.mustWatch, aiResearch: row.isAIResearch)
         }

--- a/ios/Sportivista/Assistant/AssistantViewModel.swift
+++ b/ios/Sportivista/Assistant/AssistantViewModel.swift
@@ -799,6 +799,22 @@ final class AssistantViewModel {
     /// them with a change.
     func fillSuggestion(_ text: String) { utterance = text }
 
+    /// WP-99 — the standing "Hva kan du gjøre?" help question, used both as the
+    /// first focus-suggestion pill's label and the utterance it submits. Phrased
+    /// so it routes through the EXISTING help arm (the mock's `AssistantHelp`
+    /// capability answerer matches «kan du», the FM path reads it via the
+    /// read-only `getHelp` tool) — no new intent logic.
+    static let helpPrompt = "Hva kan du gjøre?"
+
+    /// FOCUS state, first pill: ask the assistant what it can do. Unlike
+    /// `fillSuggestion`, this DOES submit (a read-only capability question, no
+    /// mutation to confirm) so the user gets the answer immediately instead of
+    /// having to send it themselves — closing the "what can I even do here?" gap.
+    func askForHelp() {
+        utterance = Self.helpPrompt
+        run()
+    }
+
     /// TYPING state: live grounding of the in-progress utterance against the
     /// SAME entity index the grounder uses — "velg, ikke stav". Reuses
     /// `EntityIndex.nearestMatches` (no new matching logic); empty until there's

--- a/ios/Sportivista/Assistant/CommandLineView.swift
+++ b/ios/Sportivista/Assistant/CommandLineView.swift
@@ -130,6 +130,22 @@ struct CommandLineView: View {
     private var focusSuggestions: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: SportivistaSpacing.s) {
+                // WP-99: a STANDING first pill that answers "what can this line
+                // even do?" — the discoverability gap the owner hit. Unlike the
+                // example prompts (which FILL the line), it routes straight to the
+                // EXISTING help arm (WP-68 getHelp/AssistantHelp) and shows the
+                // answer — so tapping it teaches, it doesn't leave homework.
+                Button {
+                    focused = false
+                    viewModel.askForHelp()
+                } label: {
+                    Text(AssistantViewModel.helpPrompt)
+                        .font(.sportivista(.footnote))
+                        .foregroundStyle(SportivistaTokens.accent)
+                }
+                .buttonStyle(SportivistaActionButtonStyle(tint: SportivistaTokens.accent))
+                .accessibilityIdentifier("assistant.help")
+
                 ForEach(Array(viewModel.focusSuggestions.enumerated()), id: \.offset) { index, text in
                     Button {
                         viewModel.fillSuggestion(text)
@@ -218,8 +234,22 @@ struct CommandLineView: View {
                 .accessibilityIdentifier("command.send")
                 .sportivistaTapTarget()
             }
+        } else if focused {
+            // WP-99: focused but EMPTY — the send button lives in this trailing
+            // slot when there's text, so the empty-focused state was the one hole
+            // with no way to put the keyboard away (the owner-hit bug). Fill it
+            // with a quiet, HIG-native keyboard-dismiss glyph (never amber — send
+            // is the row's only amber). ≥44pt via the shared tap target.
+            Button { focused = false } label: {
+                Image(systemName: "keyboard.chevron.compact.down")
+                    .font(.sportivista(.subheadline))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+            }
+            .accessibilityLabel("Lukk tastaturet")
+            .accessibilityIdentifier("command.dismissKeyboard")
+            .sportivistaTapTarget()
         } else {
-            // Idle: the blinking prompt cursor IS the whole affordance.
+            // Idle (unfocused): the blinking prompt cursor IS the whole affordance.
             BlinkingCursor()
         }
     }

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -184,6 +184,15 @@ struct ContentView: View {
                 filterLine
                 AgendaView(viewModel: agenda, onFollow: follow, onOpen: { assistant.recordOpened($0) },
                            openEventID: $requestedEventID)
+                    // WP-99: a tap anywhere on the agenda resigns the command
+                    // line's focus (DESIGN § Hjelperen: "tapp utenfor … lukker
+                    // tastaturet"). A SIMULTANEOUS gesture, so it rides ALONGSIDE
+                    // a row's own tap — the row still opens its detail; the
+                    // keyboard just also goes away. (A drag/scroll never triggers
+                    // a TapGesture, so scrolling is untouched.)
+                    .simultaneousGesture(
+                        TapGesture().onEnded { if commandFocused { commandFocused = false } }
+                    )
             }
             // Liquid Glass (iOS 26): the command line is the app's ONE custom
             // control surface — it floats over the agenda as a glass capsule
@@ -341,6 +350,13 @@ struct ContentView: View {
                             assistant.toggleStarterPack(golf)
                         }
                     case "onboarding-landing", "onboarding-landed":
+                        // WP-99: seed a deterministic golf board (two multi-day
+                        // tournaments spanning today) so the post-onboarding
+                        // agenda renders OFFLINE — the multi-day WINDOW rows this
+                        // catalog screen is meant to show can't come from the live
+                        // board in a network-free screenshot run.
+                        GolfBoardDemoSeed.seed(profileStore: profileStore)
+                        assistant.reloadProfile()
                         if let golf = StarterPacks.all.first(where: { $0.id == "norske-golfere" }) {
                             assistant.toggleStarterPack(golf)
                         }
@@ -371,6 +387,17 @@ struct ContentView: View {
                     default:
                         break
                     }
+                }
+                // WP-99: the FOCUSED command line — the discovery row (standing
+                // «Hva kan du gjøre?» help pill + example pills) and, since the
+                // line is empty, the keyboard-dismiss glyph in the trailing slot.
+                // A screenshot mode so the focused affordances are capturable
+                // deterministically (focus can't be driven by a still image).
+                if mode == "command-focused" {
+                    GolfBoardDemoSeed.seed(profileStore: profileStore)
+                    assistant.reloadProfile()
+                    agenda.reloadFromCache(now: Date())
+                    commandFocused = true
                 }
                 assistant.demoSeed(mode)
                 // WP-83: a diff/answer screenshot renders the (slimmed) result

--- a/ios/Sportivista/Demo/GolfBoardDemoSeed.swift
+++ b/ios/Sportivista/Demo/GolfBoardDemoSeed.swift
@@ -1,0 +1,68 @@
+//
+//  GolfBoardDemoSeed.swift
+//  Sportivista
+//
+//  WP-99 — DEBUG-only screenshot harness for the post-onboarding agenda
+//  (`onboarding-landed` / `onboarding-landing`). Those modes used to lean on the
+//  LIVE board (a network round-trip), so offline the agenda captured "Henter
+//  data …" and the multi-day golf-row layout artifact the WP-98 catalog flagged
+//  could not be reproduced deterministically. This seeds a fixed golf board —
+//  two multi-day tournaments (a major + a secondary event, both spanning today)
+//  plus one football row for contrast — into the SAME cache DataStore reads,
+//  with a plain broad `golf` follow (NOT the `.throughNorwegians` lens, so the
+//  tournaments render as single multi-day WINDOW rows — "13.–20. jul." in the
+//  time column — exactly the shape that exercised the row layout).
+//
+//  Never compiled into a release build (`#if DEBUG`), and lives in
+//  Sportivista/Demo/ (WP-48) so only the app targets pick it up.
+//
+
+#if DEBUG
+import Foundation
+
+enum GolfBoardDemoSeed {
+
+	/// Seed the cache + a broad golf profile, then the caller reloads the agenda.
+	static func seed(profileStore: ProfileStore, now: Date = Date()) {
+		let cache = CacheStore()
+		let iso = ISO8601DateFormatter()
+		iso.formatOptions = [.withInternetDateTime]
+		func at(_ offsetHours: Double) -> String { iso.string(from: now.addingTimeInterval(offsetHours * 3600)) }
+		func at(days: Double) -> String { iso.string(from: now.addingTimeInterval(days * 86400)) }
+
+		let events: [[String: Any]] = [
+			[
+				"sport": "golf", "title": "The Open Championship", "tournament": "PGA Tour",
+				"time": at(-6), "endTime": at(days: 2), "norwegian": true,
+				"venue": "Royal Portrush",
+				"streaming": [["platform": "TV 2 Play", "url": "https://play.tv2.no"]],
+			],
+			[
+				"sport": "golf", "title": "Corales Puntacana Championship", "tournament": "PGA Tour",
+				"time": at(-3), "endTime": at(days: 1),
+				"venue": "Puntacana Resort & Club",
+				"streaming": [["platform": "Discovery+"]],
+			],
+			[
+				"sport": "football", "title": "Lyn – Sogndal", "tournament": "OBOS-ligaen",
+				"time": at(6), "homeTeam": "Lyn", "awayTeam": "Sogndal",
+				"streaming": [["platform": "TV 2 Play"]],
+			],
+		]
+
+		let interests: [String: Any] = [
+			"followBroadly": ["golf", "football"],
+			"alwaysTrack": ["athletes": [], "teams": [], "tournaments": []],
+		]
+
+		write(events, "events.json", cache)
+		write(interests, "interests.json", cache)
+		try? cache.writeSyncState(SyncState(etag: nil, appliedFiles: [:], lastSync: now))
+	}
+
+	private static func write(_ object: Any, _ filename: String, _ cache: CacheStore) {
+		guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+		try? cache.write(data, filename: filename)
+	}
+}
+#endif

--- a/ios/Sportivista/Profile/DegView.swift
+++ b/ios/Sportivista/Profile/DegView.swift
@@ -65,6 +65,9 @@ struct DegView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
+        // WP-99: HIG keyboard avoidance for any editable field reached from Deg
+        // (e.g. a memory-edit sheet) — dragging the list puts the keyboard away.
+        .scrollDismissesKeyboard(.interactively)
         .background(SportivistaTokens.background)
         .foregroundStyle(SportivistaTokens.label)
         .navigationTitle("Deg")

--- a/ios/SportivistaTests/AssistantViewModelTests.swift
+++ b/ios/SportivistaTests/AssistantViewModelTests.swift
@@ -85,6 +85,22 @@ final class AssistantViewModelTests: XCTestCase {
         XCTAssertTrue(tally?.summary.contains("fant ikke") ?? false)
     }
 
+    // MARK: - WP-99 — the standing "Hva kan du gjøre?" help affordance
+
+    func test_askForHelp_routesToCuratedCapabilityAnswer() async {
+        let vm = makeVM()
+        // askForHelp() fires a fire-and-forget Task; drive the underlying submit
+        // deterministically (same as run() does) after setting the standing prompt.
+        vm.utterance = AssistantViewModel.helpPrompt
+        await vm.submit()
+
+        XCTAssertNotNil(vm.answer, "«Hva kan du gjøre?» routes to the answer arm")
+        XCTAssertTrue(vm.answer?.text.contains("Jeg kan tre ting") ?? false,
+                      "the answer is the curated capability overview, not an agenda answer")
+        XCTAssertTrue(vm.pending.isEmpty, "help is read-only — there is nothing to confirm")
+        XCTAssertNil(vm.errorMessage, "a capability question is never an error")
+    }
+
     func test_submit_groundsIntoPending_withoutApplying() async {
         let vm = makeVM()
         vm.utterance = "Følg Casper Ruud bare i Grand Slams"

--- a/ios/SportivistaUITests/MainFlowsUITests.swift
+++ b/ios/SportivistaUITests/MainFlowsUITests.swift
@@ -325,4 +325,90 @@ final class MainFlowsUITests: SportivistaUITestCase {
 		app.buttons["Lukk"].tap()
 		assertExists(app.textFields["command.field"], "closing the result sheet returns to the agenda")
 	}
+
+	// MARK: - Flow 12 · Keyboard dismissal — tapping the agenda releases focus (WP-99)
+
+	func testTappingAgendaDismissesKeyboard() {
+		let app = launchApp(state: "agenda")
+
+		// Focus the command line — its discovery row (the standing help pill) rises,
+		// a reliable proxy for "the line is focused / keyboard is up".
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		let helpPill = app.buttons["assistant.help"]
+		assertExists(helpPill, "focusing the line raises the discovery row")
+
+		// Tap the agenda (a day header — part of the board, NOT a row button,
+		// so nothing opens): focus is released and the discovery row collapses,
+		// i.e. the keyboard is dismissed (DESIGN § Hjelperen). Matched by the
+		// label-independent id — the label text is time-of-day-dependent (late
+		// at night the seeded now+Nh events tip past midnight and «I DAG» has
+		// no section), which made a label match flaky.
+		let dayHeader = app.staticTexts.matching(identifier: "agenda.dayHeader").firstMatch
+		assertExists(dayHeader, "the seeded board shows a day group header")
+		dayHeader.tap()
+		assertVanishes(helpPill, "tapping the agenda should release focus and dismiss the keyboard")
+		// Still on the agenda — no sheet was opened by the outside-tap.
+		assertExists(app.textFields["command.field"], "the agenda (and its command line) stays put")
+	}
+
+	// MARK: - Flow 13 · A row tap still opens detail while the line is focused (WP-99)
+
+	func testRowTapStillOpensDetailWhileFocused() {
+		let app = launchApp(state: "agenda")
+
+		// Focus the command line first, THEN tap a row: the tap-outside dismissal
+		// is a SIMULTANEOUS gesture, so it must not steal the row's own tap.
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		assertExists(app.buttons["assistant.help"], "the line is focused")
+
+		let row = agendaRow(UITestFixture.footballTitle, in: app)
+		assertExists(row, "the followed football row should be tappable")
+		row.tap()
+		// The detail sheet opened → the row's tap was NOT swallowed by the gesture.
+		assertExists(app.staticTexts["Hvorfor vises denne?"],
+		             "a row tap must still open its detail sheet while the command line is focused")
+	}
+
+	// MARK: - Flow 14 · Empty-focused keyboard-dismiss glyph (WP-99)
+
+	func testEmptyFocusedShowsKeyboardDismissGlyph() {
+		let app = launchApp(state: "agenda")
+
+		// Focusing the EMPTY line surfaces the keyboard-dismiss glyph in the
+		// trailing slot (where send lives once there's text) — the empty-focused
+		// hole the owner hit, with no way to put the keyboard away.
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		let dismiss = app.buttons["command.dismissKeyboard"]
+		assertExists(dismiss, "an empty, focused line should offer a keyboard-dismiss glyph")
+
+		// Tapping it releases focus → the glyph (and the discovery row) collapse.
+		dismiss.tap()
+		assertVanishes(dismiss, "tapping the glyph should dismiss the keyboard / release focus")
+		assertExists(app.textFields["command.field"], "the command line stays present after dismissing")
+	}
+
+	// MARK: - Flow 15 · The standing help pill answers "what can you do?" (WP-99)
+
+	func testHelpPillAnswersCapabilityQuestion() {
+		let app = launchApp(state: "agenda")
+
+		// The standing first pill is present on focus and routes to the EXISTING
+		// help arm (WP-68), showing the capability answer in the result sheet.
+		let field = app.textFields["command.field"]
+		assertExists(field, "the command line should be present")
+		field.tap()
+		let helpPill = app.buttons["assistant.help"]
+		assertExists(helpPill, "the standing help pill should show on focus")
+		helpPill.tap()
+
+		assertExists(app.staticTexts["ASSISTENT"], "tapping the help pill should raise the assistant result sheet")
+		assertExists(staticText(containing: "Jeg kan tre ting", in: app),
+		             "the help pill should show the curated capability overview")
+	}
 }

--- a/ios/SportivistaUITests/SportivistaUITestCase.swift
+++ b/ios/SportivistaUITests/SportivistaUITestCase.swift
@@ -75,6 +75,16 @@ class SportivistaUITestCase: XCTestCase {
 		XCTAssertEqual(result, .completed, "Expected label «\(expected)», got «\(element.label)»", file: file, line: line)
 	}
 
+	/// Assert an element STOPS existing within `timeout` — the mirror of
+	/// `assertExists`, for behaviours that make a control go away (e.g. releasing
+	/// the command line's focus collapses its discovery row / dismiss glyph).
+	func assertVanishes(_ element: XCUIElement, _ message: String, file: StaticString = #filePath, line: UInt = #line) {
+		let predicate = NSPredicate(format: "exists == false")
+		let exp = expectation(for: predicate, evaluatedWith: element)
+		let result = XCTWaiter().wait(for: [exp], timeout: timeout)
+		XCTAssertEqual(result, .completed, message, file: file, line: line)
+	}
+
 	/// The first staticText whose label CONTAINS `substring` — for labels that
 	/// carry a variable tail (e.g. the "· varsler deg før start" suffix).
 	/// Uses `.matching` (the element's OWN label), not `.containing` (which


### PR DESCRIPTION
Eier-dogfooding-funn fra fysisk iPhone (se commit-melding for full tabell). Alle tre lukke-veier + «Hva kan du gjøre?»-pill + layoutPriority-fiks. UI-suite 15/15 (inkl. flake-fiks: label-uavhengig `agenda.dayHeader`-id — «I DAG» finnes ikke sent på kvelden i seedet fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)