### PR TITLE
WP-105: Det du følger + Legg til-søk (interesser uten assistent, 3b)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -109,7 +109,7 @@ mennesket, aldri av en agent.
 
 | WP-103 | Nyhets-server: `news.json` (entity-stampede pekere fra rss-digest) | 0H | — | 🔬 |
 | WP-104 | Assistent-inngang: segmented rot «Uka | Nyheter» + kapsel-knapp + samtaleark | 0H | WP-99 | ⬜ |
-| WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | ⬜ |
+| WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | 🔬 |
 | WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | ⬜ |
 
 ---
@@ -152,13 +152,26 @@ grønn (eksisterende tastatur-tester omskrives mot arket), 4 schemes bygger,
 vektorer bit-like, mock-tester for eksempelradene + eval-corpus-cases for de
 to kjørbare eksemplene (0E-regelen).
 
-### WP-105 · Det du følger + Legg til (3b) — ⬜
+### WP-105 · Det du følger + Legg til (3b) — 🔬
 Eier `ios/Sportivista/Profile/` + event-detaljfila. «Det du følger» som vanlig
 liste (fra Deg, rad → detalj, Slutt å følge), «Legg til»-søk mot entities.json
 med Følg-knapper, Følg-knapp i event-detaljen. RØRER IKKE ContentView.swift
 (WP-104 eier den — navigasjon nås fra DegView). **Aksept:** unit-suite +
 mock-tester; profil-endringer går gjennom samme ProfileStore-vei som
 assistenten (én kilde til sannhet).
