### PR TITLE
Versjonssjekk forstår TestFlight: «SISTE» = nyeste kode ELLER nyeste opplasting

### DIFF
--- a/.claude/skills/ios-dev/SKILL.md
+++ b/.claude/skills/ios-dev/SKILL.md
@@ -104,6 +104,17 @@ xcodebuild -exportArchive -archivePath <path>.xcarchive \
   multitasking-kravet om alle fire orienteringer i App Store-valideringen.
 - `ITSAppUsesNonExemptEncryption: false` ligger i begge app-Info.plists så
   bygg slipper compliance-spørsmålet og blir tilgjengelige umiddelbart.
+- **Opplastings-ritualet (rekkefølgen er kontrakten):** (1) bump
+  `CURRENT_PROJECT_VERSION` i project.yml (hver opplasting trenger nytt
+  byggnummer — NB: `CFBundleVersion`/`CFBundleShortVersionString` i
+  info.properties MÅ referere `$(CURRENT_PROJECT_VERSION)`/`$(MARKETING_VERSION)`;
+  XcodeGen baker ellers bokstavelig «1» og opplastingen avvises som duplikat),
+  (2) commit så ios/-treet er RENT (dirty tre gir `-dirty`-stempel som aldri
+  matcher), (3) arkiver + last opp, (4) `node scripts/record-testflight.js
+  <bygg> <versjon>` + commit — skriver scripts/config/testflight.json (utenfor
+  ios/ med vilje), som build-events folder inn i app-version.json slik at
+  TestFlight-bygg dømmes mot siste OPPLASTING, ikke siste commit («SISTE»-
+  logikken i AppVersionCheck godtar begge).
 
 - **Kabel slår wifi:** `tunnelState: unavailable` i `devicectl device info
   details` betyr at trådløs-tunnelen ikke står — plugg kabel i stedet for å

--- a/ios/Sportivista/Info.plist
+++ b/ios/Sportivista/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/Sportivista/Sync/AppVersion.swift
+++ b/ios/Sportivista/Sync/AppVersion.swift
@@ -22,6 +22,19 @@ struct AppVersion: Codable, Equatable, Sendable {
     var committedAt: String?
     /// When the pipeline published this file (informational).
     var generatedAt: String?
+    /// The last recorded TestFlight upload (WP-17) — absent until the first
+    /// recorded upload, and in dev-only checkouts.
+    var testflight: TestFlightVersion? = nil
+}
+
+struct TestFlightVersion: Codable, Equatable, Sendable {
+    /// The ios/-commit stamp the uploaded archive was built from.
+    var stamp: String
+    /// TestFlight build number (informational).
+    var build: Int? = nil
+    /// Marketing version (informational).
+    var version: String? = nil
+    var uploadedAt: String? = nil
 }
 
 /// The pure «har jeg siste versjon?»-judgement — lives here (Sync/, compiled
@@ -47,11 +60,18 @@ enum AppVersionCheck {
     /// `nil` = cannot judge (no published truth yet, or the build is
     /// unstamped). A `-dirty` build compares on its base commit — it is
     /// "current" in the honest sense of "built on top of the latest".
+    ///
+    /// Current = the newest code OR the newest SHIPPABLE build (WP-17): a
+    /// TestFlight install cannot be more current than the last recorded
+    /// upload, so ios/-commits that haven't shipped as a build must not nag
+    /// testers with «NYERE FINNES».
     static func isCurrent(stamp: String, published: AppVersion?) -> Bool? {
         guard let latest = published?.iosCommit, !latest.isEmpty,
               stamp != "ukjent", !stamp.isEmpty else { return nil }
         let base = stamp.hasSuffix("-dirty") ? String(stamp.dropLast("-dirty".count)) : stamp
-        return base == latest
+        if base == latest { return true }
+        if let shipped = published?.testflight?.stamp, !shipped.isEmpty, base == shipped { return true }
+        return false
     }
 
     /// The quiet Tekst-TV foot line: «BYGG a1b2c3d · 16.07 21:40 · SISTE»,

--- a/ios/SportivistaDeviceDev/Info.plist
+++ b/ios/SportivistaDeviceDev/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/SportivistaTests/AppVersionCheckTests.swift
+++ b/ios/SportivistaTests/AppVersionCheckTests.swift
@@ -27,6 +27,30 @@ final class AppVersionCheckTests: XCTestCase {
         XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "0ff1ce0-dirty", published: published), false)
     }
 
