### PR TITLE
WP-103: nyhets-server — publish docs/data/news.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ npm-debug.log*
 !/docs/data/app-version.json
 !/docs/data/entities.json
 !/docs/data/build-alert.json
+!/docs/data/news.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ stay verifiable against `base.css`; DESIGN.md is the source of intent behind the
 `usage-state.json` + `usage-history.jsonl` + `usage-summary.json` (quota governor: snapshot, append-only history, digest),
 `scout-log.json`, `calibration.json` + `calibration-ledger.jsonl`, `tv-listings.json`,
 `entities.json` (stable-id index of known athletes/teams/tournaments/leagues, published by `build-entities.js`; `build-events.js` uses it to stamp `entityId` onto matched events),
+`news.json` (lens-ready news pointers — `id`/`title`/`link`/`source`/`sport`/`entityIds`/`publishedAt`, NEVER article text — built from `rss-digest.json` × the entity index by `scripts/lib/news.js` and published by `build-events.js`; dedupe-on-link, cap ~100 items / 7 days, byte-idempotent; the client lens-filters on `entityIds`/`sport` per profile),
 `manifest.json` (per-file `bytes` + `sha256`, published by `build-manifest.js` — the sync contract that lets a client diff its cache without re-downloading everything),
 `app-version.json` (siste ios/-commit, published by `build-events.js` via `scripts/lib/app-version.js` — the iOS app compares its build-time stamp against it and shows «SISTE / NYERE FINNES»),
 `catalog.json` (a published read-only copy of `scripts/config/catalog.json` — "what we cover" — so the dashboard's "Dette dekker vi" surface can render it; WP-96 replaced the published `interests.json`, which is now the owner's private profile and is no longer published),

--- a/PLAN.md
+++ b/PLAN.md
@@ -107,7 +107,7 @@ mennesket, aldri av en agent.
 | WP-98 | Brand-harmonisering + skjermkatalog | 0G | WP-97 | ✅ merget (#310) — web-merkelås rettet til godkjent (label+amber-kolon, 28px; DESIGN.md-rad korrigert: ingen skjerm bruker largeTitle); tertiaryLabel inn i token-systemet (enum+migrering+test 48→52); skjermkatalog: 17 demo-moduser × 2 temaer = 34 PNG on-demand (design/screens/generate.sh). TO NYE FUNN fra kjøringen: reset-entry/-confirm rendrer samme skjerm (harness-begrensning) + EKTE AgendaView-layoutbug (overlappende tekst i flerdags-golfrader, onboarding-landing/landed, begge temaer) — logget som oppfølger. 594 JS + 526 iOS grønne |
 | WP-99 | Tastatur-lukking + assistent-klarhet + agenda-layoutbug (eier-dogfooding) | 0G | WP-98 | ✅ #311 merget 18.07, installert på eierens iPhone (stempel 95b1fbe71) — TRE eier-funn fra fysisk-iPhone-dogfooding: (1) tastaturet i kommandolinja kunne ikke lukkes — HIG-native fiks: `.scrollDismissesKeyboard(.interactively)` på agenda+Deg, tapp-utenfor (simultaneous gesture, stjeler ikke rad-tap), lukke-glyf (`keyboard.chevron.compact.down`) i tom-fokusert-hullet; (2) uklart hva chatten kan → stående FØRSTE «Hva kan du gjøre?»-pill som ruter til eksisterende hjelp-arm (WP-68), verifisert at fokus-forslag ikke er mock-only; (3) rotårsak flerdags-golf-overlapp: `TimeColumn` (fixedSize+minWidth 58) tapte bredde-forhandlingen mot grådig `RowBody` (maxWidth .infinity) → bred dato-vindu-tekst tegnet OVER tittelen — fikset med `.layoutPriority(1)` på tidskolonnen; deterministisk offline-repro (GolfBoardDemoSeed) for onboarding-landed/-landing. Vektorer urørt (ren layout). 4 nye UI-tester + 1 unit; før/etter-skjermbilder |
 
-| WP-103 | Nyhets-server: `news.json` (entity-stampede pekere fra rss-digest) | 0H | — | ⬜ |
+| WP-103 | Nyhets-server: `news.json` (entity-stampede pekere fra rss-digest) | 0H | — | 🔬 |
 | WP-104 | Assistent-inngang: segmented rot «Uka | Nyheter» + kapsel-knapp + samtaleark | 0H | WP-99 | ⬜ |
 | WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | ⬜ |
 | WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | ⬜ |
@@ -130,7 +130,7 @@ assistent — eier ContentView.swift + Assistant/), WP-105 (3b — eier Profile/
 event-detaljen). Bølge 2: WP-106 (Nyheter-klienten, avhenger av alle tre).
 Menneskebeslutninger: ingen beskyttede stier i noen av pakkene.
 