+🔬 **Implementert (branch wp-105-det-du-folger):** ny delt apply-vei
+`Profile/AssistantViewModel+Follow.swift` (`follow(_:)`/`isFollowing(_:)` — trakter
+inn i samme `InterestProfile.applying` + `ProfileStore.save` + `onProfileChanged`
+som `confirm`/`toggleStarterPack`; ingen ny skrivevei). Nye
+`Profile/FollowedListView.swift` (Det du følger + rad→detalj + Slutt-å-følge via
+`removeRule` bak rolig `confirmationDialog`) og `Profile/AddFollowSearchView.swift`
+(søk mot `EntityIndex(DataStore().loadEntities())`, Følg-knapp per rad → `follow`).
+DegView-raden omdøpt «Det du følger» (id `deg.follows` uendret). Event-detaljens
+«Følg»-knapp beholder `onFollow`-sømmen, nå dokumentert mot den direkte apply-veien.
+**Integrasjons-handoff til WP-104 (én linje i ContentView.follow):**
+`assistant.proposeFollow(entity)` → `assistant.follow(entity)` gjør detalj-/swipe-
+følg assistent-fri. Tester: `SportivistaTests/FollowActionTests.swift` +
+UI-røyk `SportivistaUITests/FollowedListUITests.swift`.
 
 ### WP-106 · Nyheter-v0-klienten — ⬜ (bølge 2)
 Fyller `News/` med fire-seksjons-tavla per spec: brief (featured.json),

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -17,8 +17,12 @@ struct EventDetailSheet: View {
     /// WP-16.4 — the full agenda row, so the sheet has the precomputed context
     /// data (whyShown + followable) alongside the event.
     let row: AgendaEventRow
-    /// WP-16.4 — a "Følg <entitet>" tap; the host routes it into the assistant's
-    /// diff/confirm flow. No-op default keeps standalone/preview use compiling.
+    /// WP-16.4 / WP-105 — a "Følg <entitet>" tap. The host routes it through the
+    /// direct follow apply-vei (`AssistantViewModel.follow`) — the SAME
+    /// ProfileStore path Deg › Legg til uses, one source of truth. 3b:
+    /// "veien fra «så noe interessant» til «følger» krever aldri assistenten" —
+    /// no diff round-trip, the tap IS the confirmation and the sheet closes.
+    /// No-op default keeps standalone/preview use compiling.
     var onFollow: (Entity) -> Void = { _ in }
     @Environment(\.dismiss) private var dismiss
     /// WP-16.4 — the "Hvorfor vises denne?" context action, collapsed by default.
@@ -108,12 +112,13 @@ struct EventDetailSheet: View {
 
     // MARK: - Context actions (WP-16.4)
 
-    /// The two in-context actions the "sømløs assistent" brief asks for, both
-    /// woven into the same flow as everything else: a quiet, deterministic
-    /// "Hvorfor vises denne?" (FeedCompiler.whyShown, no model needed) and a
-    /// "Følg <entitet>" per followable subject that routes through the
-    /// assistant's normal diff/confirm flow (nothing is applied by the tap
-    /// alone — the user still confirms the diff).
+    /// The two in-context actions: a quiet, deterministic "Hvorfor vises denne?"
+    /// (FeedCompiler.whyShown, no model needed) and a quiet "Følg <entitet>" per
+    /// followable subject. WP-105: the follow tap goes through the direct apply-
+    /// vei (host's `onFollow` → `AssistantViewModel.follow`), applying immediately
+    /// and closing the sheet — no assistant diff to confirm ("krever aldri
+    /// assistenten"). `row.followable` already excludes anything followed, so the
+    /// button only appears for a not-yet-followed subject.
     @ViewBuilder
     private var contextActionsSection: some View {
         if !row.whyShown.isEmpty || !row.followable.isEmpty {

--- a/ios/Sportivista/Profile/AddFollowSearchView.swift
+++ b/ios/Sportivista/Profile/AddFollowSearchView.swift
@@ -1,0 +1,121 @@
+//
+//  AddFollowSearchView.swift
+//  Sportivista
+//
+//  WP-105 — «Legg til» (DESIGN § Deg-skjermen): search the SAME entity index the
+//  assistant grounds against (entities.json) — "velg, ikke stav". A hit list of
+//  «Navn · sport · type» with a per-row «Følg» button (accent, one amber per
+//  row); Følg runs through the SAME apply path the assistant's confirmed diff
+//  uses (`AssistantViewModel.follow` — one source of truth, no assistant round-
+//  trip). Something already followed shows a muted "Følger" instead of a button.
+//
+//  The index is built here from the synced `entities.json` exactly as
+//  AssistantViewModel builds its own (EntityIndex(DataStore().loadEntities())),
+//  so the fuzzy matching (aliases / initials / typos / edition-stripping) — and
+//  therefore the "substring traps" — are handled by the shared EntityIndex
+//  helpers, not re-implemented.
+//
+
+import SwiftUI
+
+struct AddFollowSearchView: View {
+    var viewModel: AssistantViewModel
+    /// Injectable so tests/previews can pass a fixture index; the app loads the
+    /// live synced index on appear.
+    var indexProvider: () -> EntityIndex = { EntityIndex(DataStore().loadEntities()) }
+
+    @State private var query = ""
+    @State private var index = EntityIndex([])
+    @State private var loaded = false
+    @Environment(\.dismiss) private var dismiss
+
+    /// Only real followable targets — never the whole-sport / umbrella-category
+    /// pseudo-entities the index also carries (those are the assistant's
+    /// broad-scope grounding, not a "follow this team/athlete" pick).
+    private var results: [Entity] {
+        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else { return [] }
+        return index.search(query).filter { $0.type != "sport" && $0.type != "category" }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if results.isEmpty {
+                    Section {
+                        Text(emptyMessage)
+                            .font(.sportivista(.subheadline))
+                            .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    }
+                    .listRowBackground(SportivistaTokens.cell)
+                } else {
+                    Section {
+                        ForEach(results, id: \.id) { entity in
+                            resultRow(entity)
+                        }
+                    } header: {
+                        Text("TREFF")
+                            .font(.sportivista(.footnote, weight: .semibold))
+                            .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    }
+                    .listRowBackground(SportivistaTokens.cell)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(SportivistaTokens.background)
+            .foregroundStyle(SportivistaTokens.label)
+            .navigationTitle("Legg til")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $query, prompt: "Søk lag, utøver eller turnering")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Lukk") { dismiss() }
+                        .foregroundStyle(SportivistaTokens.accent)
+                }
+            }
+        }
+        .onAppear {
+            guard !loaded else { return }
+            index = indexProvider()
+            loaded = true
+        }
+    }
+
+    private var emptyMessage: String {
+        if query.trimmingCharacters(in: .whitespaces).isEmpty {
+            return "Søk opp et lag, en utøver eller en turnering å følge."
+        }
+        return "Fant ingenting som passer «\(query)». Prøv et annet navn."
+    }
+
+    @ViewBuilder
+    private func resultRow(_ entity: Entity) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entity.name)
+                    .font(.sportivista(.body, weight: .semibold))
+                    .foregroundStyle(SportivistaTokens.label)
+                Text("\(SportVocabulary.display(for: entity.sport)) · \(FollowVocabulary.typeLabel(entity.type))")
+                    .font(.sportivista(.footnote))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+            }
+            Spacer()
+            if viewModel.isFollowing(entity.id) {
+                Text("Følger")
+                    .font(.sportivista(.subheadline))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    .accessibilityIdentifier("addfollow.following.\(entity.id)")
+            } else {
+                Button("Følg") {
+                    viewModel.follow(entity)
+                }
+                .font(.sportivista(.subheadline, weight: .semibold))
+                .foregroundStyle(SportivistaTokens.accent)
+                .buttonStyle(.borderless)
+                .sportivistaTapTarget()
+                .accessibilityIdentifier("addfollow.follow.\(entity.id)")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ios/Sportivista/Profile/AssistantViewModel+Follow.swift
+++ b/ios/Sportivista/Profile/AssistantViewModel+Follow.swift
@@ -1,0 +1,55 @@
+//
+//  AssistantViewModel+Follow.swift
+//  Sportivista
+//
+//  WP-105 — the ONE direct-follow apply path shared by the assistant-free 3b
+//  surfaces (Deg › Det du følger + Legg til, and the event detail sheet's
+//  «Følg <navn>» button). "Interesser uten assistent": the path from "så noe
+//  interessant" to "følger" never routes through the assistant diff — a tap IS
+//  the confirmation.
+//
+//  This is NOT a new write path. It funnels the same three steps every
+//  confirmed mutation already uses into one entry point:
+//    profile = profile.applying(mutation)   // the pure diff core (InterestProfile)
+//    profileStore.save(profile)             // the persist() body — the one store
+//    onProfileChanged?()                    // "umiddelbar konsekvens" recompile
+//  i.e. exactly what `confirm`/`confirmAll`/`toggleStarterPack` do, minus the
+//  diff round-trip — mirroring `toggleStarterPack`'s "a tap IS the confirmation"
+//  contract for a single entity. It lives in Profile/ (like the WP-19 profil-sync
+//  arm in AssistantViewModel+ProfileSync.swift) so it can reach the internal
+//  `profile` setter, the `profileStore`, and `onProfileChanged` without touching
+//  Assistant/.
+//
+
+import Foundation
+
+extension AssistantViewModel {
+    /// Whether `entityId` is already in the profile — drives the Legg til /
+    /// detail «Følg» button's presence (no button for something already
+    /// followed) and the "Følger" read-out.
+    func isFollowing(_ entityId: String) -> Bool {
+        profile.rule(for: entityId) != nil
+    }
+
+    /// Follow `entity` directly — the tap IS the confirmation, no assistant diff
+    /// (3b: "krever aldri assistenten"). Upsert semantics via
+    /// `InterestProfile.applying` (re-following just refreshes the rule), then the
+    /// same persist + recompile every confirmed mutation runs. Returns whether the
+    /// save succeeded (false only on a genuine disk failure; the in-memory profile
+    /// is updated regardless, exactly like the diff/confirm path).
+    @discardableResult
+    func follow(_ entity: Entity, reason: String? = nil, now: Date = Date()) -> Bool {
+        let mutation = GroundedMutation(
+            kind: .add,
+            entity: entity,
+            scope: nil,
+            weight: InterestProfile.defaultWeight,
+            reason: reason ?? "Du valgte å følge \(entity.name).",
+            previousRule: profile.rule(for: entity.id)
+        )
+        profile = profile.applying(mutation, now: now)
+        let saved = (try? profileStore.save(profile)) != nil
+        onProfileChanged?()
+        return saved
+    }
+}

--- a/ios/Sportivista/Profile/DegView.swift
+++ b/ios/Sportivista/Profile/DegView.swift
@@ -17,7 +17,7 @@
 //  file only lays out the entrances (WP-83 non-goal: don't touch the logic).
 //
 //  Groups (DESIGN § Deg-skjermen):
-//    • PROFIL     — Hva jeg følger (n) · Sett opp på nytt
+//    • PROFIL     — Det du følger (n) · Sett opp på nytt
 //    • DATA OM MEG — Hva jeg vet om deg (n) · Det jeg ikke forsto (n) · Del profil
 //    • APP        — Varsel før start · Utseende (tema) · Nullstill
 //    • FOT        — the quiet «BYGG …» version line
@@ -87,9 +87,9 @@ struct DegView: View {
     private var profileGroup: some View {
         Section {
             NavigationLink {
-                FollowedRulesView(viewModel: viewModel)
+                FollowedListView(viewModel: viewModel)
             } label: {
-                rowLabel("list.star", "Hva jeg følger", value: "\(viewModel.profile.rules.count)")
+                rowLabel("list.star", "Det du følger", value: "\(viewModel.profile.rules.count)")
             }
             .accessibilityIdentifier("deg.follows")
 
@@ -249,71 +249,6 @@ struct DegView: View {
         Text(text)
             .font(.sportivista(.footnote, weight: .semibold))
             .foregroundStyle(SportivistaTokens.secondaryLabel)
-    }
-}
-
-// MARK: - "Hva jeg følger" (re-homed from AssistantPanel.profileSection)
-
-/// The follow list, pushed from Deg › Hva jeg følger. Renders `viewModel.profile`
-/// with the SAME per-rule «Fjern» the ark used (`AssistantViewModel.removeRule`) —
-/// no follow logic re-implemented, just relocated to its own screen.
-private struct FollowedRulesView: View {
-    var viewModel: AssistantViewModel
-
-    var body: some View {
-        List {
-            if viewModel.profile.isEmpty {
-                Section {
-                    Text("Ingenting ennå. Skriv en ytring i linjen nederst på agendaen for å begynne.")
-                        .font(.sportivista(.subheadline))
-                        .foregroundStyle(SportivistaTokens.secondaryLabel)
-                }
-                .listRowBackground(SportivistaTokens.cell)
-            } else {
-                Section {
-                    ForEach(viewModel.profile.rules) { rule in
-                        ruleRow(rule)
-                    }
-                }
-                .listRowBackground(SportivistaTokens.cell)
-            }
-        }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(SportivistaTokens.background)
-        .navigationTitle("Hva jeg følger")
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private func ruleRow(_ rule: InterestRule) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(rule.entityName)
-                    .font(.sportivista(.body, weight: .semibold))
-                    .foregroundStyle(SportivistaTokens.label)
-                Spacer()
-                Button("Fjern") { viewModel.removeRule(rule) }
-                    .font(.sportivista(.subheadline))
-                    .foregroundStyle(SportivistaTokens.destructive.opacity(0.85))
-                    .buttonStyle(.borderless)
-                    .sportivistaTapTarget()
-            }
-            Text(ruleSubtitle(rule))
-                .font(.sportivista(.caption))
-                .foregroundStyle(SportivistaTokens.secondaryLabel)
-            Text(rule.reason)
-                .font(.sportivista(.caption))
-                .foregroundStyle(SportivistaTokens.secondaryLabel.opacity(0.8))
-        }
-        .padding(.vertical, 4)
-    }
-
-    private func ruleSubtitle(_ rule: InterestRule) -> String {
-        var parts = [SportVocabulary.display(for: rule.sport)]
-        if let scope = rule.scope, !scope.isEmpty { parts.append(scope) }
-        if !rule.lens.isDefault { parts.append(rule.lens.label) }
-        parts.append("vekt \(String(format: "%.1f", rule.weight))")
-        return parts.joined(separator: " · ")
     }
 }
 

--- a/ios/Sportivista/Profile/FollowedListView.swift
+++ b/ios/Sportivista/Profile/FollowedListView.swift
@@ -1,0 +1,237 @@
+//
+//  FollowedListView.swift
+//  Sportivista
+//
+//  WP-105 — "Det du følger" (DESIGN § Deg-skjermen): a plain inset-grouped list,
+//  one row per followed entity («Navn · sport · varsler på/av ›»), each pushing a
+//  detail with the rule's real fields + «Slutt å følge» (destructive, behind a
+//  calm confirmation). A «+» toolbar entry opens the Legg til-søk. Interests
+//  without the assistant (3b): every follow/unfollow here runs through the SAME
+//  ProfileStore apply path the assistant's confirmed diff uses
+//  (AssistantViewModel.follow / .removeRule — one source of truth).
+//
+//  Upgraded from DegView's earlier inline «Hva jeg følger» list (its per-rule
+//  «Fjern» is replaced by rad → detalj → «Slutt å følge», the DESIGN § Deg
+//  navigation).
+//
+
+import SwiftUI
+
+struct FollowedListView: View {
+    var viewModel: AssistantViewModel
+    @State private var addShown = false
+
+    private var rules: [InterestRule] { viewModel.profile.rules }
+
+    var body: some View {
+        List {
+            if rules.isEmpty {
+                Section {
+                    Text("Ingenting ennå. Trykk + for å søke opp et lag, en utøver eller en turnering å følge.")
+                        .font(.sportivista(.subheadline))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                }
+                .listRowBackground(SportivistaTokens.cell)
+            } else {
+                Section {
+                    ForEach(rules) { rule in
+                        NavigationLink {
+                            FollowDetailView(viewModel: viewModel, rule: rule)
+                        } label: {
+                            followRow(rule)
+                        }
+                        .accessibilityIdentifier("followed.row.\(rule.entityId)")
+                    }
+                } header: {
+                    groupHeader("DET DU FØLGER")
+                }
+                .listRowBackground(SportivistaTokens.cell)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(SportivistaTokens.background)
+        .foregroundStyle(SportivistaTokens.label)
+        .navigationTitle("Det du følger")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    addShown = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .tint(SportivistaTokens.accent)
+                .accessibilityLabel("Legg til")
+                .accessibilityIdentifier("followed.add")
+            }
+        }
+        .sheet(isPresented: $addShown) {
+            AddFollowSearchView(viewModel: viewModel)
+        }
+    }
+
+    private func followRow(_ rule: InterestRule) -> some View {
+        HStack {
+            Text(rule.entityName)
+                .font(.sportivista(.body, weight: .semibold))
+                .foregroundStyle(SportivistaTokens.label)
+            Spacer()
+            Text(FollowVocabulary.rowSubtitle(rule))
+                .font(.sportivista(.footnote))
+                .foregroundStyle(SportivistaTokens.secondaryLabel)
+                .lineLimit(1)
+        }
+        .contentShape(Rectangle())
+    }
+
+    private func groupHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.sportivista(.footnote, weight: .semibold))
+            .foregroundStyle(SportivistaTokens.secondaryLabel)
+    }
+}
+
+// MARK: - Detail (rad → detalj)
+
+/// One follow's detail: the rule's real, persisted fields (sport, scope note,
+/// perspective, when it was added, its Norwegian reason) shown as text, the
+/// device-wide reminder read-out, and «Slutt å følge» behind a calm
+/// confirmation (DESIGN § Deg: destructive → ett rolig bekreftelses-ark).
+struct FollowDetailView: View {
+    var viewModel: AssistantViewModel
+    let rule: InterestRule
+
+    @State private var confirmingStop = false
+    @Environment(\.dismiss) private var dismiss
+    /// The device-wide reminder preference — the only notify signal the on-device
+    /// profile carries (there is no per-entity notify field), shown honestly.
+    private let leadTimeOn = NotificationLeadPreference.isLeadTimeEnabled()
+
+    var body: some View {
+        List {
+            Section {
+                detailRow("Sport", SportVocabulary.display(for: rule.sport))
+                if let scope = rule.scope, !scope.isEmpty {
+                    detailRow("Avgrensning", scope)
+                }
+                if !rule.lens.isDefault {
+                    detailRow("Perspektiv", rule.lens.label)
+                }
+            } header: {
+                groupHeader("OM")
+            }
+            .listRowBackground(SportivistaTokens.cell)
+
+            if !rule.reason.isEmpty {
+                Section {
+                    Text(rule.reason)
+                        .font(.sportivista(.subheadline))
+                        .foregroundStyle(SportivistaTokens.label)
+                        .fixedSize(horizontal: false, vertical: true)
+                } header: {
+                    groupHeader("HVORFOR")
+                }
+                .listRowBackground(SportivistaTokens.cell)
+            }
+
+            Section {
+                HStack(spacing: 8) {
+                    Text(leadTimeOn ? "På" : "Av")
+                        .font(.sportivista(.subheadline, weight: .semibold))
+                        .foregroundStyle(leadTimeOn ? SportivistaTokens.accent : SportivistaTokens.secondaryLabel)
+                    Text(leadTimeOn ? "minner deg før start" : "ingen påminnelse")
+                        .font(.sportivista(.caption))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                }
+                .padding(.vertical, 2)
+            } header: {
+                groupHeader("VARSEL")
+            } footer: {
+                Text("Varsel før start styres samlet i Deg › Varsel før start.")
+                    .font(.sportivista(.footnote))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+            }
+            .listRowBackground(SportivistaTokens.cell)
+
+            Section {
+                Button(role: .destructive) {
+                    confirmingStop = true
+                } label: {
+                    Text("Slutt å følge")
+                        .font(.sportivista(.body, weight: .semibold))
+                        .foregroundStyle(SportivistaTokens.destructive)
+                        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityIdentifier("followed.stop")
+            }
+            .listRowBackground(SportivistaTokens.cell)
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(SportivistaTokens.background)
+        .foregroundStyle(SportivistaTokens.label)
+        .navigationTitle(rule.entityName)
+        .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "Slutt å følge \(rule.entityName)?",
+            isPresented: $confirmingStop,
+            titleVisibility: .visible
+        ) {
+            Button("Slutt å følge", role: .destructive) {
+                viewModel.removeRule(rule)
+                dismiss()
+            }
+            .accessibilityIdentifier("followed.stop.confirm")
+            Button("Avbryt", role: .cancel) {}
+        } message: {
+            Text("\(rule.entityName) forsvinner fra det du følger, og agendaen oppdateres. Du kan legge til igjen når som helst.")
+        }
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.sportivista(.body))
+                .foregroundStyle(SportivistaTokens.label)
+            Spacer()
+            Text(value)
+                .font(.sportivista(.body))
+                .foregroundStyle(SportivistaTokens.secondaryLabel)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func groupHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.sportivista(.footnote, weight: .semibold))
+            .foregroundStyle(SportivistaTokens.secondaryLabel)
+    }
+}
+
+// MARK: - Shared Norwegian vocabulary for the follow surfaces
+
+enum FollowVocabulary {
+    /// «sport · varsler på/av» — the row subtitle. "varsler" reflects the
+    /// device-wide `NotificationLeadPreference` (the on-device profile has no
+    /// per-entity notify field), so the read-out stays honest.
+    static func rowSubtitle(_ rule: InterestRule) -> String {
+        let notify = NotificationLeadPreference.isLeadTimeEnabled() ? "varsler på" : "varsler av"
+        return "\(SportVocabulary.display(for: rule.sport)) · \(notify)"
+    }
+
+    /// A Norwegian word for an entity's `type` (athlete/team/tournament/…), for
+    /// the Legg til search rows' «sport · type» line.
+    static func typeLabel(_ type: String) -> String {
+        switch type {
+        case "athlete": return "utøver"
+        case "team": return "lag"
+        case "tournament": return "turnering"
+        case "league": return "liga"
+        case "sport": return "sport"
+        case "category": return "kategori"
+        default: return type
+        }
+    }
+}