+    // WP-17: current = newest code ELLER newest shippable (TestFlight) build —
+    // a tester cannot be more current than the last upload, so unshipped
+    // commits must not nag them.
+    func test_stampMatchingRecordedTestflightUpload_isCurrent_evenWhenCodeMovedOn() {
+        let shipped = AppVersion(
+            iosCommit: "a1b2c3d", committedAt: nil, generatedAt: nil,
+            testflight: TestFlightVersion(stamp: "0ff1ce0", build: 3, version: "0.1.0", uploadedAt: nil)
+        )
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "0ff1ce0", published: shipped), true)
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "0ff1ce0-dirty", published: shipped), true)
+        // Neither the newest code nor the shipped build → genuinely stale.
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "dead000", published: shipped), false)
+        // The newest code is always current, testflight block or not.
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "a1b2c3d", published: shipped), true)
+    }
+
+    func test_publishedWithoutTestflightBlock_decodesAndJudgesAsBefore() throws {
+        let json = #"{"iosCommit":"a1b2c3d","committedAt":null}"#
+        let decoded = try JSONDecoder().decode(AppVersion.self, from: Data(json.utf8))
+        XCTAssertNil(decoded.testflight)
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "a1b2c3d", published: decoded), true)
+        XCTAssertEqual(AppVersionCheck.isCurrent(stamp: "0ff1ce0", published: decoded), false)
+    }
+
     func test_noPublishedTruth_orUnstampedBuild_hasNoVerdict() {
         XCTAssertNil(AppVersionCheck.isCurrent(stamp: "a1b2c3d", published: nil))
         XCTAssertNil(AppVersionCheck.isCurrent(stamp: "ukjent", published: published))

--- a/ios/SportivistaWidget/Info.plist
+++ b/ios/SportivistaWidget/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -14,7 +14,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     MARKETING_VERSION: "0.1.0"
-    CURRENT_PROJECT_VERSION: "2"
+    CURRENT_PROJECT_VERSION: "3"
     # WP-17: iPhone-only (iPad runs the app in compatibility mode). "1,2" made
     # App Store validation demand all four iPad-multitasking orientations,
     # which fights the portrait-only calm design.
@@ -66,6 +66,11 @@ targets:
       properties:
         CFBundleDevelopmentRegion: nb
         CFBundleDisplayName: Sportivista
+        # WP-17: XcodeGen bakes LITERAL "1.0"/"1" unless the keys explicitly
+        # reference the build settings — TestFlight build 2 shipped as
+        # CFBundleVersion 1 because of this (duplicate, rejected in processing).
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundlePackageType: APPL
         LSRequiresIPhoneOS: true
         # WP-17: standard HTTPS only — declares the exemption once so every
@@ -130,6 +135,11 @@ targets:
       properties:
         CFBundleDevelopmentRegion: nb
         CFBundleDisplayName: Sportivista
+        # WP-17: XcodeGen bakes LITERAL "1.0"/"1" unless the keys explicitly
+        # reference the build settings — TestFlight build 2 shipped as
+        # CFBundleVersion 1 because of this (duplicate, rejected in processing).
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:
@@ -322,6 +332,11 @@ targets:
       properties:
         CFBundleDevelopmentRegion: nb
         CFBundleDisplayName: Sportivista
+        # WP-17: XcodeGen bakes LITERAL "1.0"/"1" unless the keys explicitly
+        # reference the build settings — TestFlight build 2 shipped as
+        # CFBundleVersion 1 because of this (duplicate, rejected in processing).
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundlePackageType: APPL
         LSRequiresIPhoneOS: true
         # WP-17: standard HTTPS only — declares the exemption once so every

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -5,7 +5,7 @@ import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, MS_PER_DAY, matchInterest, mustWatchEntity, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
 import { resolveStreaming } from "./lib/norwegian-rights.js";
 import { writeManifest } from "./build-manifest.js";
-import { readIosCommit, buildAppVersion } from "./lib/app-version.js";
+import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
 import { fileURLToPath } from "url";
 import { writeEntities } from "./build-entities.js";
 import { validateEvents, loadEventSchema } from "./validate-events.js";
@@ -738,10 +738,13 @@ for (const name of ["tracked.json", "catalog.json"]) {
 
 // Publish app-version.json — the short hash of the last commit touching
 // ios/ — so a sideloaded build can tell whether it is stale (it compares its
-// build-time stamp against this; the manifest sync delivers the file). Runs
-// before writeManifest so the manifest covers it. Skipped gracefully when
-// git/history is unavailable.
-const appVersion = buildAppVersion(readIosCommit(fileURLToPath(new URL("..", import.meta.url))));
+// build-time stamp against this; the manifest sync delivers the file). Since
+// WP-17 it also carries the last recorded TestFlight upload (testflight.json)
+// so TestFlight installs judge against the newest SHIPPABLE build, not the
+// newest commit. Runs before writeManifest so the manifest covers it.
+// Skipped gracefully when git/history is unavailable.
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const appVersion = buildAppVersion(readIosCommit(repoRoot), readTestflight(repoRoot));
 if (appVersion) {
 	fs.writeFileSync(path.join(dataDir, "app-version.json"), JSON.stringify(appVersion, null, 2) + "\n");
 	console.log(`Published app-version.json (ios @ ${appVersion.iosCommit}).`);

--- a/scripts/lib/app-version.js
+++ b/scripts/lib/app-version.js
@@ -5,6 +5,8 @@
 // ios/Zenji/BuildStamp.swift). Data commits (docs/data/) never touch ios/,
 // so the hash only moves when the app's source actually changed.
 import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
 
 // Reads {iosCommit, committedAt} from git, or null when git/history is
 // unavailable (e.g. a tarball checkout) — the pipeline then simply skips the
@@ -24,14 +26,41 @@ export function readIosCommit(repoRoot, exec = execFileSync) {
 	}
 }
 
+// Reads scripts/config/testflight.json — the record of the LAST UPLOADED
+// TestFlight build (written by scripts/record-testflight.js right after an
+// upload; lives OUTSIDE ios/ so recording it never moves the ios/-commit
+// stamp it records). Returns null when absent/invalid: app-version.json then
+// simply carries no testflight block and the app falls back to the pure
+// commit comparison.
+export function readTestflight(repoRoot, fsImpl = fs) {
+	try {
+		const raw = fsImpl.readFileSync(path.join(repoRoot, "scripts", "config", "testflight.json"), "utf-8");
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed.stamp !== "string" || !parsed.stamp) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
 // Deliberately NO generatedAt/run-timestamp: the file must be byte-identical
 // between runs on unchanged input (manifest idempotence — and the hourly
 // pipeline would otherwise commit + deploy churn every run). It changes when
-// and only when the last ios/-touching commit changes.
-export function buildAppVersion(commit) {
+// and only when the last ios/-touching commit changes — or a new TestFlight
+// build is recorded.
+export function buildAppVersion(commit, testflight = null) {
 	if (!commit) return null;
-	return {
+	const out = {
 		iosCommit: commit.iosCommit,
 		committedAt: commit.committedAt,
 	};
+	if (testflight) {
+		out.testflight = {
+			stamp: testflight.stamp,
+			build: testflight.build ?? null,
+			version: testflight.version ?? null,
+			uploadedAt: testflight.uploadedAt ?? null,
+		};
+	}
+	return out;
 }

--- a/scripts/record-testflight.js
+++ b/scripts/record-testflight.js
@@ -1,0 +1,52 @@
+// Record a completed TestFlight upload — run RIGHT AFTER `xcodebuild
+// -exportArchive` says "Upload succeeded":
+//
+//   node scripts/record-testflight.js <build-number> [version]
+//
+// Writes scripts/config/testflight.json with the CURRENT last-ios/-commit
+// stamp (which is what the archive baked into SportivistaBuildStamp, provided
+// the tree was clean — refused otherwise). build-events.js folds the file
+// into app-version.json's `testflight` block, and the app treats a stamp
+// matching EITHER the latest ios/-commit OR this recorded upload as SISTE —
+// a TestFlight tester cannot be more current than the last upload, so newer
+// unshipped commits must not nag them. The file lives OUTSIDE ios/ so
+// recording an upload never moves the stamp it records.
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { readIosCommit } from "./lib/app-version.js";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const build = Number(process.argv[2]);
+const version = process.argv[3] || null;
+if (!Number.isInteger(build) || build < 1) {
+	console.error("Bruk: node scripts/record-testflight.js <byggnummer> [versjon]");
+	process.exit(1);
+}
+
+// The stamp is only honest if the archive came from a clean ios/ tree — a
+// dirty archive bakes "<hash>-dirty", which will never match anything here.
+try {
+	execFileSync("git", ["-C", repoRoot, "diff", "--quiet", "--", "ios/"]);
+} catch {
+	console.error("ios/ har ucommittede endringer — arkivet ville vært -dirty. Commit først.");
+	process.exit(1);
+}
+
+const commit = readIosCommit(repoRoot);
+if (!commit) {
+	console.error("Fant ingen ios/-commit (ikke et git-repo?).");
+	process.exit(1);
+}
+
+const record = {
+	stamp: commit.iosCommit,
+	build,
+	version,
+	uploadedAt: new Date().toISOString(),
+};
+const target = path.join(repoRoot, "scripts", "config", "testflight.json");
+fs.writeFileSync(target, JSON.stringify(record, null, 2) + "\n");
+console.log(`Registrert TestFlight-opplasting: bygg ${build} @ ${record.stamp} → ${target}`);

--- a/tests/app-version.test.js
+++ b/tests/app-version.test.js
@@ -1,7 +1,7 @@
 // app-version.js — the published half of the iOS «har jeg siste versjon?»
 // contract: last-ios/-commit from git, resilient to missing git/history.
 import { describe, it, expect } from "vitest";
-import { readIosCommit, buildAppVersion } from "../scripts/lib/app-version.js";
+import { readIosCommit, buildAppVersion, readTestflight } from "../scripts/lib/app-version.js";
 
 describe("readIosCommit", () => {
 	it("parses short hash + commit timestamp from git output", () => {
@@ -34,5 +34,51 @@ describe("buildAppVersion", () => {
 
 	it("passes null through (pipeline skips the file)", () => {
 		expect(buildAppVersion(null)).toBeNull();
+	});
+
+	it("folds a recorded TestFlight upload into a testflight block (WP-17)", () => {
+		expect(
+			buildAppVersion(
+				{ iosCommit: "a1b2c3d", committedAt: "x" },
+				{ stamp: "0ff1ce0", build: 3, version: "0.1.0", uploadedAt: "y" },
+			),
+		).toEqual({
+			iosCommit: "a1b2c3d",
+			committedAt: "x",
+			testflight: { stamp: "0ff1ce0", build: 3, version: "0.1.0", uploadedAt: "y" },
+		});
+	});
+
+	it("normalises missing optional testflight fields to null", () => {
+		expect(buildAppVersion({ iosCommit: "a", committedAt: null }, { stamp: "b" }).testflight).toEqual({
+			stamp: "b",
+			build: null,
+			version: null,
+			uploadedAt: null,
+		});
+	});
+});
+
+describe("readTestflight", () => {
+	const fsWith = (content) => ({ readFileSync: () => content });
+
+	it("reads scripts/config/testflight.json", () => {
+		const record = { stamp: "0ff1ce0", build: 3, version: "0.1.0", uploadedAt: "y" };
+		expect(readTestflight("/repo", fsWith(JSON.stringify(record)))).toEqual(record);
+	});
+
+	it("returns null when the file is absent (pre-first-upload checkouts)", () => {
+		const fsThrows = {
+			readFileSync: () => {
+				throw new Error("ENOENT");
+			},
+		};
+		expect(readTestflight("/repo", fsThrows)).toBeNull();
+	});
+
+	it("returns null on invalid JSON or a record without a stamp", () => {
+		expect(readTestflight("/repo", fsWith("ikke json"))).toBeNull();
+		expect(readTestflight("/repo", fsWith('{"build":3}'))).toBeNull();
+		expect(readTestflight("/repo", fsWith('{"stamp":""}'))).toBeNull();
 	});
 });


### PR DESCRIPTION
Eier-funn fra TestFlight-dogfooding: appen viste «NYERE FINNES» selv på ferskt
TestFlight-bygg — sjekken sammenlignet kun mot siste ios/-commit, som alltid
løper fra siste opplasting. Semantikken er nå: en TestFlight-tester kan ikke
være mer oppdatert enn siste opplasting, så uskippede commits skal ikke mase.

- scripts/record-testflight.js (NY): kjøres etter «Upload succeeded», skriver
  scripts/config/testflight.json (stamp = siste ios/-commit; nekter dirty
  ios/-tre). Ligger utenfor ios/ med vilje: registreringen flytter aldri
  stempelet den registrerer.
- app-version.js: readTestflight + testflight-blokk i app-version.json
  (fortsatt idempotent — ingen kjøre-timestamps).
- iOS AppVersionCheck.isCurrent: godtar stamp som matcher iosCommit ELLER
  testflight.stamp; AppVersion får optional testflight-felt (bakoverkompatibel
  dekoding testet).
- project.yml: CFBundleVersion/CFBundleShortVersionString må EKSPLISITT
  referere $(CURRENT_PROJECT_VERSION)/$(MARKETING_VERSION) — XcodeGen baker
  ellers bokstavelig «1»; det var derfor bygg 2 lastet opp som CFBundleVersion
  1 (duplikat, avvist i prosessering). Bump til bygg 3.
- ios-dev-skillen: opplastings-ritualet (bump → rent tre → arkiver/last opp →
  record) + fellene.

Tester: JS 599/599 (nye: readTestflight + testflight-blokk), Swift 528/528
(nye: TestFlight-stempel gir SISTE, gammel JSON dekoder uendret).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