-### WP-103 · Nyhets-server — ⬜
+### WP-103 · Nyhets-server — 🔬
 `scripts/lib/news.js` + kall fra `build-events.js` (IKKE nytt pipeline-steg —
 workflows er beskyttet): bygg `docs/data/news.json` fra `rss-digest.json`-items
 × `entities.json`-navnematching (gjenbruk helpers-matchingen build-events

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -6,6 +6,7 @@ import { readJsonIfExists, rootDataPath, MS_PER_DAY, matchInterest, mustWatchEnt
 import { resolveStreaming } from "./lib/norwegian-rights.js";
 import { writeManifest } from "./build-manifest.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
+import { buildNews } from "./lib/news.js";
 import { fileURLToPath } from "url";
 import { writeEntities } from "./build-entities.js";
 import { validateEvents, loadEventSchema } from "./validate-events.js";
@@ -749,6 +750,18 @@ if (appVersion) {
 	fs.writeFileSync(path.join(dataDir, "app-version.json"), JSON.stringify(appVersion, null, 2) + "\n");
 	console.log(`Published app-version.json (ios @ ${appVersion.iosCommit}).`);
 }
+
+// WP-103: publish news.json — lens-ready news pointers built from the RSS
+// digest × the entity index. Reuses the SAME word-boundary entity name-matching
+// build-events uses to stamp entityId on events (helpers.matchesEntity), so the
+// Brooklyn/Lyn substring trap is avoided identically. Pure builder lives in
+// scripts/lib/news.js; written here (before writeManifest) so the manifest
+// covers it and the client can diff-sync it. Byte-idempotent on unchanged input
+// (no run-timestamp in the file). Empty/missing digest ⇒ { items: [] }.
+const rssDigest = readJsonIfExists(path.join(dataDir, "rss-digest.json"));
+const news = buildNews({ digest: rssDigest, entities });
+fs.writeFileSync(path.join(dataDir, "news.json"), JSON.stringify(news, null, 2) + "\n");
+console.log(`Published news.json (${news.items.length} item(s)).`);
 
 // WP-03: publish manifest.json (bytes + sha256 per published data file) —
 // last thing this script does, so it reflects everything build-events.js

--- a/scripts/lib/news.js
+++ b/scripts/lib/news.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * WP-103 · Nyhets-server. Turns the RSS digest (docs/data/rss-digest.json) into
+ * docs/data/news.json — a set of *lens-ready news pointers*, never article text
+ * or an AI summary (DSM art. 15; see design/specs/assistent-nyheter-v0.md). Each
+ * item is { id, title, link, source, sport, entityIds, publishedAt }; the client
+ * lens-filters on entityIds/sport per profile — the server never sees the profile
+ * (the two-layer architecture).
+ *
+ * Pure + injectable (mirrors scripts/lib/app-version.js): buildNews() reads
+ * nothing from disk, takes the digest + entity index as arguments, and is called
+ * from build-events.js (which does the read/write) before writeManifest so the
+ * manifest covers news.json.
+ *
+ * Entity matching REUSES the exact word-boundary name-matching build-events uses
+ * to stamp entityId onto events (helpers.matchesEntity → containsName), so the
+ * Brooklyn/Lyn substring trap is avoided identically: an article about
+ * "Brooklyn FC" does NOT match the tracked club "Lyn" (see
+ * tests/fixtures/feed-vectors/DIVERGENCES.md §2 and the negative test in
+ * tests/news.test.js). No new matching logic is introduced here.
+ *
+ * Byte-idempotent on unchanged input (the manifest sync contract): the output
+ * carries NO run-timestamp, only the parsed publishedAt of each item, so two
+ * builds over the same digest emit identical bytes.
+ */
+
+import crypto from "crypto";
+import { matchesEntity } from "./helpers.js";
+
+export const NEWS_MAX_ITEMS = 100;
+export const NEWS_MAX_AGE_DAYS = 7;
+const MS_PER_DAY = 86_400_000;
+
+// Which entity types become news pointers. Mirrors build-events.js's enrichment
+// pools (athlete / team / league) plus tournaments — a news reader follows
+// "Tour de France" or "Wimbledon" as readily as a club. The server-inert
+// "sport" / "category" umbrella entities (WP-64) are deliberately EXCLUDED: they
+// would match nearly every article, and per-sport filtering is the item.sport
+// field's job (the client's declared fallback filter), not an entityId.
+const NEWS_ENTITY_TYPES = new Set(["athlete", "team", "league", "tournament"]);
+
+/** Stable id for an item = sha1 of its canonical link (the dedupe key). */
+function hashLink(link) {
+	return crypto.createHash("sha1").update(link).digest("hex");
+}
+
+/** The entity pool a news item is matched against (concrete, followable types). */
+export function newsEntityPool(entities) {
+	return (entities || []).filter((e) => e && NEWS_ENTITY_TYPES.has(e.type));
+}
+
+/**
+ * Which entity ids does `text` mention (word-boundary, accent-insensitive)?
+ * Order-preserving + de-duplicated. Uses helpers.matchesEntity — the same
+ * containsName word-boundary check build-events uses on events, so a substring
+ * like "lyn" inside "Brooklyn" never matches the club "Lyn".
+ */
+export function matchEntityIds(text, pool) {
+	const ids = [];
+	for (const e of pool) {
+		if (e && e.id && matchesEntity(text, e) && !ids.includes(e.id)) ids.push(e.id);
+	}
+	return ids;
+}
+
+/**
+ * Build the news.json object from an RSS digest and the entity index.
+ *
+ * @param {object}  opts
+ * @param {object}  opts.digest      parsed rss-digest.json ({ items: [...] })
+ * @param {Array}   opts.entities    the entities.json index ({ id, name, aliases, sport, type })
+ * @param {number} [opts.now]        clock (injectable for deterministic tests)
+ * @param {number} [opts.maxItems]   cap (default 100)
+ * @param {number} [opts.maxAgeDays] freshness window in days (default 7)
+ * @returns {{ items: Array }}       never throws on empty/missing input
+ */
+export function buildNews({
+	digest,
+	entities,
+	now = Date.now(),
+	maxItems = NEWS_MAX_ITEMS,
+	maxAgeDays = NEWS_MAX_AGE_DAYS,
+} = {}) {
+	const rssItems = Array.isArray(digest?.items) ? digest.items : [];
+	const pool = newsEntityPool(entities);
+	const cutoff = now - maxAgeDays * MS_PER_DAY;
+	const seen = new Set();
+	const out = [];
+
+	for (const it of rssItems) {
+		const link = it && typeof it.link === "string" ? it.link : null;
+		if (!link) continue; // no stable id without a link
+		if (seen.has(link)) continue; // dedupe on link (first occurrence wins)
+		// RFC 822 ("Sun, 19 Jul 2026 04:01:57 GMT") → epoch. An unparseable date is
+		// dropped rather than guessed — honest over a fabricated timestamp.
+		const ts = Date.parse(it.pubDate);
+		if (!Number.isFinite(ts)) continue;
+		if (ts < cutoff) continue; // older than the freshness window
+		seen.add(link);
+		const haystack = [it.title, it.description].filter(Boolean).join(" ");
+		out.push({
+			id: hashLink(link),
+			title: typeof it.title === "string" ? it.title : "",
+			link,
+			source: it.source || null,
+			sport: it.sport || null,
+			entityIds: matchEntityIds(haystack, pool),
+			publishedAt: new Date(ts).toISOString(), // normalized ISO (UTC)
+			_ts: ts,
+		});
+	}
+
+	// Newest first. Array.sort is stable in Node, so equal timestamps keep input
+	// order — part of the byte-idempotency guarantee.
+	out.sort((a, b) => b._ts - a._ts);
+	const items = out.slice(0, maxItems).map(({ _ts, ...rest }) => rest);
+	return { items };
+}

--- a/tests/news.test.js
+++ b/tests/news.test.js
@@ -1,0 +1,243 @@
+// news.js (WP-103): docs/data/news.json — lens-ready news pointers built from
+// the RSS digest × the entity index. Pointers only (id/title/link/source/sport/
+// entityIds/publishedAt), never article text. Entity matching reuses the same
+// word-boundary containsName the events pipeline uses, so the Brooklyn/Lyn
+// substring trap (feed-vectors/DIVERGENCES.md §2) is avoided here too.
+import { describe, it, expect } from "vitest";
+import crypto from "crypto";
+import { buildNews, matchEntityIds, newsEntityPool, NEWS_MAX_ITEMS } from "../scripts/lib/news.js";
+
+const NOW = Date.parse("2026-07-19T12:00:00Z");
+
+// A minimal entity index in the entities.json shape { id, name, aliases, sport, type }.
+const ENTITIES = [
+	{ id: "team:lyn", name: "Lyn", aliases: ["FK Lyn Oslo"], sport: "football", type: "team" },
+	{ id: "team:arsenal", name: "Arsenal", aliases: ["Arsenal FC"], sport: "football", type: "team" },
+	{ id: "athlete:carlsen", name: "Magnus Carlsen", aliases: ["Carlsen"], sport: "chess", type: "athlete" },
+	{ id: "tournament:tdf", name: "Tour de France", aliases: [], sport: "cycling", type: "tournament" },
+	{ id: "league:pl", name: "Premier League", aliases: [], sport: "football", type: "league" },
+	// server-inert umbrella entities (WP-64) — must NOT become news entityIds
+	{ id: "sport:football", name: "Fotball", aliases: [], sport: "football", type: "sport" },
+	{ id: "category:winter", name: "Vintersport", aliases: [], sport: null, type: "category" },
+];
+
+function item(overrides = {}) {
+	return {
+		source: "nrk-sport",
+		sport: "football",
+		title: "Arsenal vant",
+		description: "En kamp.",
+		link: "https://example.com/" + Math.random().toString(36).slice(2),
+		pubDate: "Sun, 19 Jul 2026 10:00:00 GMT",
+		...overrides,
+	};
+}
+
+describe("entity matching (word-boundary, reused from helpers)", () => {
+	it("matches an entity named in the title or description", () => {
+		const ids = matchEntityIds("Arsenal vant mot Tottenham", newsEntityPool(ENTITIES));
+		expect(ids).toContain("team:arsenal");
+	});
+
+	it("matches on an alias too", () => {
+		const ids = matchEntityIds("Magnus Carlsen vinner igjen — Carlsen dominerer", newsEntityPool(ENTITIES));
+		expect(ids).toContain("athlete:carlsen");
+	});
+
+	it("does NOT match 'Lyn' inside 'Brooklyn' (the substring trap)", () => {
+		const ids = matchEntityIds("Brooklyn FC klar for ny sesong", newsEntityPool(ENTITIES));
+		expect(ids).not.toContain("team:lyn");
+	});
+
+	it("DOES match a real word-boundary 'Lyn' mention", () => {
+		const ids = matchEntityIds("Vålerenga slo Lyn i derbyet", newsEntityPool(ENTITIES));
+		expect(ids).toContain("team:lyn");
+	});
+
+	it("excludes server-inert sport/category umbrella entities", () => {
+		// "Fotball" (sport) and "Vintersport" (category) present in the text must
+		// never surface as entityIds — per-sport filtering is item.sport's job.
+		const ids = matchEntityIds("Fotball og vintersport i vinter", newsEntityPool(ENTITIES));
+		expect(ids).not.toContain("sport:football");
+		expect(ids).not.toContain("category:winter");
+	});
+
+	it("de-duplicates repeated entity mentions to one id", () => {
+		const ids = matchEntityIds("Arsenal, Arsenal, Arsenal FC", newsEntityPool(ENTITIES));
+		expect(ids.filter((id) => id === "team:arsenal")).toHaveLength(1);
+	});
+
+	it("matches tournaments (a followable pointer)", () => {
+		const ids = matchEntityIds("Tour de France starter i dag", newsEntityPool(ENTITIES));
+		expect(ids).toContain("tournament:tdf");
+	});
+});
+
+describe("buildNews — item contract", () => {
+	it("emits the pointer shape and nothing article-like", () => {
+		const news = buildNews({
+			digest: { items: [item({ link: "https://ex.com/a", title: "Arsenal vant", description: "Carlsen så på" })] },
+			entities: ENTITIES,
+			now: NOW,
+		});
+		expect(news.items).toHaveLength(1);
+		const n = news.items[0];
+		expect(n).toHaveProperty("id");
+		expect(n).toHaveProperty("title", "Arsenal vant");
+		expect(n).toHaveProperty("link", "https://ex.com/a");
+		expect(n).toHaveProperty("source", "nrk-sport");
+		expect(n).toHaveProperty("sport", "football");
+		expect(n).toHaveProperty("publishedAt");
+		expect(n.entityIds).toContain("team:arsenal");
+		expect(n.entityIds).toContain("athlete:carlsen");
+		// no article-body fields leak through
+		expect(n).not.toHaveProperty("description");
+		expect(n).not.toHaveProperty("_ts");
+	});
+
+	it("id is the sha1 of the link (stable across runs)", () => {
+		const link = "https://ex.com/stable";
+		const news = buildNews({ digest: { items: [item({ link })] }, entities: ENTITIES, now: NOW });
+		expect(news.items[0].id).toBe(crypto.createHash("sha1").update(link).digest("hex"));
+	});
+});
+
+describe("dedupe on link", () => {
+	it("keeps only the first occurrence of a repeated link", () => {
+		const link = "https://ex.com/dup";
+		const news = buildNews({
+			digest: {
+				items: [
+					item({ link, title: "First" }),
+					item({ link, title: "Second (dup)" }),
+				],
+			},
+			entities: ENTITIES,
+			now: NOW,
+		});
+		expect(news.items).toHaveLength(1);
+		expect(news.items[0].title).toBe("First");
+	});
+});
+
+describe("cap + freshness window", () => {
+	it("caps at NEWS_MAX_ITEMS, keeping the newest", () => {
+		const items = [];
+		for (let i = 0; i < NEWS_MAX_ITEMS + 25; i++) {
+			// stagger pubDate by minutes so ordering is well-defined; all within 7 days
+			const d = new Date(NOW - i * 60_000).toUTCString();
+			items.push(item({ link: "https://ex.com/n" + i, pubDate: d }));
+		}
+		const news = buildNews({ digest: { items }, entities: ENTITIES, now: NOW });
+		expect(news.items).toHaveLength(NEWS_MAX_ITEMS);
+		// newest first: item n0 (most recent) survives, the oldest are cut
+		expect(news.items[0].link).toBe("https://ex.com/n0");
+	});
+
+	it("drops items older than 7 days", () => {
+		const news = buildNews({
+			digest: {
+				items: [
+					item({ link: "https://ex.com/fresh", pubDate: new Date(NOW - 2 * 86_400_000).toUTCString() }),
+					item({ link: "https://ex.com/stale", pubDate: new Date(NOW - 10 * 86_400_000).toUTCString() }),
+				],
+			},
+			entities: ENTITIES,
+			now: NOW,
+		});
+		const links = news.items.map((n) => n.link);
+		expect(links).toContain("https://ex.com/fresh");
+		expect(links).not.toContain("https://ex.com/stale");
+	});
+
+	it("sorts newest first", () => {
+		const news = buildNews({
+			digest: {
+				items: [
+					item({ link: "https://ex.com/old", pubDate: new Date(NOW - 3 * 3600_000).toUTCString() }),
+					item({ link: "https://ex.com/new", pubDate: new Date(NOW - 1 * 3600_000).toUTCString() }),
+					item({ link: "https://ex.com/mid", pubDate: new Date(NOW - 2 * 3600_000).toUTCString() }),
+				],
+			},
+			entities: ENTITIES,
+			now: NOW,
+		});
+		expect(news.items.map((n) => n.link)).toEqual([
+			"https://ex.com/new",
+			"https://ex.com/mid",
+			"https://ex.com/old",
+		]);
+	});
+});
+
+describe("RFC 822 → ISO", () => {
+	it("converts an RFC 822 pubDate to normalized ISO (UTC)", () => {
+		const news = buildNews({
+			digest: { items: [item({ link: "https://ex.com/t", pubDate: "Sun, 19 Jul 2026 04:01:57 GMT" })] },
+			entities: ENTITIES,
+			now: NOW,
+		});
+		expect(news.items[0].publishedAt).toBe("2026-07-19T04:01:57.000Z");
+	});
+
+	it("drops an item with an unparseable date (honest over guess)", () => {
+		const news = buildNews({
+			digest: {
+				items: [
+					item({ link: "https://ex.com/good", pubDate: "Sun, 19 Jul 2026 04:00:00 GMT" }),
+					item({ link: "https://ex.com/bad", pubDate: "not a date" }),
+					item({ link: "https://ex.com/missing", pubDate: undefined }),
+				],
+			},
+			entities: ENTITIES,
+			now: NOW,
+		});
+		const links = news.items.map((n) => n.link);
+		expect(links).toEqual(["https://ex.com/good"]);
+	});
+});
+
+describe("idempotency", () => {
+	it("two builds over the same input emit byte-identical JSON", () => {
+		const digest = {
+			items: [
+				item({ link: "https://ex.com/1", pubDate: new Date(NOW - 3600_000).toUTCString() }),
+				item({ link: "https://ex.com/2", pubDate: new Date(NOW - 7200_000).toUTCString() }),
+			],
+		};
+		const a = JSON.stringify(buildNews({ digest, entities: ENTITIES, now: NOW }), null, 2);
+		const b = JSON.stringify(buildNews({ digest, entities: ENTITIES, now: NOW }), null, 2);
+		expect(a).toBe(b);
+		// and no run-timestamp field crept into the object
+		expect(a).not.toMatch(/generatedAt|builtAt|"now"/);
+	});
+});
+
+describe("empty / missing input never crashes", () => {
+	it("returns { items: [] } for a missing digest", () => {
+		expect(buildNews({ digest: undefined, entities: ENTITIES, now: NOW })).toEqual({ items: [] });
+	});
+
+	it("returns { items: [] } for a digest with no items", () => {
+		expect(buildNews({ digest: {}, entities: ENTITIES, now: NOW })).toEqual({ items: [] });
+	});
+
+	it("tolerates a missing entity index (no entityIds, no throw)", () => {
+		const news = buildNews({ digest: { items: [item({ link: "https://ex.com/x" })] }, entities: undefined, now: NOW });
+		expect(news.items).toHaveLength(1);
+		expect(news.items[0].entityIds).toEqual([]);
+	});
+
+	it("skips items without a link (no stable id)", () => {
+		const news = buildNews({
+			digest: { items: [item({ link: undefined }), item({ link: "https://ex.com/ok" })] },
+			entities: ENTITIES,
+			now: NOW,
+		});
+		expect(news.items.map((n) => n.link)).toEqual(["https://ex.com/ok"]);
+	});
+
+	it("no-arg call does not throw and returns empty items", () => {
+		expect(buildNews()).toEqual({ items: [] });
+	});
+});


### PR DESCRIPTION
## WP-103 · Nyhets-server (FASE 0H, bølge 1)

Adds `scripts/lib/news.js` (pure, injectable) + a call from `build-events.js` that publishes `docs/data/news.json` — lens-ready **news pointers** from `rss-digest.json` × the entity index. Pointers only (`id`/`title`/`link`/`source`/`sport`/`entityIds`/`publishedAt`), never article text or an AI summary (DSM art. 15). The client lens-filters on `entityIds`/`sport` per profile — the server never sees the profile (two-layer arch).

### Contract (per spec `design/specs/assistent-nyheter-v0.md`)
- `id` = sha1(link); **dedupe on link** (first wins); cap ~100 items / max 7 days old; sorted newest first.
- **Byte-idempotent** on unchanged input — no run-timestamp in the file (manifest sync contract).
- RFC 822 `pubDate` → normalized ISO; **unparseable date ⇒ item dropped** (honest over guess).
- `entityIds` via the SAME word-boundary name-matching `build-events` uses on events (`helpers.matchesEntity → containsName`) — reused, not reimplemented — so the **Brooklyn/Lyn substring trap is avoided identically**. Server-inert `sport`/`category` umbrella entities excluded; `item.sport` kept as the client's fallback filter.
- Whitelisted in `.gitignore`; `build-manifest.js` therefore covers it (written before `writeManifest`).

### Deviations from spec (with rationale)
- **Tournaments included** in the match pool alongside `build-events`'s athlete/team/league pools. A news reader follows "Tour de France"/"Wimbledon" as readily as a club; excluding them would strip meaningful pointers of their entityId. `sport`/`category` umbrella entities stay excluded (they'd match nearly every article).

### Verification
- `tests/news.test.js` — 21 tests (matching incl. Brooklyn/Lyn, alias, dedupe, cap, freshness window, RFC822→ISO, idempotency, empty/missing input never crashes). **All pass.**
- Full suite: **628/628 pass** (`npx vitest run --maxWorkers=1`).
- Smoke: `node scripts/build-events.js` → `Published news.json (36 item(s))` with real matches (`tour-de-france-2026`, `kristoffer-reitan`, `uno-x-mobility`); `node scripts/validate-events.js` → 0 errors; `news.json` present in `manifest.json`; two builds → byte-identical `news.json` (idempotent).

### Notes
Docs data outputs (`news.json`, `manifest.json`) are pipeline artifacts and are NOT committed here — the static pipeline regenerates them on its next run. No protected paths touched. CLAUDE.md data-file list + PLAN.md WP-103 row updated (⬜→🔬).

🤖 Generated with [Claude Code](https://claude.com/claude-code)