--- a/ios/SportivistaTests/FollowActionTests.swift
+++ b/ios/SportivistaTests/FollowActionTests.swift
@@ -1,0 +1,95 @@
+//
+//  FollowActionTests.swift
+//  SportivistaTests
+//
+//  WP-105 — the assistant-free 3b apply path: follow / unfollow / search, all
+//  hostless. Proves that `AssistantViewModel.follow` (the one path Deg › Legg til
+//  and the event detail «Følg» button share) applies DIRECTLY — no diff to
+//  confirm — persists through the same ProfileStore, and recompiles the agenda
+//  (onProfileChanged), exactly like a confirmed conversation mutation. Also
+//  proves the Legg til search grounds against the shared EntityIndex.
+//
+
+import XCTest
+
+@MainActor
+final class FollowActionTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func makeVM(store: ProfileStore) -> AssistantViewModel {
+        AssistantViewModel(
+            assistant: MockInterestAssistant(),
+            profileStore: store,
+            index: index,
+            misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
+        )
+    }
+
+    // MARK: - follow (direct apply-vei)
+
+    func test_follow_appliesDirectly_persists_andRecompiles() {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+        var recompiled = 0
+        vm.onProfileChanged = { recompiled += 1 }
+
+        let lyn = index.entity(id: "fk-lyn-oslo")!
+        XCTAssertFalse(vm.isFollowing("fk-lyn-oslo"))
+
+        vm.follow(lyn)
+
+        XCTAssertTrue(vm.isFollowing("fk-lyn-oslo"), "the tap IS the confirmation")
+        XCTAssertEqual(vm.profile.rules.map(\.entityId), ["fk-lyn-oslo"])
+        XCTAssertTrue(vm.pending.isEmpty, "no diff round-trip — nothing left to confirm")
+        XCTAssertEqual(recompiled, 1, "following recompiles the agenda immediately")
+        XCTAssertEqual(store.load().rule(for: "fk-lyn-oslo")?.entityId, "fk-lyn-oslo",
+                       "the follow is persisted through the same ProfileStore")
+    }
+
+    func test_follow_isIdempotentUpsert() {
+        let vm = makeVM(store: AssistantTestSupport.tempProfileStore())
+        let lyn = index.entity(id: "fk-lyn-oslo")!
+
+        vm.follow(lyn)
+        vm.follow(lyn)
+
+        XCTAssertEqual(vm.profile.rules.filter { $0.entityId == "fk-lyn-oslo" }.count, 1,
+                       "re-following an entity refreshes its rule, never duplicates it")
+    }
+
+    // MARK: - unfollow (Slutt å følge → removeRule)
+
+    func test_unfollow_removesAndRecompiles() {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+        let lyn = index.entity(id: "fk-lyn-oslo")!
+        vm.follow(lyn)
+
+        var recompiled = 0
+        vm.onProfileChanged = { recompiled += 1 }
+        let rule = vm.profile.rule(for: "fk-lyn-oslo")!
+
+        vm.removeRule(rule)
+
+        XCTAssertFalse(vm.isFollowing("fk-lyn-oslo"), "«Slutt å følge» drops the rule")
+        XCTAssertTrue(vm.profile.isEmpty)
+        XCTAssertEqual(recompiled, 1, "unfollowing recompiles the agenda")
+        XCTAssertNil(store.load().rule(for: "fk-lyn-oslo"), "the removal is persisted")
+    }
+
+    // MARK: - Legg til search (shared EntityIndex grounding)
+
+    func test_search_findsFollowableTargets() {
+        let hits = index.search("Lyn")
+        XCTAssertTrue(hits.contains { $0.id == "fk-lyn-oslo" }, "«Lyn» resolves to FK Lyn Oslo")
+    }
+
+    func test_search_filtersOutSportPseudoEntities() {
+        // The Legg til list drops whole-sport / umbrella entities (they are the
+        // assistant's broad grounding, not a followable team/athlete/tournament).
+        let hits = index.search("fotball").filter { $0.type != "sport" && $0.type != "category" }
+        XCTAssertFalse(hits.contains { $0.type == "sport" },
+                       "no whole-sport pseudo-entity offered as a Legg til row")
+    }
+}

