### PR TITLE
WP-17 (del 2): første TestFlight-opplasting — compliance-flagg + iPhone-only

### DIFF
--- a/ios/Sportivista/Info.plist
+++ b/ios/Sportivista/Info.plist
@@ -35,6 +35,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/SportivistaDeviceDev/Info.plist
+++ b/ios/SportivistaDeviceDev/Info.plist
@@ -35,6 +35,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -15,7 +15,10 @@ settings:
     SWIFT_VERSION: "6.0"
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
-    TARGETED_DEVICE_FAMILY: "1,2"
+    # WP-17: iPhone-only (iPad runs the app in compatibility mode). "1,2" made
+    # App Store validation demand all four iPad-multitasking orientations,
+    # which fights the portrait-only calm design.
+    TARGETED_DEVICE_FAMILY: "1"
     IPHONEOS_DEPLOYMENT_TARGET: "26.0"
     ENABLE_PREVIEWS: YES
     # WP-10 scaffold must build+run on the Simulator with no Apple Developer
@@ -65,6 +68,9 @@ targets:
         CFBundleDisplayName: Sportivista
         CFBundlePackageType: APPL
         LSRequiresIPhoneOS: true
+        # WP-17: standard HTTPS only — declares the exemption once so every
+        # TestFlight upload skips the manual encryption-compliance question.
+        ITSAppUsesNonExemptEncryption: false
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen: {}
@@ -89,6 +95,9 @@ targets:
         PRODUCT_NAME: Sportivista
         PRODUCT_BUNDLE_IDENTIFIER: app.sportivista.ios
         CODE_SIGN_ENTITLEMENTS: Sportivista/Sportivista.entitlements
+        # WP-17: iPhone-only — XcodeGen's per-target default is "1,2", which the
+        # project-level setting does NOT override; must be set on each target.
+        TARGETED_DEVICE_FAMILY: "1"
     dependencies:
       - target: SportivistaWidgetExtension
         embed: true
@@ -129,6 +138,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.sportivista.ios.widget
         CODE_SIGN_ENTITLEMENTS: SportivistaWidget/SportivistaWidget.entitlements
         SKIP_INSTALL: YES
+        TARGETED_DEVICE_FAMILY: "1"
         # WP-17: target-level signing so the widget can be embedded in the
         # signed device build (and GUI device runs work without CLI overrides).
         # Unsigned Simulator builds of the app target are unaffected — Simulator
@@ -314,6 +324,9 @@ targets:
         CFBundleDisplayName: Sportivista
         CFBundlePackageType: APPL
         LSRequiresIPhoneOS: true
+        # WP-17: standard HTTPS only — declares the exemption once so every
+        # TestFlight upload skips the manual encryption-compliance question.
+        ITSAppUsesNonExemptEncryption: false
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
         UILaunchScreen: {}
@@ -351,6 +364,7 @@ targets:
         # ProfileSyncBackendFactory to CloudKitProfileSync.
         CODE_SIGN_ENTITLEMENTS: Sportivista/Sportivista.entitlements
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) SPORTIVISTA_CLOUDKIT"
+        TARGETED_DEVICE_FAMILY: "1"
         CODE_SIGN_STYLE: Automatic
         CODE_SIGNING_ALLOWED: YES
         CODE_SIGNING_REQUIRED: YES


### PR DESCRIPTION
To valideringsfunn fra selve opplastingen:
- ITSAppUsesNonExemptEncryption=false i begge app-Info.plists (standard HTTPS
  only) så hvert TestFlight-bygg slipper det manuelle krypteringsspørsmålet.
- TARGETED_DEVICE_FAMILY=1 (iPhone-only; iPad kjører kompatibilitetsmodus):
  "1,2" fikk App Store-validering til å kreve alle fire iPad-multitasking-
  orienteringer, som strider mot portrett-låsen i calm-designet. NB: XcodeGen
  setter "1,2" per TARGET, så prosjekt-nivå-settingen overstyres — flagget må
  stå på hvert app/widget-target.

Bygg 0.1.0 (1) arkivert, eksportert (app-store-connect, automatisk signering
via Xcode-kontoen — ASC API-nøkkelen med App Manager-rolle mangler cloud-
signing-rettigheter, lærdom notert) og LASTET OPP: «Upload succeeded»,
prosesseres i App Store Connect.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