--- a/ios/SportivistaUITests/FollowedListUITests.swift
+++ b/ios/SportivistaUITests/FollowedListUITests.swift
@@ -1,0 +1,34 @@
+//
+//  FollowedListUITests.swift
+//  SportivistaUITests
+//
+//  WP-105 — UI smoke for the assistant-free 3b path: Deg › «Det du følger» opens
+//  the plain list, and its «+» opens the Legg til-søk. In its own file (not the
+//  WP-104-owned MainFlowsUITests) so the parallel waves never touch the same file.
+//
+
+import XCTest
+
+final class FollowedListUITests: SportivistaUITestCase {
+
+    func testOpenDetDuFolgerThenLeggTil() {
+        let app = launchApp(state: "agenda")
+
+        // gearshape → Deg → «Det du følger» (same entry the WP-83 nav test uses,
+        // now renamed; the accessibility id `deg.follows` is unchanged).
+        let gear = app.buttons["nav.settings"]
+        assertExists(gear, "the gearshape settings button should be in the nav bar")
+        gear.tap()
+
+        let followsRow = app.buttons["deg.follows"]
+        assertExists(followsRow, "Deg should home «Det du følger»")
+        followsRow.tap()
+        assertExists(app.navigationBars["Det du følger"], "the row pushes «Det du følger»")
+
+        // The «+» opens the Legg til-søk (a plain search sheet, no assistant).
+        let add = app.buttons["followed.add"]
+        assertExists(add, "«Det du følger» offers a Legg til «+»")
+        add.tap()
+        assertExists(app.navigationBars["Legg til"], "«+» opens the Legg til-søk")
+    }
+}


### PR DESCRIPTION
Implements FASE 0H · **WP-105** (spec `design/specs/assistent-nyheter-v0.md` §3b, DESIGN.md §Deg). Assistant-free interest management for iOS. Owns `ios/Sportivista/Profile/` + the event-detail file; does not touch `ContentView.swift`, `Assistant/**`, `News/**`, or `scripts/**`.

## One reused apply path (én kilde til sannhet, no new write path)
`Profile/AssistantViewModel+Follow.swift` adds `follow(_:)` / `isFollowing(_:)` as an extension (in `Profile/`, mirroring the WP-19 profil-sync arm) that funnels into the **same** `InterestProfile.applying` + `ProfileStore.save` + `onProfileChanged` that `confirm`/`confirmAll`/`toggleStarterPack` already use — a tap IS the confirmation, no diff round-trip.

## Surfaces
- **Det du følger** (`Profile/FollowedListView.swift`) — inset-grouped list, one row per follow «Navn · sport · varsler på/av ›» → detail (push) with the rule's real fields (sport, scope note, perspective, reason, varsel read-out) + **Slutt å følge** (destructive, behind a calm `confirmationDialog` per DESIGN §Deg, via existing `removeRule`). A «+» toolbar entry opens Legg til.
- **Legg til** (`Profile/AddFollowSearchView.swift`) — searches the shared `EntityIndex(DataStore().loadEntities())` (same grounding as the assistant — velg, ikke stav), hit rows «Navn · sport · type» with a per-row accent **Følg** button → `follow(_:)`; muted «Følger» when already followed.
- **DegView** row renamed **«Det du følger»** → `FollowedListView` (accessibility id `deg.follows` unchanged; obsolete inline `FollowedRulesView` removed).
- **Event detail** «Følg» button kept on the `onFollow` seam, doc'd to the direct apply-vei.

## ⚠️ Integration handoff to WP-104 (one line)
The detail/swipe «Følg» is wired via `ContentView.follow` (WP-104-owned, off-limits here). To make it fully assistant-free per §3b, WP-104 should change that one line:
`assistant.proposeFollow(entity)` → `assistant.follow(entity)`. The button/method are ready; no other change needed.

## Verification
- Full unit suite green: **534 tests**, incl. 5 new `FollowActionTests` (follow applies+persists+recompiles, idempotent upsert, unfollow, search finds targets, search filters sport pseudo-entities). The one run-level failure was `AgendaMatchingPerfTests` (timing-sensitive scaling test) under parallel load — **passes in isolation**; no matching code changed, feed vectors unaffected (bit-like).
- All **4 schemes build**: Sportivista, SportivistaUITests, SportivistaWidgetExtension, SportivistaDeviceDev.
- UI smoke `SportivistaUITests/FollowedListUITests.swift` (Deg → Det du følger → Legg til) added in its own file (MainFlowsUITests left for WP-104). Runs in the main session's combined verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)