### PR TITLE
WP-106: Nyheter-v0-klienten (fire-seksjons-tavla)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -110,7 +110,7 @@ mennesket, aldri av en agent.
 | WP-103 | Nyhets-server: `news.json` (entity-stampede pekere fra rss-digest) | 0H | — | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
 | WP-104 | Assistent-inngang: segmented rot «Uka/Nyheter» + kapsel-knapp + samtaleark | 0H | WP-99 | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
 | WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
-| WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | ⬜ |
+| WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | 🔬 |
 
 ---
 
@@ -181,6 +181,23 @@ featured.json + recent-results.json inn i filesOfInterest (og fjern død
 `interests.json`-referanse — avpublisert i WP-96); kilder åpnes UT (Link/
 SFSafariVC). «Det du følger»-lenke øverst (WP-105s view). **Aksept:** unit +
 UI-røyk på tavla, 4 schemes, skjermkatalog-modus `news` legges til.
+🔬 **Implementert (branch wp-106-nyheter-klient):** Nyheter-modeller i
+`Models/` (`NewsItem`/`NewsFeed`, `FeaturedBrief`, `RecentResults`/`FootballResult`
+— widget-trygge Codable som den delte `DataStore` leser via nye `loadNews/
+loadFeatured/loadRecentResults`); `SyncClient.defaultFilesOfInterest` fikk
+`news.json`/`featured.json`/`recent-results.json` og MISTET død `interests.json`
+(WP-96-avpublisert). Ny `News/`: `NewsLens` (linse-matching — entityId ∩ fulgte,
+ELLER fulgt hel-sport/kategori-regel via profilens rule-semantikk + SportVocabulary,
+ingen ny fuzzy), `NewsBoard` (ren fire-seksjons-bygger: brief-headline, linse-
+matchet NYTT nyest-først/capped, RESULTAT for fulgte lag med spoiler-flagg fra
+`SpoilerShield`, FREMOVER via `FeedCompiler.isEventInWindow` utover 7-dagers
+horisont), og `NewsView` (fire seksjoner + stille «Det du følger»-lenke til
+`FollowedListView`, NYTT-rader åpner kilden UT via `Link`, RESULTAT bak «Vis
+resultat» med `eye.slash`-reveal). Demo-modus `news` (`Demo/NewsDemoSeed`) + i
+`design/screens/generate.sh`/README. `Sportivista/News` lagt i test-targetet.
+Tester: `NewsLensTests` (linse/decode/tom+korrupt fil) + `NewsBoardTests`
+(seksjons-montering) + `NewsBoardUITests` (bytt til Nyheter, se seksjon);
+`SyncClientTests`/`SyncTestSupport` + nye fixtures oppdatert for fil-settet.
 
 ---
 

--- a/design/screens/README.md
+++ b/design/screens/README.md
@@ -23,7 +23,7 @@ capturing.
 
 ## What gets captured
 
-One PNG per `(mode, theme)` pair — 18 modes × 2 themes = 36 screenshots,
+One PNG per `(mode, theme)` pair — 19 modes × 2 themes = 38 screenshots,
 named `<mode>-<theme>.png`:
 
 | Mode | Screen |
@@ -31,6 +31,7 @@ named `<mode>-<theme>.png`:
 | `uitest` | The XCUITest harness's deterministic seeded agenda (real board content, no network) |
 | `lens` | Agenda through a seeded interest lens (athlete-centred rows) |
 | `filter` | Agenda with an active presentation filter ("VISER: GOLF") |
+| `news` | The Nyheter board (WP-106): the four sections — I DIN VERDEN I DAG · NYTT · RESULTAT · FREMOVER — over a seeded follow-profile |
 | `share` | Profile share sheet (QR + link) with a seeded non-empty profile |
 | `deg` | The Deg (Profile/Settings) screen with a seeded profile + memory |
 | `memory` | "Hva jeg vet om deg" (What I know about you) page |

--- a/design/screens/generate.sh
+++ b/design/screens/generate.sh
@@ -48,6 +48,7 @@ MODES=(
 	uitest
 	lens
 	filter
+	news
 	share
 	deg
 	memory

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -210,7 +210,7 @@ struct ContentView: View {
                     AgendaView(viewModel: agenda, onFollow: follow, onOpen: { assistant.recordOpened($0) },
                                openEventID: $requestedEventID)
                 case .nyheter:
-                    NewsView()
+                    NewsView(dataStore: dataStore, profileStore: profileStore, assistant: assistant)
                 }
             }
             // Liquid Glass (iOS 26): the assistant capsule is the app's ONE custom
@@ -420,6 +420,16 @@ struct ContentView: View {
                     assistant.reloadProfile()
                     agenda.reloadFromCache(now: Date())
                     demoSheet = .assistantResult
+                }
+                // WP-106: the Nyheter board (four sections) — seed a deterministic
+                // news/featured/results/events cache + a matching follow-profile,
+                // then switch the root to the Nyheter side so the screenshot
+                // captures the board (not the agenda).
+                if mode == "news" {
+                    NewsDemoSeed.seed(profileStore: profileStore)
+                    assistant.reloadProfile()
+                    agenda.reloadFromCache(now: Date())
+                    rootTab = .nyheter
                 }
                 assistant.demoSeed(mode)
                 // WP-83: a diff/answer screenshot renders the (slimmed) result

--- a/ios/Sportivista/Demo/NewsDemoSeed.swift
+++ b/ios/Sportivista/Demo/NewsDemoSeed.swift
@@ -1,0 +1,116 @@
+//
+//  NewsDemoSeed.swift
+//  Sportivista
+//
+//  WP-106 — DEBUG-only screenshot harness for the Nyheter board (SPORTIVISTA_DEMO=
+//  news). Live sync + Apple Intelligence aren't deterministic in the Simulator,
+//  so this seeds a FIXED cache — news.json / featured.json / recent-results.json
+//  / events.json / entities.json — plus a matching follow-profile (a team + a
+//  whole-sport follow) into the SAME CacheStore/ProfileStore the board reads
+//  from, so every one of the four sections renders with real content and no
+//  network. Never compiled into a release build (`#if DEBUG`) and quarantined
+//  in Sportivista/Demo/ (only the app targets' `path: Sportivista` picks it up;
+//  the widget + test targets list their sources explicitly and exclude it).
+//
+//  All timestamps are anchored to `now`: the result sits yesterday, the news
+//  pointers a few hours back, and the FREMOVER events well past the 7-day near
+//  horizon (a season opener + a league fixture) so they land in that section.
+//
+
+#if DEBUG
+import Foundation
+
+enum NewsDemoSeed {
+
+	static func seed(profileStore: ProfileStore, now: Date = Date()) {
+		let cache = CacheStore()
+		let iso = ISO8601DateFormatter()
+		iso.formatOptions = [.withInternetDateTime]
+		func at(hours: Double) -> String { iso.string(from: now.addingTimeInterval(hours * 3600)) }
+		func at(days: Double) -> String { iso.string(from: now.addingTimeInterval(days * 86400)) }
+
+		// SECTION 2 — NYTT: two matched (a Lyn headline by entityId, a langrenn
+		// headline by followed whole-sport) + one unfollowed (F1) that the lens
+		// filters out.
+		let news: [String: Any] = [
+			"items": [
+				[
+					"id": "n1", "title": "Lyn sikret opprykk med seiersmål på overtid",
+					"link": "https://www.nrk.no/sport/lyn-opprykk", "source": "nrk-sport",
+					"sport": "football", "entityIds": ["fk-lyn-oslo"], "publishedAt": at(hours: -3),
+				],
+				[
+					"id": "n2", "title": "Klæbo klar for sesongåpningen i Ruka",
+					"link": "https://www.nrk.no/sport/langrenn-ruka", "source": "nrk-sport",
+					"sport": "cross-country", "entityIds": [], "publishedAt": at(hours: -8),
+				],
+				[
+					"id": "n3", "title": "Verstappen om VM-kampen mot Norris",
+					"link": "https://www.bbc.co.uk/sport/formula1", "source": "bbc-f1",
+					"sport": "formula1", "entityIds": [], "publishedAt": at(hours: -5),
+				],
+			],
+		]
+
+		// SECTION 1 — I DIN VERDEN I DAG.
+		let featured: [String: Any] = [
+			"generatedAt": at(hours: -1), "mode": "morning",
+			"blocks": [["type": "headline", "text": "Opprykksfest for Lyn — og langrennssesongen banker på"]],
+		]
+
+		// SECTION 3 — RESULTAT: a followed-team result (no spoiler policy seeded,
+		// so it shows plainly — the masked path is unit-tested).
+		let recentResults: [String: Any] = [
+			"football": [
+				[
+					"homeTeam": "Lyn", "awayTeam": "Sogndal", "homeScore": 2, "awayScore": 1,
+					"date": at(days: -1), "league": "OBOS-ligaen", "venue": "Bislett stadion, Oslo",
+					"isFavorite": true,
+				],
+			],
+		]
+
+		// SECTION 4 — FREMOVER: two followed events beyond the 7-day horizon.
+		let events: [[String: Any]] = [
+			[
+				"sport": "cross-country", "title": "Verdenscup langrenn: sesongåpning",
+				"tournament": "FIS verdenscup", "time": at(days: 21),
+				"venue": "Ruka, Finland", "source": "ai-research", "confidence": "high",
+				"evidence": ["https://fis-ski.com", "https://nrk.no/sport"],
+				"streaming": [["platform": "NRK"]],
+			],
+			[
+				"sport": "football", "title": "Lyn – Bryne", "tournament": "OBOS-ligaen",
+				"time": at(days: 12), "homeTeam": "Lyn", "awayTeam": "Bryne",
+				"homeTeamEntityId": "fk-lyn-oslo",
+				"streaming": [["platform": "TV 2 Play", "url": "https://play.tv2.no"]],
+			],
+		]
+
+		let entities: [[String: Any]] = [
+			["id": "fk-lyn-oslo", "name": "FK Lyn Oslo", "aliases": ["Lyn"], "sport": "football", "type": "team"],
+			["id": "sport-cross-country", "name": "Langrenn", "aliases": ["langrenn"], "sport": "cross-country", "type": "sport"],
+		]
+
+		write(news, "news.json", cache)
+		write(featured, "featured.json", cache)
+		write(recentResults, "recent-results.json", cache)
+		write(events, "events.json", cache)
+		write(entities, "entities.json", cache)
+		try? cache.writeSyncState(SyncState(etag: nil, appliedFiles: [:], lastSync: now))
+
+		let rules = [
+			InterestRule(entityId: "fk-lyn-oslo", entityName: "FK Lyn Oslo", sport: "football",
+			             weight: 0.7, reason: "Følger FK Lyn Oslo.", addedAt: now),
+			InterestRule(entityId: "sport-cross-country", entityName: "Langrenn", sport: "cross-country",
+			             weight: 0.6, reason: "Følger langrenn.", addedAt: now),
+		]
+		try? profileStore.save(InterestProfile(rules: rules), now: now)
+	}
+
+	private static func write(_ object: Any, _ filename: String, _ cache: CacheStore) {
+		guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+		try? cache.write(data, filename: filename)
+	}
+}
+#endif

--- a/ios/Sportivista/Models/FeaturedBrief.swift
+++ b/ios/Sportivista/Models/FeaturedBrief.swift
@@ -1,0 +1,59 @@
+//
+//  FeaturedBrief.swift
+//  Sportivista
+//
+//  WP-106 — mirrors docs/data/featured.json, the editorial agent's brief:
+//  `{ generatedAt, mode: "morning"|"evening", blocks: [ { type, text } ] }`.
+//  The Nyheter board's «I DIN VERDEN I DAG» section shows the single `headline`
+//  block as one quiet line (spec § Nyheter-v0: "editorial-briefens headline …
+//  én stille blokk"). Only the headline is consumed today; the full block list
+//  is decoded (forward-compatible) so a future block type needs no model change.
+//
+
+import Foundation
+
+struct FeaturedBrief: Codable, Equatable {
+	struct Block: Codable, Equatable {
+		var type: String
+		var text: String?
+
+		private enum CodingKeys: String, CodingKey { case type, text }
+
+		init(type: String, text: String?) {
+			self.type = type
+			self.text = text
+		}
+
+		init(from decoder: Decoder) throws {
+			let c = try decoder.container(keyedBy: CodingKeys.self)
+			type = try c.decodeIfPresent(String.self, forKey: .type) ?? ""
+			text = try c.decodeIfPresent(String.self, forKey: .text)
+		}
+	}
+
+	var generatedAt: Date?
+	var mode: String?
+	var blocks: [Block]
+
+	private enum CodingKeys: String, CodingKey { case generatedAt, mode, blocks }
+
+	init(generatedAt: Date? = nil, mode: String? = nil, blocks: [Block] = []) {
+		self.generatedAt = generatedAt
+		self.mode = mode
+		self.blocks = blocks
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		generatedAt = try c.decodeIfPresent(Date.self, forKey: .generatedAt)
+		mode = try c.decodeIfPresent(String.self, forKey: .mode)
+		blocks = try c.decodeIfPresent([Block].self, forKey: .blocks) ?? []
+	}
+
+	/// The editorial headline — the first `headline` block's text, non-empty.
+	/// `nil` when the brief carries none (the section is then hidden).
+	var headline: String? {
+		guard let text = blocks.first(where: { $0.type == "headline" })?.text, !text.isEmpty else { return nil }
+		return text
+	}
+}

--- a/ios/Sportivista/Models/NewsItem.swift
+++ b/ios/Sportivista/Models/NewsItem.swift
@@ -1,0 +1,72 @@
+//
+//  NewsItem.swift
+//  Sportivista
+//
+//  WP-103 server / WP-106 client — mirrors ONE element of docs/data/news.json
+//  (`{ items: [ { id, title, link, source, sport, entityIds, publishedAt } ] }`),
+//  the entity-stamped RSS pointers the Nyheter board lens-filters client-side.
+//  Same forward-compatibility shape as the other Models/ types: unknown keys are
+//  ignored by Codable, and the fields the pipeline always writes but that a
+//  malformed payload could drop are defaulted via a hand-written `init(from:)`
+//  (Swift's synthesised Decodable applies no stored-property default for a
+//  missing non-Optional key). `publishedAt` is Optional so a pointer with a
+//  missing/garbled timestamp still decodes (it simply sorts last).
+//
+
+import Foundation
+
+struct NewsItem: Codable, Equatable, Identifiable {
+	/// sha1-of-link (server) — the dedupe/stable id.
+	var id: String
+	var title: String
+	var link: String
+	/// RSS feed slug, e.g. "nrk-sport", "bbc-f1".
+	var source: String
+	/// Sport tag, e.g. "formula1", "cycling", "general".
+	var sport: String
+	/// WP-05 stable entity ids the server matched the headline against (may be
+	/// empty — many headlines match no tracked entity).
+	var entityIds: [String]
+	var publishedAt: Date?
+
+	private enum CodingKeys: String, CodingKey {
+		case id, title, link, source, sport, entityIds, publishedAt
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		id = try c.decode(String.self, forKey: .id)
+		title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
+		link = try c.decodeIfPresent(String.self, forKey: .link) ?? ""
+		source = try c.decodeIfPresent(String.self, forKey: .source) ?? ""
+		sport = try c.decodeIfPresent(String.self, forKey: .sport) ?? ""
+		entityIds = try c.decodeIfPresent([String].self, forKey: .entityIds) ?? []
+		publishedAt = try c.decodeIfPresent(Date.self, forKey: .publishedAt)
+	}
+
+	init(id: String, title: String, link: String, source: String, sport: String, entityIds: [String] = [], publishedAt: Date? = nil) {
+		self.id = id
+		self.title = title
+		self.link = link
+		self.source = source
+		self.sport = sport
+		self.entityIds = entityIds
+		self.publishedAt = publishedAt
+	}
+}
+
+/// The top-level `docs/data/news.json` object: `{ items: [...] }`. A missing or
+/// non-array `items` decodes to an empty list rather than throwing (an empty
+/// NYTT section, never a crash).
+struct NewsFeed: Codable, Equatable {
+	var items: [NewsItem]
+
+	init(items: [NewsItem] = []) { self.items = items }
+
+	private enum CodingKeys: String, CodingKey { case items }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		items = try c.decodeIfPresent([NewsItem].self, forKey: .items) ?? []
+	}
+}

--- a/ios/Sportivista/Models/RecentResults.swift
+++ b/ios/Sportivista/Models/RecentResults.swift
@@ -1,0 +1,109 @@
+//
+//  RecentResults.swift
+//  Sportivista
+//
+//  WP-106 — mirrors the parts of docs/data/recent-results.json (fetch-results.js)
+//  the Nyheter «RESULTAT» section consumes. That file is keyed by sport
+//  (`football`, `golf`, `tennis`, `f1`, …); v0 models the FOOTBALL array — the
+//  populated, team-named results the client can lens-match to a followed team
+//  and mask behind the spoiler shield. Other sport keys are ignored (decoded to
+//  absent) rather than modelled, so a niche/empty sport array is never a crash;
+//  they can be added here when the section grows to cover them.
+//
+
+import Foundation
+
+struct RecentResults: Codable, Equatable {
+	var football: [FootballResult]
+
+	private enum CodingKeys: String, CodingKey { case football }
+
+	init(football: [FootballResult] = []) { self.football = football }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		football = try c.decodeIfPresent([FootballResult].self, forKey: .football) ?? []
+	}
+}
+
+/// One finished football match (fetch-results.js `football[]`). Only the fields
+/// the RESULTAT row needs are modelled; the goal-scorer list, leagueCode etc.
+/// are ignored by Codable.
+struct FootballResult: Codable, Equatable {
+	var homeTeam: String
+	var awayTeam: String
+	var homeScore: Int?
+	var awayScore: Int?
+	var date: Date?
+	var league: String?
+	var venue: String?
+	var recapHeadline: String?
+	var isFavorite: Bool
+
+	private enum CodingKeys: String, CodingKey {
+		case homeTeam, awayTeam, homeScore, awayScore, date, league, venue, recapHeadline, isFavorite
+	}
+
+	init(homeTeam: String, awayTeam: String, homeScore: Int? = nil, awayScore: Int? = nil,
+	     date: Date? = nil, league: String? = nil, venue: String? = nil,
+	     recapHeadline: String? = nil, isFavorite: Bool = false) {
+		self.homeTeam = homeTeam
+		self.awayTeam = awayTeam
+		self.homeScore = homeScore
+		self.awayScore = awayScore
+		self.date = date
+		self.league = league
+		self.venue = venue
+		self.recapHeadline = recapHeadline
+		self.isFavorite = isFavorite
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		homeTeam = try c.decodeIfPresent(String.self, forKey: .homeTeam) ?? ""
+		awayTeam = try c.decodeIfPresent(String.self, forKey: .awayTeam) ?? ""
+		homeScore = try c.decodeIfPresent(Int.self, forKey: .homeScore)
+		awayScore = try c.decodeIfPresent(Int.self, forKey: .awayScore)
+		// fetch-results.js emits football dates WITHOUT seconds ("2026-07-18T21:00Z"),
+		// which the shared SportivistaJSON strategy (internet-date-time, seconds
+		// required) rejects. Decode the raw string and parse it leniently here so a
+		// truncated timestamp is a nil date, never a whole-file decode failure —
+		// the score/teams (what RESULTAT shows) never depend on it.
+		date = (try c.decodeIfPresent(String.self, forKey: .date)).flatMap(Self.parseDate)
+		league = try c.decodeIfPresent(String.self, forKey: .league)
+		venue = try c.decodeIfPresent(String.self, forKey: .venue)
+		recapHeadline = try c.decodeIfPresent(String.self, forKey: .recapHeadline)
+		isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
+	}
+
+	/// Parse an ISO 8601 date in any of the shapes fetch-results.js / the agents
+	/// emit: with fractional seconds, with whole seconds, or WITHOUT seconds
+	/// ("…THH:mmZ"). `nil` for anything else (a missing/garbled date just sorts
+	/// last — it never fails the decode).
+	private static func parseDate(_ raw: String) -> Date? {
+		if let d = withFractionalSeconds.date(from: raw) { return d }
+		if let d = withSeconds.date(from: raw) { return d }
+		return withoutSeconds.date(from: raw)
+	}
+
+	nonisolated(unsafe) private static let withFractionalSeconds: ISO8601DateFormatter = {
+		let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f
+	}()
+	nonisolated(unsafe) private static let withSeconds: ISO8601DateFormatter = {
+		let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime]; return f
+	}()
+	nonisolated(unsafe) private static let withoutSeconds: DateFormatter = {
+		let f = DateFormatter()
+		f.locale = Locale(identifier: "en_US_POSIX")
+		f.timeZone = TimeZone(identifier: "UTC")
+		f.dateFormat = "yyyy-MM-dd'T'HH:mmXXXXX"
+		return f
+	}()
+
+	/// "2–1" (en dash) when both scores are present, else nil (the row then has
+	/// no outcome to show/mask).
+	var scoreLine: String? {
+		guard let h = homeScore, let a = awayScore else { return nil }
+		return "\(h)–\(a)"
+	}
+}

--- a/ios/Sportivista/News/NewsBoard.swift
+++ b/ios/Sportivista/News/NewsBoard.swift
@@ -1,0 +1,198 @@
+//
+//  NewsBoard.swift
+//  Sportivista
+//
+//  WP-106 — the PURE builder for the four-section Nyheter board (spec
+//  § Nyheter-v0 / DESIGN § Nyheter). A function of plain cached values (news,
+//  featured, results, events, entities, profile, spoiler shield, now) with no
+//  I/O and no clock read, so the whole board is unit-testable directly
+//  (NewsLensTests / NewsBoardTests) — the view is a thin renderer over it.
+//
+//  The board is ENDELIG: exactly four sections, no unread counters, no
+//  engagement mechanics.
+//    1. headline  — the editorial brief's headline (featured.json), one line.
+//    2. news      — lens-matched pointers (NewsLens), newest first, capped.
+//    3. results   — followed teams' recent results, each carrying whether the
+//                   spoiler shield must mask its score.
+//    4. forward   — followed events beyond the near horizon (forvarsler).
+//
+
+import Foundation
+
+struct NewsBoard: Equatable {
+	var headline: String?
+	var news: [NewsItem]
+	var results: [NewsResultRow]
+	var forward: [NewsForwardRow]
+
+	static let empty = NewsBoard(headline: nil, news: [], results: [], forward: [])
+
+	/// Events starting sooner than this many days ahead belong to the agenda
+	/// («Uka»); FREMOVER previews what's beyond it (draws, season starts).
+	static let forwardHorizonDays: Double = 7
+
+	static func build(
+		news: [NewsItem],
+		featured: FeaturedBrief?,
+		results: RecentResults,
+		events: [Event],
+		entities: [Entity],
+		profile: InterestProfile,
+		shield: SpoilerShield,
+		now: Date,
+		maxNews: Int = 20,
+		maxForward: Int = 8
+	) -> NewsBoard {
+		let index = EntityIndex(entities)
+		let lens = NewsLens(profile: profile, index: index)
+
+		// SECTION 2 — NYTT: lens-matched pointers, newest first.
+		let matchedNews = news
+			.filter { lens.matches($0) }
+			.sorted { ($0.publishedAt ?? .distantPast) > ($1.publishedAt ?? .distantPast) }
+			.prefix(maxNews)
+
+		return NewsBoard(
+			headline: featured?.headline,
+			news: Array(matchedNews),
+			results: footballResultRows(results.football, lens: lens, index: index, shield: shield),
+			forward: forwardRows(events, lens: lens, index: index, now: now, max: maxForward)
+		)
+	}
+
+	// MARK: - RESULTAT (followed teams)
+
+	/// Football results ABOUT a followed team, each stamped with whether its
+	/// score must be masked (the spoiler shield, keyed off the resolved entity
+	/// ids + sport). A result matches when a followed rule's entity name/alias
+	/// word-boundary-hits a team name (reusing the resolver + TextMatch, not a
+	/// new predicate); newest first.
+	private static func footballResultRows(_ results: [FootballResult], lens: NewsLens, index: EntityIndex, shield: SpoilerShield) -> [NewsResultRow] {
+		var rows: [NewsResultRow] = []
+		for r in results {
+			guard !r.homeTeam.isEmpty, !r.awayTeam.isEmpty else { continue }
+			let matchedIds = followedTeamIds(home: r.homeTeam, away: r.awayTeam, lens: lens, index: index)
+			guard !matchedIds.isEmpty else { continue }
+			let sensitive = shield.isSpoilerSensitive(sport: "football", entityIds: matchedIds)
+			rows.append(NewsResultRow(
+				id: resultId(r),
+				title: AgendaFormat.title(homeTeam: r.homeTeam, awayTeam: r.awayTeam, fallback: r.recapHeadline ?? ""),
+				score: r.scoreLine,
+				meta: r.league,
+				date: r.date,
+				spoilerSensitive: sensitive
+			))
+		}
+		return rows.sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
+	}
+
+	/// The followed entity ids either team resolves to. Two signals, both reusing
+	/// existing machinery: the resolver's served entity for the team NAME, and a
+	/// sport-scoped name/alias hit for each followed rule (so an alias like "Lyn"
+	/// on "FK Lyn Oslo" counts). Never invents a new fuzzy scheme.
+	private static func followedTeamIds(home: String, away: String, lens: NewsLens, index: EntityIndex) -> Set<String> {
+		var ids = Set<String>()
+		for name in [home, away] {
+			if let served = index.servedEntity(for: name), lens.followedEntityIds.contains(served.id) {
+				ids.insert(served.id)
+			}
+		}
+		let hay = "\(home) \(away)"
+		for id in lens.followedEntityIds {
+			guard let e = index.entity(id: id) else { continue }
+			if !e.sport.isEmpty, TextMatch.normalize(e.sport) != "football" { continue }
+			if ([e.name] + e.aliases).contains(where: { !$0.isEmpty && TextMatch.containsName(hay, $0) }) {
+				ids.insert(id)
+			}
+		}
+		return ids
+	}
+
+	private static func resultId(_ r: FootballResult) -> String {
+		let stamp = r.date.map { String($0.timeIntervalSince1970) } ?? "?"
+		return "result|\(r.homeTeam)|\(r.awayTeam)|\(stamp)"
+	}
+
+	// MARK: - FREMOVER (forvarsler beyond the near horizon)
+
+	/// Followed events whose window overlaps [now + horizon, far-future) — the
+	/// forvarsler the agenda's near view doesn't foreground. Uses
+	/// `FeedCompiler.isEventInWindow` (never a manual `time >= x` filter, per the
+	/// CLAUDE.md convention, so multi-day events survive) and the lens for
+	/// personal relevance; sorted by start.
+	private static func forwardRows(_ events: [Event], lens: NewsLens, index: EntityIndex, now: Date, max: Int) -> [NewsForwardRow] {
+		guard !lens.isEmpty else { return [] }
+		let horizonStart = now.addingTimeInterval(forwardHorizonDays * 86_400)
+		let farFuture = now.addingTimeInterval(400 * 86_400)
+		let matched = events.filter { lens.matchesEvent($0, index: index) }
+		let (feedEvents, lookup) = EventBridge.bridge(matched)
+		let rows = feedEvents
+			.filter { FeedCompiler.isEventInWindow($0, start: horizonStart, end: farFuture) }
+			.compactMap { fe -> (sort: Date, row: NewsForwardRow)? in
+				guard let id = fe.id, let event = lookup[id], let time = fe.time else { return nil }
+				let title = AgendaFormat.title(homeTeam: event.homeTeam, awayTeam: event.awayTeam, fallback: event.title)
+				return (time, NewsForwardRow(
+					id: id,
+					dateLabel: forwardDateLabel(time: time, endTime: event.endTime),
+					title: title,
+					meta: AgendaFormat.metaLabel(tournament: event.tournament, title: title),
+					channel: AgendaFormat.channelLabel(event.streaming),
+					isAIResearch: event.source == "ai-research"
+				))
+			}
+			.sorted { $0.sort < $1.sort }
+			.prefix(max)
+			.map(\.row)
+		return Array(rows)
+	}
+
+	// MARK: - Forward date label ("20. jul" / "20.–27. jul")
+
+	private static let dayMonth: DateFormatter = {
+		let f = DateFormatter()
+		f.locale = Locale(identifier: "nb_NO")
+		f.timeZone = FeedCompiler.osloTimeZone
+		f.dateFormat = "d. MMM"
+		return f
+	}()
+
+	private static let dayOnly: DateFormatter = {
+		let f = DateFormatter()
+		f.locale = Locale(identifier: "nb_NO")
+		f.timeZone = FeedCompiler.osloTimeZone
+		f.dateFormat = "d."
+		return f
+	}()
+
+	/// A DATE label for a forvarsel (never a clock — a season start weeks out is
+	/// answered by "when", i.e. the day, not the hour). A multi-day span reads
+	/// "20.–27. jul".
+	static func forwardDateLabel(time: Date, endTime: Date?) -> String {
+		guard let end = endTime, FeedCompiler.osloDayKey(time) != FeedCompiler.osloDayKey(end) else {
+			return dayMonth.string(from: time)
+		}
+		return "\(dayOnly.string(from: time))–\(dayMonth.string(from: end))"
+	}
+}
+
+/// SECTION 3 row — a followed team's recent result. `score` is nil when the
+/// source carried no final score; `spoilerSensitive` drives the tap-to-reveal.
+struct NewsResultRow: Identifiable, Equatable {
+	var id: String
+	var title: String
+	var score: String?
+	var meta: String?
+	var date: Date?
+	var spoilerSensitive: Bool
+}
+
+/// SECTION 4 row — a forvarsel. Non-interactive: a calm date + what + where line
+/// (the board sends its live traffic OUT via NYTT, not from here).
+struct NewsForwardRow: Identifiable, Equatable {
+	var id: String
+	var dateLabel: String
+	var title: String
+	var meta: String?
+	var channel: String
+	var isAIResearch: Bool
+}

--- a/ios/Sportivista/News/NewsLens.swift
+++ b/ios/Sportivista/News/NewsLens.swift
@@ -1,0 +1,115 @@
+//
+//  NewsLens.swift
+//  Sportivista
+//
+//  WP-106 — the CLIENT-side lens for the Nyheter board (two-layer architecture:
+//  the server publishes catalog-wide, the profile is on-device). A news pointer
+//  is shown when it is ABOUT something the owner follows, decided two ways
+//  (spec § Nyheter-v0):
+//
+//    1. entityIds ∩ followed entities ≠ ∅  — the server stamped the headline
+//       with a WP-05 entity id the profile follows;
+//    2. sport matches a followed WHOLE-sport rule — the profile follows that
+//       sport/umbrella-category as such (not merely a single entity within it).
+//
+//  It reuses the profile's own rule semantics + SportVocabulary (the same
+//  keyword→sport / category→sports maps the assistant grounds against); it
+//  invents NO new fuzzy matching. Whole-sport follows are the profile rules
+//  whose entity is a `sport`/`category` type (or, when the entity index hasn't
+//  synced, whose id carries the build-entities `sport-`/`category-` prefix).
+//  Athlete/team/tournament rules do NOT open their whole sport — only their own
+//  entityId — so following Hovland admits golf headlines that name Hovland, not
+//  every golf headline.
+//
+//  `matchesEvent` applies the SAME lens to a full `Event` (used by the FREMOVER
+//  section), matching on the event's own entity ids, its sport, or a sport-scoped
+//  name/alias hit — mirroring AgendaViewModel.ruleMatches, not a new predicate.
+//
+
+import Foundation
+
+struct NewsLens: Equatable {
+	/// Entity ids the profile follows (one per rule).
+	let followedEntityIds: Set<String>
+	/// Canonical sport tags the profile follows WHOLESALE (sport/category rules).
+	let followedSports: Set<String>
+
+	init(followedEntityIds: Set<String> = [], followedSports: Set<String> = []) {
+		self.followedEntityIds = followedEntityIds
+		self.followedSports = followedSports
+	}
+
+	/// Derive the lens from the on-device profile, resolving each rule against
+	/// the entity index to classify whole-sport / category follows.
+	init(profile: InterestProfile, index: EntityIndex) {
+		var ids = Set<String>()
+		var sports = Set<String>()
+		for rule in profile.rules {
+			ids.insert(rule.entityId)
+			let entity = index.entity(id: rule.entityId)
+			switch entity?.type {
+			case "sport":
+				sports.insert(Self.canonicalSport(entity?.sport ?? rule.sport))
+			case "category":
+				for s in Self.categorySports(entityId: rule.entityId) { sports.insert(s) }
+			case nil:
+				// Index not synced (or the entity dropped out): fall back to the
+				// build-entities id convention so a whole-sport follow still counts.
+				if rule.entityId.hasPrefix("sport-") {
+					sports.insert(Self.canonicalSport(String(rule.entityId.dropFirst("sport-".count))))
+				} else if rule.entityId.hasPrefix("category-") {
+					for s in Self.categorySports(entityId: rule.entityId) { sports.insert(s) }
+				}
+			default:
+				break // athlete / team / tournament / league → entity-scoped only
+			}
+		}
+		self.followedEntityIds = ids
+		self.followedSports = sports
+	}
+
+	var isEmpty: Bool { followedEntityIds.isEmpty && followedSports.isEmpty }
+
+	// MARK: - Matching
+
+	/// Whether a news pointer is in the lens: an entityId hit OR a followed
+	/// whole-sport hit (the item's sport tag, normalised through SportVocabulary
+	/// so "formula1" ≡ "f1").
+	func matches(_ item: NewsItem) -> Bool {
+		if !item.entityIds.isEmpty, !followedEntityIds.isDisjoint(with: Set(item.entityIds)) { return true }
+		return followedSports.contains(Self.canonicalSport(item.sport))
+	}
+
+	/// The SAME lens over a full event (FREMOVER). A whole-sport follow, an
+	/// entity id the event carries (home/away team + Norwegian players), or a
+	/// sport-scoped name/alias hit against the event's server haystack — the
+	/// last mirroring AgendaViewModel.ruleMatches so a followed entity with no
+	/// stamped id still matches its own events.
+	func matchesEvent(_ event: Event, index: EntityIndex) -> Bool {
+		if followedSports.contains(Self.canonicalSport(event.sport)) { return true }
+		if !followedEntityIds.isDisjoint(with: SpoilerShield.entityIds(of: event)) { return true }
+		let hay = FeedCompiler.serverHaystack(FeedEvent(from: event))
+		for id in followedEntityIds {
+			guard let e = index.entity(id: id) else { continue }
+			if !e.sport.isEmpty, TextMatch.normalize(e.sport) != TextMatch.normalize(event.sport) { continue }
+			if ([e.name] + e.aliases).contains(where: { !$0.isEmpty && TextMatch.containsName(hay, $0) }) { return true }
+		}
+		return false
+	}
+
+	// MARK: - Sport vocabulary bridges
+
+	/// Normalise a raw sport tag to the canonical entity tag ("formula1" → "f1"),
+	/// falling back to the lowercased raw when it isn't a known keyword.
+	static func canonicalSport(_ raw: String) -> String {
+		let lower = raw.lowercased()
+		return SportVocabulary.keywordToSport[lower] ?? lower
+	}
+
+	/// The member sports of an umbrella-category rule (e.g. `category-winter-sports`
+	/// → biathlon/cross-country/…), via SportVocabulary.categoryToSports.
+	static func categorySports(entityId: String) -> [String] {
+		let key = entityId.hasPrefix("category-") ? String(entityId.dropFirst("category-".count)) : entityId
+		return SportVocabulary.categoryToSports[key] ?? []
+	}
+}

--- a/ios/Sportivista/News/NewsView.swift
+++ b/ios/Sportivista/News/NewsView.swift
@@ -2,35 +2,365 @@
 //  NewsView.swift
 //  Sportivista
 //
-//  WP-104 — the SHELL for the Nyheter side of the root segmented control
-//  («Uka | Nyheter»). This ships the navigation first; the four-section board
-//  (I DIN VERDEN I DAG · NYTT · RESULTAT · FREMOVER) is WP-106's job and fills
-//  this file in bølge 2. For now it is a calm empty state with one dempet
-//  setning — nothing more (DESIGN § Nyheter: én hjelpesetning maks; ingen
-//  uleste-tellere, ingen engasjements-mekanikk).
+//  WP-106 — the Nyheter side of the root segmented control («Uka | Nyheter»):
+//  the four-section board from the Claude Design handoff (spec § Nyheter-v0,
+//  DESIGN § Nyheter). It is ENDELIG — exactly four sections, no unread counters,
+//  no engagement mechanics, no own refresh beyond the system's:
+//
+//    • «Det du følger ›» — a quiet link atop the board to WP-105's FollowedListView.
+//    1. I DIN VERDEN I DAG — the editorial brief's headline (featured.json), one
+//       quiet line, with a provenance ⓘ ("bygget på dine events og resultater").
+//    2. NYTT — lens-matched RSS pointers (news.json); each row taps OUT to the
+//       source (Link), never inlining article text (DSM art. 15).
+//    3. RESULTAT — followed teams' results, the score ALWAYS behind «Vis
+//       resultat» when the spoiler shield applies (the same reveal the event
+//       detail sheet uses).
+//    4. FREMOVER — followed events beyond the near horizon (forvarsler).
+//
+//  Pure data (NewsBoard.build) is computed off the cache on appear and whenever
+//  the follow-profile changes (a just-added follow re-lenses the board). No
+//  spinner ever (DESIGN § Bevegelse); amber is the one accent.
 //
 
 import SwiftUI
 
 struct NewsView: View {
-    var body: some View {
-        VStack {
-            Spacer()
-            Text("Nyheter om det du følger kommer snart.")
-                .font(.sportivista(.subheadline))
-                .foregroundStyle(SportivistaTokens.secondaryLabel)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 40)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(SportivistaTokens.background)
-        .accessibilityElement(children: .combine)
-        .accessibilityIdentifier("news.placeholder")
-    }
+	let dataStore: DataStore
+	let profileStore: ProfileStore
+	/// WP-105 — the shared assistant view model, only so the «Det du følger»
+	/// link can push FollowedListView (the same list Deg homes). The board reads
+	/// its lens from the profile, never drives the assistant.
+	var assistant: AssistantViewModel
+
+	@State private var board: NewsBoard = .empty
+	@State private var provenanceShown = false
+
+	var body: some View {
+		List {
+			followedLink
+			briefSection
+			nyttSection
+			resultatSection
+			fremoverSection
+		}
+		.listStyle(.insetGrouped)
+		.scrollContentBackground(.hidden)
+		.background(SportivistaTokens.background)
+		.accessibilityIdentifier("news.board")
+		.task { rebuild() }
+		// A just-confirmed follow (from the assistant, the agenda swipe, or Deg)
+		// re-lenses the board immediately — the same shared profile the agenda
+		// recompiles against.
+		.onChange(of: assistant.profile) { _, _ in rebuild() }
+	}
+
+	private func rebuild() {
+		let syncState = profileStore.loadSyncState()
+		board = NewsBoard.build(
+			news: dataStore.loadNews(),
+			featured: dataStore.loadFeatured(),
+			results: dataStore.loadRecentResults(),
+			events: dataStore.loadEvents(),
+			entities: dataStore.loadEntities(),
+			profile: syncState.profile,
+			shield: SpoilerShield(memory: MemoryState(from: syncState)),
+			now: Date()
+		)
+	}
+
+	// MARK: - «Det du følger» link (quiet, atop the board)
+
+	private var followedLink: some View {
+		Section {
+			NavigationLink {
+				FollowedListView(viewModel: assistant)
+			} label: {
+				HStack {
+					Text("Det du følger")
+						.font(.sportivista(.subheadline))
+						.foregroundStyle(SportivistaTokens.label)
+					Spacer()
+				}
+				.frame(minHeight: 44, alignment: .leading)
+				.contentShape(Rectangle())
+			}
+			.accessibilityIdentifier("news.followedLink")
+			.listRowBackground(SportivistaTokens.cell)
+		}
+	}
+
+	// MARK: - 1 · I DIN VERDEN I DAG
+
+	@ViewBuilder
+	private var briefSection: some View {
+		if let headline = board.headline {
+			Section {
+				VStack(alignment: .leading, spacing: 6) {
+					HStack(alignment: .top, spacing: 8) {
+						Text(headline)
+							.font(.sportivista(.subheadline))
+							.foregroundStyle(SportivistaTokens.label)
+							.fixedSize(horizontal: false, vertical: true)
+							.frame(maxWidth: .infinity, alignment: .leading)
+						Button {
+							provenanceShown.toggle()
+						} label: {
+							Image(systemName: "info.circle")
+								.font(.sportivista(.footnote))
+								.foregroundStyle(SportivistaTokens.secondaryLabel)
+						}
+						.buttonStyle(.plain)
+						.accessibilityLabel("Hvorfor ser jeg dette?")
+						.accessibilityIdentifier("news.brief.provenance")
+					}
+					if provenanceShown {
+						Text("Bygget på dine events og resultater.")
+							.font(.sportivista(.caption))
+							.foregroundStyle(SportivistaTokens.secondaryLabel)
+							.fixedSize(horizontal: false, vertical: true)
+					}
+				}
+				.padding(.vertical, 2)
+				.listRowBackground(SportivistaTokens.cell)
+			} header: {
+				sectionHeader("I DIN VERDEN I DAG", id: "news.section.brief")
+			}
+		}
+	}
+
+	// MARK: - 2 · NYTT
+
+	private var nyttSection: some View {
+		Section {
+			if board.news.isEmpty {
+				Text("Ingen nyheter om det du følger akkurat nå.")
+					.font(.sportivista(.subheadline))
+					.foregroundStyle(SportivistaTokens.secondaryLabel)
+					.fixedSize(horizontal: false, vertical: true)
+					.listRowBackground(SportivistaTokens.cell)
+			} else {
+				ForEach(board.news) { item in
+					NewsPointerRow(item: item)
+						.listRowBackground(SportivistaTokens.cell)
+				}
+			}
+		} header: {
+			sectionHeader("NYTT", id: "news.section.nytt")
+		}
+	}
+
+	// MARK: - 3 · RESULTAT
+
+	@ViewBuilder
+	private var resultatSection: some View {
+		if !board.results.isEmpty {
+			Section {
+				ForEach(board.results) { row in
+					NewsResultRowView(row: row)
+						.listRowBackground(SportivistaTokens.cell)
+				}
+			} header: {
+				sectionHeader("RESULTAT", id: "news.section.resultat")
+			}
+		}
+	}
+
+	// MARK: - 4 · FREMOVER
+
+	@ViewBuilder
+	private var fremoverSection: some View {
+		if !board.forward.isEmpty {
+			Section {
+				ForEach(board.forward) { row in
+					NewsForwardRowView(row: row)
+						.listRowBackground(SportivistaTokens.cell)
+				}
+			} header: {
+				sectionHeader("FREMOVER", id: "news.section.fremover")
+			}
+		}
+	}
+
+	// MARK: - Shared header
+
+	private func sectionHeader(_ text: String, id: String) -> some View {
+		Text(text)
+			.font(.sportivista(.footnote, weight: .semibold))
+			.foregroundStyle(SportivistaTokens.secondaryLabel)
+			.accessibilityIdentifier(id)
+	}
 }
 
-#Preview {
-    NewsView()
+// MARK: - NYTT row (taps OUT to the source)
+
+/// One news pointer. Whole row is a `Link` to the source (opens externally —
+/// DSM art. 15: pointers send traffic out, never inline the article). Rad-DNA
+/// = agendaens: the type-tag slot is DELIBERATELY omitted in v0 (classification
+/// missing) but the layout is ready for it; title on one line, then a quiet
+/// line of sport · source ↗ · relative time.
+private struct NewsPointerRow: View {
+	let item: NewsItem
+
+	var body: some View {
+		Group {
+			if let url = URL(string: item.link) {
+				Link(destination: url) { content }
+			} else {
+				content
+			}
+		}
+		.accessibilityIdentifier("news.item")
+	}
+
+	private var content: some View {
+		VStack(alignment: .leading, spacing: 3) {
+			Text(item.title)
+				.font(.sportivista(.body))
+				.foregroundStyle(SportivistaTokens.label)
+				.lineLimit(1)
+				.truncationMode(.tail)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			HStack(spacing: 6) {
+				Text(sportLabel)
+					.foregroundStyle(SportivistaTokens.secondaryLabel)
+				dot
+				Text("\(item.source) ↗")
+					.foregroundStyle(SportivistaTokens.accent)
+					.lineLimit(1)
+				if let rel = relativeTime {
+					dot
+					Text(rel)
+						.foregroundStyle(SportivistaTokens.secondaryLabel)
+						.lineLimit(1)
+				}
+				Spacer(minLength: 0)
+			}
+			.font(.sportivista(.caption))
+		}
+		.frame(minHeight: 44, alignment: .leading)
+		.contentShape(Rectangle())
+	}
+
+	private var dot: some View {
+		Text("·")
+			.font(.sportivista(.caption))
+			.foregroundStyle(SportivistaTokens.secondaryLabel.opacity(0.6))
+	}
+
+	private var sportLabel: String {
+		SportVocabulary.display(for: NewsLens.canonicalSport(item.sport))
+	}
+
+	private var relativeTime: String? {
+		guard let published = item.publishedAt else { return nil }
+		return Self.relativeFormatter.localizedString(for: published, relativeTo: Date())
+	}
+
+	private static let relativeFormatter: RelativeDateTimeFormatter = {
+		let f = RelativeDateTimeFormatter()
+		f.locale = Locale(identifier: "nb_NO")
+		f.unitsStyle = .abbreviated
+		return f
+	}()
+}
+
+// MARK: - RESULTAT row (spoiler-masked)
+
+/// A followed team's result. When the spoiler shield applies, the score stays
+/// behind a calm «Vis resultat» (eye.slash) until tapped — the exact same
+/// reveal mechanism the event detail sheet uses (WP-30), so a glance never
+/// spoils a game watched on delay.
+private struct NewsResultRowView: View {
+	let row: NewsResultRow
+	@State private var revealed = false
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 3) {
+			Text(row.title.isEmpty ? "Kamp" : row.title)
+				.font(.sportivista(.body))
+				.foregroundStyle(SportivistaTokens.label)
+				.fixedSize(horizontal: false, vertical: true)
+				.frame(maxWidth: .infinity, alignment: .leading)
+			scoreLine
+			if let meta = row.meta, !meta.isEmpty {
+				Text(meta)
+					.font(.sportivista(.caption))
+					.foregroundStyle(SportivistaTokens.secondaryLabel)
+					.lineLimit(1)
+			}
+		}
+		.padding(.vertical, 2)
+	}
+
+	@ViewBuilder
+	private var scoreLine: some View {
+		if let score = row.score {
+			if !row.spoilerSensitive || revealed {
+				Text(score)
+					.font(.sportivistaTabular(.subheadline, weight: .semibold))
+					.foregroundStyle(SportivistaTokens.label)
+			} else {
+				Button {
+					revealed = true
+				} label: {
+					HStack(spacing: 6) {
+						Image(systemName: "eye.slash")
+							.font(.sportivista(.caption))
+						Text("Vis resultat")
+							.font(.sportivista(.subheadline, weight: .semibold))
+					}
+					.foregroundStyle(SportivistaTokens.accent)
+					.frame(minHeight: 44, alignment: .leading)
+					.contentShape(Rectangle())
+				}
+				.buttonStyle(.plain)
+				.accessibilityIdentifier("news.result.reveal")
+			}
+		}
+	}
+}
+
+// MARK: - FREMOVER row
+
+/// One forvarsel: a calm date · what · where line. Non-interactive (the board's
+/// outgoing traffic is NYTT's job); an `info.circle` marks an AI-research find.
+private struct NewsForwardRowView: View {
+	let row: NewsForwardRow
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 10) {
+			Text(row.dateLabel)
+				.font(.sportivistaTabular(.footnote, weight: .medium))
+				.foregroundStyle(SportivistaTokens.label)
+				.lineLimit(1)
+				.fixedSize(horizontal: true, vertical: false)
+				.frame(minWidth: 72, alignment: .leading)
+			VStack(alignment: .leading, spacing: 3) {
+				Text(row.title)
+					.font(.sportivista(.body))
+					.foregroundStyle(SportivistaTokens.label)
+					.fixedSize(horizontal: false, vertical: true)
+					.frame(maxWidth: .infinity, alignment: .leading)
+				HStack(spacing: 6) {
+					if let meta = row.meta, !meta.isEmpty {
+						Text(meta)
+							.font(.sportivista(.caption))
+							.foregroundStyle(SportivistaTokens.secondaryLabel)
+							.lineLimit(1)
+					}
+					Text(row.channel)
+						.font(.sportivista(.caption))
+						.foregroundStyle(row.channel == "–" ? SportivistaTokens.secondaryLabel.opacity(0.5) : SportivistaTokens.secondaryLabel)
+						.lineLimit(1)
+				}
+			}
+			if row.isAIResearch {
+				Image(systemName: "info.circle")
+					.font(.sportivista(.footnote))
+					.foregroundStyle(SportivistaTokens.secondaryLabel)
+					.accessibilityLabel("Funnet av AI")
+			}
+		}
+		.padding(.vertical, 2)
+	}
 }

--- a/ios/Sportivista/Sync/DataStore.swift
+++ b/ios/Sportivista/Sync/DataStore.swift
@@ -52,6 +52,30 @@ struct DataStore: Sendable {
         return try? SportivistaJSON.decoder.decode(AppVersion.self, from: data)
     }
 
+    /// WP-106: the entity-stamped RSS pointers (docs/data/news.json) the Nyheter
+    /// board lens-filters client-side. Empty list when never synced / corrupt /
+    /// the `items` key is missing — an empty NYTT section, never a crash.
+    func loadNews() -> [NewsItem] {
+        guard let data = cache.read("news.json") else { return [] }
+        return (try? SportivistaJSON.decoder.decode(NewsFeed.self, from: data))?.items ?? []
+    }
+
+    /// WP-106: the editorial brief (docs/data/featured.json) — the Nyheter
+    /// board's «I DIN VERDEN I DAG» headline. `nil` when never synced or corrupt
+    /// (the section is then hidden).
+    func loadFeatured() -> FeaturedBrief? {
+        guard let data = cache.read("featured.json") else { return nil }
+        return try? SportivistaJSON.decoder.decode(FeaturedBrief.self, from: data)
+    }
+
+    /// WP-106: recent results (docs/data/recent-results.json) for the Nyheter
+    /// board's «RESULTAT» section. An empty `RecentResults` when never synced or
+    /// corrupt — an empty section, never a crash.
+    func loadRecentResults() -> RecentResults {
+        guard let data = cache.read("recent-results.json") else { return RecentResults() }
+        return (try? SportivistaJSON.decoder.decode(RecentResults.self, from: data)) ?? RecentResults()
+    }
+
     /// `nil` means "never synced" — see the type-level doc above for why
     /// this is the flag callers should check, not an empty `loadEvents()`.
     var lastSync: Date? {

--- a/ios/Sportivista/Sync/SyncClient.swift
+++ b/ios/Sportivista/Sync/SyncClient.swift
@@ -11,10 +11,16 @@
 //  `filesOfInterest` narrows the manifest's ~30 published files down to the
 //  ones the iOS app consumes (events.json for the agenda, entities.json for
 //  WP-05 entity ids, tracked.json for "what we track" transparency,
-//  interests.json (WP-15) so NotificationPlanner has the real notify-config/
-//  mustWatch entities to plan against) — the rest of the manifest (agent
-//  logs, calibration, per-sport source files, …) is irrelevant to this
-//  client and never fetched, changed or not.
+//  app-version.json for the "har jeg siste?" check, and — WP-106 — the three
+//  Nyheter-board files: news.json (entity-stamped RSS pointers), featured.json
+//  (the editorial brief headline) and recent-results.json). The rest of the
+//  manifest (agent logs, calibration, per-sport source files, …) is irrelevant
+//  to this client and never fetched, changed or not.
+//
+//  WP-106 dropped `interests.json`: WP-96 stopped publishing it (it is now the
+//  owner's private profile, no longer the server compass), so it is no longer a
+//  manifest key — fetching it was dead. The on-device follow-profile
+//  (ProfileStore), not a synced interests.json, is the personalisation source.
 //
 //  A file whose downloaded bytes don't hash to what the manifest declared is
 //  discarded outright: the old cached copy (if any) is kept, and — because
@@ -34,7 +40,7 @@ struct SyncClient: Sendable {
 
     /// The published files this iOS client actually consumes. See the
     /// type-level doc above for why the rest of the manifest is ignored.
-    static let defaultFilesOfInterest: Set<String> = ["events.json", "entities.json", "tracked.json", "interests.json", "app-version.json"]
+    static let defaultFilesOfInterest: Set<String> = ["events.json", "entities.json", "tracked.json", "app-version.json", "news.json", "featured.json", "recent-results.json"]
 
     private static let manifestFilename = "manifest.json"
 

--- a/ios/SportivistaTests/Fixtures/featured.json
+++ b/ios/SportivistaTests/Fixtures/featured.json
@@ -1,0 +1,7 @@
+{
+  "generatedAt": "2026-07-18T16:02:00Z",
+  "mode": "evening",
+  "blocks": [
+    { "type": "headline", "text": "VM-bronsefinale på NRK i kveld — og selve VM-finalen venter i morgen" }
+  ]
+}

--- a/ios/SportivistaTests/Fixtures/news.json
+++ b/ios/SportivistaTests/Fixtures/news.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    {
+      "id": "d2cb4e01161cd8b605b4c6284061e234",
+      "title": "Lyn sikret opprykk med seiersmål på overtid",
+      "link": "https://www.nrk.no/sport/lyn-opprykk",
+      "source": "nrk-sport",
+      "sport": "football",
+      "entityIds": ["fk-lyn-oslo"],
+      "publishedAt": "2026-07-19T11:00:00Z"
+    }
+  ]
+}

--- a/ios/SportivistaTests/Fixtures/recent-results.json
+++ b/ios/SportivistaTests/Fixtures/recent-results.json
@@ -1,0 +1,16 @@
+{
+  "lastUpdated": "2026-07-19T12:09:34.377Z",
+  "football": [
+    {
+      "homeTeam": "France",
+      "awayTeam": "England",
+      "homeScore": 4,
+      "awayScore": 6,
+      "date": "2026-07-18T21:00Z",
+      "league": "FIFA World Cup",
+      "venue": "Hard Rock Stadium",
+      "recapHeadline": "England til finale etter målfest",
+      "isFavorite": false
+    }
+  ]
+}

--- a/ios/SportivistaTests/NewsBoardTests.swift
+++ b/ios/SportivistaTests/NewsBoardTests.swift
@@ -1,0 +1,123 @@
+//
+//  NewsBoardTests.swift
+//  SportivistaTests
+//
+//  WP-106 — hostless tests for NewsBoard.build, the pure four-section assembler.
+//  Covers: NYTT lens-filtering + newest-first order + cap; RESULTAT scoped to a
+//  followed team with the spoiler flag set from the shield; FREMOVER's near-
+//  horizon exclusion (via isEventInWindow) + lens relevance; and the empty
+//  board when nothing is followed.
+//
+
+import XCTest
+
+final class NewsBoardTests: XCTestCase {
+
+	private let now = ISO8601DateFormatter().date(from: "2026-07-19T12:00:00Z")!
+	private let lynTeam = Entity(id: "fk-lyn-oslo", name: "FK Lyn Oslo", aliases: ["Lyn"], sport: "football", type: "team")
+	private let langrenn = Entity(id: "sport-cross-country", name: "Langrenn", aliases: ["langrenn"], sport: "cross-country", type: "sport")
+
+	private func rule(_ entityId: String, _ name: String, sport: String) -> InterestRule {
+		InterestRule(entityId: entityId, entityName: name, sport: sport, weight: 0.5, reason: "test", addedAt: now)
+	}
+
+	private var followProfile: InterestProfile {
+		InterestProfile(rules: [
+			rule("fk-lyn-oslo", "FK Lyn Oslo", sport: "football"),
+			rule("sport-cross-country", "Langrenn", sport: "cross-country"),
+		])
+	}
+
+	private func iso(_ offsetDays: Double) -> String {
+		ISO8601DateFormatter().string(from: now.addingTimeInterval(offsetDays * 86400))
+	}
+
+	private func item(_ id: String, sport: String, entityIds: [String] = [], published: Double) -> NewsItem {
+		NewsItem(id: id, title: id, link: "https://x/\(id)", source: "nrk", sport: sport, entityIds: entityIds,
+		         publishedAt: now.addingTimeInterval(published * 3600))
+	}
+
+	// MARK: - Section 1 (headline)
+
+	func testHeadline_fromFeatured() {
+		let brief = FeaturedBrief(mode: "morning", blocks: [FeaturedBrief.Block(type: "headline", text: "Hei")])
+		let board = NewsBoard.build(news: [], featured: brief, results: RecentResults(), events: [], entities: [], profile: followProfile, shield: SpoilerShield(), now: now)
+		XCTAssertEqual(board.headline, "Hei")
+	}
+
+	// MARK: - Section 2 (NYTT)
+
+	func testNytt_filtersAndSortsNewestFirst() {
+		let news = [
+			item("old-lyn", sport: "football", entityIds: ["fk-lyn-oslo"], published: -10),
+			item("new-langrenn", sport: "cross-country", published: -1),
+			item("unfollowed-f1", sport: "formula1", published: -2),
+		]
+		let board = NewsBoard.build(news: news, featured: nil, results: RecentResults(), events: [], entities: [lynTeam, langrenn], profile: followProfile, shield: SpoilerShield(), now: now)
+		XCTAssertEqual(board.news.map(\.id), ["new-langrenn", "old-lyn"], "unfollowed dropped; newest first")
+	}
+
+	func testNytt_capped() {
+		let news = (0..<40).map { item("n\($0)", sport: "cross-country", published: Double(-$0)) }
+		let board = NewsBoard.build(news: news, featured: nil, results: RecentResults(), events: [], entities: [langrenn], profile: followProfile, shield: SpoilerShield(), now: now, maxNews: 20)
+		XCTAssertEqual(board.news.count, 20)
+	}
+
+	// MARK: - Section 3 (RESULTAT)
+
+	func testResultat_scopedToFollowedTeam_withSpoilerFlag() {
+		let results = RecentResults(football: [
+			FootballResult(homeTeam: "Lyn", awayTeam: "Sogndal", homeScore: 2, awayScore: 1, date: now.addingTimeInterval(-86400), league: "OBOS-ligaen"),
+			FootballResult(homeTeam: "Brann", awayTeam: "Molde", homeScore: 0, awayScore: 0, date: now.addingTimeInterval(-3600), league: "Eliteserien"),
+		])
+		// Spoiler shield on football → the followed result's score must be masked.
+		let shield = SpoilerShield(sports: ["football"], entityIds: [])
+		let board = NewsBoard.build(news: [], featured: nil, results: results, events: [], entities: [lynTeam], profile: followProfile, shield: shield, now: now)
+
+		XCTAssertEqual(board.results.count, 1, "only the followed team's match is included")
+		let row = try? XCTUnwrap(board.results.first)
+		XCTAssertEqual(row?.score, "2–1")
+		XCTAssertTrue(row?.spoilerSensitive ?? false)
+		XCTAssertTrue(row?.title.contains("Lyn") ?? false)
+	}
+
+	func testResultat_noSpoilerPolicy_notSensitive() {
+		let results = RecentResults(football: [
+			FootballResult(homeTeam: "Lyn", awayTeam: "Sogndal", homeScore: 2, awayScore: 1, date: now, league: "OBOS-ligaen"),
+		])
+		let board = NewsBoard.build(news: [], featured: nil, results: results, events: [], entities: [lynTeam], profile: followProfile, shield: SpoilerShield(), now: now)
+		XCTAssertEqual(board.results.first?.spoilerSensitive, false)
+	}
+
+	// MARK: - Section 4 (FREMOVER)
+
+	func testFremover_excludesNearHorizon_keepsFarFollowed() {
+		let near = EventBuilder.make(sport: "cross-country", title: "Nær langrenn", time: iso(3), id: "near")       // < 7d
+		let far = EventBuilder.make(sport: "cross-country", title: "Fjern langrenn", time: iso(30), id: "far")      // > 7d, followed
+		let farUnfollowed = EventBuilder.make(sport: "tennis", title: "Fjern tennis", time: iso(30), id: "tennis")  // > 7d, NOT followed
+		let board = NewsBoard.build(news: [], featured: nil, results: RecentResults(), events: [near, far, farUnfollowed], entities: [lynTeam, langrenn], profile: followProfile, shield: SpoilerShield(), now: now)
+
+		XCTAssertEqual(board.forward.map(\.id), ["far"], "only the far-future FOLLOWED event is a forvarsel")
+	}
+
+	func testFremover_sortedByStart_andCapped() {
+		let events = (1...12).map { EventBuilder.make(sport: "cross-country", title: "E\($0)", time: iso(Double(10 + $0)), id: "e\($0)") }
+		let board = NewsBoard.build(news: [], featured: nil, results: RecentResults(), events: events, entities: [langrenn], profile: followProfile, shield: SpoilerShield(), now: now, maxForward: 8)
+		XCTAssertEqual(board.forward.count, 8)
+		XCTAssertEqual(board.forward.first?.id, "e1", "earliest first")
+	}
+
+	// MARK: - Empty board
+
+	func testEmptyProfile_producesEmptySections() {
+		let news = [item("lyn", sport: "football", entityIds: ["fk-lyn-oslo"], published: -1)]
+		let results = RecentResults(football: [FootballResult(homeTeam: "Lyn", awayTeam: "Sogndal", homeScore: 2, awayScore: 1, date: now, league: "OBOS")])
+		let events = [EventBuilder.make(sport: "cross-country", title: "Far", time: iso(30), id: "far")]
+		let board = NewsBoard.build(news: news, featured: nil, results: results, events: events, entities: [lynTeam, langrenn], profile: InterestProfile(rules: []), shield: SpoilerShield(), now: now)
+
+		XCTAssertTrue(board.news.isEmpty)
+		XCTAssertTrue(board.results.isEmpty)
+		XCTAssertTrue(board.forward.isEmpty)
+		XCTAssertNil(board.headline)
+	}
+}

--- a/ios/SportivistaTests/NewsLensTests.swift
+++ b/ios/SportivistaTests/NewsLensTests.swift
@@ -1,0 +1,170 @@
+//
+//  NewsLensTests.swift
+//  SportivistaTests
+//
+//  WP-106 — hostless tests for the Nyheter board's client-side lens (NewsLens)
+//  and the Codable models it reads. Covers the two match signals (entityId ∩
+//  followed, and a followed WHOLE-sport / category rule), the deliberate
+//  non-match of a single-entity rule against its whole sport, sport-tag
+//  normalisation, the empty-profile ⇒ nothing case, and — via DataStore against
+//  a temp cache — that a missing or corrupt news.json is an empty section, never
+//  a crash.
+//
+
+import XCTest
+
+final class NewsLensTests: XCTestCase {
+
+	// MARK: - Fixtures
+
+	private func index(_ entities: [Entity]) -> EntityIndex { EntityIndex(entities) }
+
+	private let lynTeam = Entity(id: "fk-lyn-oslo", name: "FK Lyn Oslo", aliases: ["Lyn"], sport: "football", type: "team")
+	private let hovland = Entity(id: "viktor-hovland", name: "Viktor Hovland", aliases: ["Hovland"], sport: "golf", type: "athlete")
+	private let langrenn = Entity(id: "sport-cross-country", name: "Langrenn", aliases: ["langrenn"], sport: "cross-country", type: "sport")
+	private let vintersport = Entity(id: "category-winter-sports", name: "Vintersport", aliases: [], sport: "", type: "category")
+
+	private func rule(_ entityId: String, _ name: String, sport: String) -> InterestRule {
+		InterestRule(entityId: entityId, entityName: name, sport: sport, weight: 0.5, reason: "test", addedAt: Date())
+	}
+
+	private func newsItem(id: String = "n", sport: String, entityIds: [String] = []) -> NewsItem {
+		NewsItem(id: id, title: "t", link: "https://x", source: "s", sport: sport, entityIds: entityIds, publishedAt: Date())
+	}
+
+	// MARK: - Signal 1: entityId ∩ followed
+
+	func testMatches_byEntityId() {
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("fk-lyn-oslo", "FK Lyn Oslo", sport: "football")]), index: index([lynTeam]))
+		XCTAssertTrue(lens.matches(newsItem(sport: "football", entityIds: ["fk-lyn-oslo"])))
+		XCTAssertFalse(lens.matches(newsItem(sport: "football", entityIds: ["some-other-team"])),
+		               "a football headline about an UNfollowed team must not match on sport alone")
+	}
+
+	// MARK: - Signal 2: followed whole-sport / category
+
+	func testMatches_byWholeSportRule() {
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("sport-cross-country", "Langrenn", sport: "cross-country")]), index: index([langrenn]))
+		XCTAssertTrue(lens.matches(newsItem(sport: "cross-country")), "a langrenn follow opens langrenn headlines")
+		XCTAssertFalse(lens.matches(newsItem(sport: "football")))
+	}
+
+	func testMatches_byCategoryExpansion() {
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("category-winter-sports", "Vintersport", sport: "winter-sports")]), index: index([vintersport]))
+		// winter-sports expands to biathlon/cross-country/alpine/… via SportVocabulary.
+		XCTAssertTrue(lens.matches(newsItem(sport: "biathlon")))
+		XCTAssertTrue(lens.matches(newsItem(sport: "alpine")))
+		XCTAssertFalse(lens.matches(newsItem(sport: "football")))
+	}
+
+	func testAthleteRule_doesNotOpenWholeSport() {
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("viktor-hovland", "Viktor Hovland", sport: "golf")]), index: index([hovland]))
+		XCTAssertFalse(lens.matches(newsItem(sport: "golf")), "following Hovland must NOT admit every golf headline")
+		XCTAssertTrue(lens.matches(newsItem(sport: "golf", entityIds: ["viktor-hovland"])), "only golf headlines that name Hovland")
+	}
+
+	// MARK: - Sport-tag normalisation
+
+	func testCanonicalSport_normalisesAliases() {
+		XCTAssertEqual(NewsLens.canonicalSport("formula1"), "f1")
+		XCTAssertEqual(NewsLens.canonicalSport("FOOTBALL"), "football")
+		XCTAssertEqual(NewsLens.canonicalSport("general"), "general") // unknown → passthrough (lowercased)
+	}
+
+	func testMatches_sportAliasNormalised() {
+		// news.js emits "formula1"; a followed f1 sport rule must still match it.
+		let f1Sport = Entity(id: "sport-f1", name: "Formel 1", aliases: [], sport: "f1", type: "sport")
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("sport-f1", "Formel 1", sport: "f1")]), index: index([f1Sport]))
+		XCTAssertTrue(lens.matches(newsItem(sport: "formula1")))
+	}
+
+	// MARK: - Empty / degenerate
+
+	func testEmptyProfile_matchesNothing() {
+		let lens = NewsLens(profile: InterestProfile(rules: []), index: index([]))
+		XCTAssertTrue(lens.isEmpty)
+		XCTAssertFalse(lens.matches(newsItem(sport: "football", entityIds: ["fk-lyn-oslo"])))
+	}
+
+	func testWholeSportFallback_whenIndexUnsynced() {
+		// Entity index empty (unsynced) → fall back to the build-entities id prefix.
+		let lens = NewsLens(profile: InterestProfile(rules: [rule("sport-cross-country", "Langrenn", sport: "cross-country")]), index: index([]))
+		XCTAssertTrue(lens.matches(newsItem(sport: "cross-country")))
+	}
+
+	// MARK: - matchesEvent (FREMOVER lens over full events)
+
+	func testMatchesEvent_byEntityIdSportAndName() {
+		let idx = index([lynTeam, langrenn])
+		let lens = NewsLens(profile: InterestProfile(rules: [
+			rule("fk-lyn-oslo", "FK Lyn Oslo", sport: "football"),
+			rule("sport-cross-country", "Langrenn", sport: "cross-country"),
+		]), index: idx)
+
+		let byId = EventBuilder.make(sport: "football", title: "Lyn – Bryne", time: "2026-08-01T17:00:00Z",
+		                             homeTeam: "Lyn", awayTeam: "Bryne", homeTeamEntityId: "fk-lyn-oslo")
+		XCTAssertTrue(lens.matchesEvent(byId, index: idx))
+
+		let bySport = EventBuilder.make(sport: "cross-country", title: "Verdenscup: sesongåpning", time: "2026-11-01T10:00:00Z")
+		XCTAssertTrue(lens.matchesEvent(bySport, index: idx))
+
+		let byName = EventBuilder.make(sport: "football", title: "Sarpsborg – Lyn", time: "2026-08-10T17:00:00Z",
+		                               homeTeam: "Sarpsborg", awayTeam: "Lyn") // alias "Lyn", no id stamped
+		XCTAssertTrue(lens.matchesEvent(byName, index: idx))
+
+		let unrelated = EventBuilder.make(sport: "tennis", title: "Wimbledon-finale", time: "2026-07-12T14:00:00Z")
+		XCTAssertFalse(lens.matchesEvent(unrelated, index: idx))
+	}
+
+	// MARK: - Codable models (decode from fixtures)
+
+	func testDecode_newsFeed() throws {
+		let feed = try SportivistaJSON.decoder.decode(NewsFeed.self, from: Fixture.data("news"))
+		XCTAssertEqual(feed.items.count, 1)
+		XCTAssertEqual(feed.items.first?.entityIds, ["fk-lyn-oslo"])
+		XCTAssertNotNil(feed.items.first?.publishedAt)
+	}
+
+	func testDecode_featuredHeadline() throws {
+		let brief = try SportivistaJSON.decoder.decode(FeaturedBrief.self, from: Fixture.data("featured"))
+		XCTAssertEqual(brief.mode, "evening")
+		XCTAssertNotNil(brief.headline)
+		XCTAssertTrue(brief.headline?.contains("VM-bronsefinale") ?? false)
+	}
+
+	func testDecode_recentResults() throws {
+		let results = try SportivistaJSON.decoder.decode(RecentResults.self, from: Fixture.data("recent-results"))
+		XCTAssertEqual(results.football.count, 1)
+		XCTAssertEqual(results.football.first?.scoreLine, "4–6")
+	}
+
+	func testFeatured_noHeadlineBlock_isNil() throws {
+		let json = Data(#"{"mode":"morning","blocks":[{"type":"other","text":"x"}]}"#.utf8)
+		let brief = try SportivistaJSON.decoder.decode(FeaturedBrief.self, from: json)
+		XCTAssertNil(brief.headline)
+	}
+
+	// MARK: - DataStore: missing / corrupt files never crash
+
+	func testDataStore_missingFiles_returnEmpty() {
+		let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		defer { try? FileManager.default.removeItem(at: temp) }
+		let store = DataStore(cache: CacheStore(rootDirectory: temp))
+		XCTAssertTrue(store.loadNews().isEmpty)
+		XCTAssertNil(store.loadFeatured())
+		XCTAssertEqual(store.loadRecentResults(), RecentResults())
+	}
+
+	func testDataStore_corruptFiles_returnEmpty() throws {
+		let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		defer { try? FileManager.default.removeItem(at: temp) }
+		let cache = CacheStore(rootDirectory: temp)
+		try cache.write(Data("not json".utf8), filename: "news.json")
+		try cache.write(Data("not json".utf8), filename: "featured.json")
+		try cache.write(Data("{".utf8), filename: "recent-results.json")
+		let store = DataStore(cache: cache)
+		XCTAssertTrue(store.loadNews().isEmpty)
+		XCTAssertNil(store.loadFeatured())
+		XCTAssertEqual(store.loadRecentResults(), RecentResults())
+	}
+}

--- a/ios/SportivistaTests/SyncClientTests.swift
+++ b/ios/SportivistaTests/SyncClientTests.swift
@@ -44,28 +44,35 @@ final class SyncClientTests: XCTestCase {
 
     // MARK: - Baseline: first-ever sync against the real, full manifest fixture
 
-    /// The real manifest.json fixture lists ~28 published files; only four
-    /// (events/entities/tracked/interests) are `SyncClient.defaultFilesOfInterest`.
-    /// This proves the diff-and-fetch loop is scoped to those four, not the
-    /// whole manifest, on a completely realistic payload.
+    /// The manifest fixture lists ~28 published files; only six
+    /// (events/entities/tracked + the WP-106 Nyheter-board trio
+    /// news/featured/recent-results) are `SyncClient.defaultFilesOfInterest`.
+    /// This proves the diff-and-fetch loop is scoped to those, not the whole
+    /// manifest, on a realistic payload — and that interests.json (WP-96
+    /// unpublished, WP-106 dropped) is NOT fetched even though the manifest
+    /// still lists it.
     func testInitialSync_fetchesOnlyFilesOfInterest_fromRealManifest() async throws {
         let result = await SyncTestSupport.performBaselineSync(cache: cache)
 
-        XCTAssertEqual(result, .changedFiles(["entities.json", "events.json", "interests.json", "tracked.json"]))
+        XCTAssertEqual(result, .changedFiles(SyncTestSupport.baselineChangedFiles))
 
         let requestedFilenames = Set(MockURLProtocol.recordedRequests.compactMap { $0.url?.lastPathComponent })
-        XCTAssertEqual(requestedFilenames, ["manifest.json", "events.json", "entities.json", "tracked.json", "interests.json"])
-        XCTAssertEqual(MockURLProtocol.recordedRequests.count, 5, "no other manifest file should have been requested")
+        XCTAssertEqual(requestedFilenames, Set(["manifest.json"] + SyncTestSupport.baselineFileBodies.keys))
+        XCTAssertEqual(MockURLProtocol.recordedRequests.count, SyncTestSupport.baselineFileBodies.count + 1,
+                       "no other manifest file should have been requested")
+        XCTAssertFalse(requestedFilenames.contains("interests.json"), "the unpublished interests.json must never be fetched")
 
         XCTAssertEqual(cache.read("events.json"), Fixture.data("events"))
         XCTAssertEqual(cache.read("entities.json"), Fixture.data("entities"))
         XCTAssertEqual(cache.read("tracked.json"), Fixture.data("tracked"))
-        XCTAssertEqual(cache.read("interests.json"), Fixture.data("interests"))
+        XCTAssertEqual(cache.read("featured.json"), Fixture.data("featured"))
+        XCTAssertEqual(cache.read("recent-results.json"), Fixture.data("recent-results"))
+        XCTAssertEqual(cache.read("news.json"), Fixture.data("news"))
 
         let state = try XCTUnwrap(cache.readSyncState())
         XCTAssertEqual(state.etag, "W/\"v1\"")
         XCTAssertNotNil(state.lastSync)
-        XCTAssertEqual(state.appliedFiles.count, 4)
+        XCTAssertEqual(state.appliedFiles.count, SyncTestSupport.baselineFileBodies.count)
     }
 
     // MARK: (a) 304 → no file requests at all beyond the manifest
@@ -95,10 +102,9 @@ final class SyncClientTests: XCTestCase {
 
         MockURLProtocol.reset()
         SyncTestSupport.stubSuccessfulSync(manifestBody: manifestV2, etag: "W/\"v2\"", fileBodies: ["events.json": newEvents])
-        // Deliberately no stub for entities.json/tracked.json/interests.json —
-        // if SyncClient wrongly re-fetched any (their hashes are unchanged
-        // from the baseline), the request would still land in
-        // recordedRequests below.
+        // Deliberately no stub for the other files of interest — if SyncClient
+        // wrongly re-fetched any (their hashes are unchanged from the baseline),
+        // the request would still land in recordedRequests below.
 
         let result = await makeClient().sync()
 
@@ -109,7 +115,9 @@ final class SyncClientTests: XCTestCase {
         XCTAssertEqual(cache.read("events.json"), newEvents)
         XCTAssertEqual(cache.read("entities.json"), Fixture.data("entities"), "unchanged file must be left alone")
         XCTAssertEqual(cache.read("tracked.json"), Fixture.data("tracked"), "unchanged file must be left alone")
-        XCTAssertEqual(cache.read("interests.json"), Fixture.data("interests"), "unchanged file must be left alone")
+        XCTAssertEqual(cache.read("featured.json"), Fixture.data("featured"), "unchanged file must be left alone")
+        XCTAssertEqual(cache.read("recent-results.json"), Fixture.data("recent-results"), "unchanged file must be left alone")
+        XCTAssertEqual(cache.read("news.json"), Fixture.data("news"), "unchanged file must be left alone")
 
         let events = try SportivistaJSON.decoder.decode([Event].self, from: cache.read("events.json")!)
         XCTAssertTrue(events.isEmpty)

--- a/ios/SportivistaTests/SyncTestSupport.swift
+++ b/ios/SportivistaTests/SyncTestSupport.swift
@@ -4,17 +4,24 @@
 //
 //  WP-12: shared helpers for the sync tests. The guiding idea across all of
 //  them is to reuse the REAL, checked-in SportivistaTests/Fixtures/{events,
-//  entities,tracked,interests,manifest}.json as the mock server's responses —
-//  the same fasit WP-11's decode tests already use — rather than inventing
-//  separate, parallel test data. Where a test needs a scenario the frozen
-//  fixture doesn't represent (a changed file, a corrupt download), it starts
-//  from the real manifest fixture and surgically mutates just the one entry
-//  that scenario needs, computing the replacement sha256 with the SAME
-//  `Data.sha256Hex` SyncClient itself uses — so there is never a hand-typed
-//  hash to keep in sync by hand. (WP-15 added `interests.json` to
-//  `SyncClient.defaultFilesOfInterest` — NotificationPlanner needs the real
-//  notify-config synced — so the baseline sync now fetches four files, not
-//  three.)
+//  entities,tracked,featured,recent-results,news,manifest}.json as the mock
+//  server's responses — the same fasit WP-11's decode tests already use —
+//  rather than inventing separate, parallel test data. Where a test needs a
+//  scenario the frozen fixture doesn't represent (a changed file, a corrupt
+//  download), it starts from the CANONICAL manifest and surgically mutates just
+//  the one entry that scenario needs, computing the replacement sha256 with the
+//  SAME `Data.sha256Hex` SyncClient itself uses — so there is never a
+//  hand-typed hash to keep in sync by hand.
+//
+//  WP-106: `SyncClient.defaultFilesOfInterest` gained the three Nyheter-board
+//  files (news.json, featured.json, recent-results.json) and DROPPED the
+//  now-unpublished interests.json. The real manifest fixture predates those
+//  three fixtures, so its declared sha256 for featured/recent-results would not
+//  match the CURRENT fixture bytes (and it has no news.json entry at all).
+//  `canonicalManifestData()` therefore overrides exactly those three entries to
+//  match the fixture bytes served below — keeping the full ~28-file manifest
+//  (so the "scoped down from the whole manifest" proof stands) while guaranteeing
+//  every file-of-interest hash is internally consistent.
 //
 
 import Foundation
@@ -28,13 +35,36 @@ enum SyncTestSupport {
         return encoder
     }()
 
-    /// Decodes the real manifest fixture, replaces exactly one file's entry
+    /// The Nyheter-board files added in WP-106, served as their checked-in
+    /// fixtures. `canonicalManifestData` overrides the manifest's entries for
+    /// these to match — the base fixture's featured/recent-results hashes are
+    /// stale and it carries no news.json entry.
+    static let newFilesOfInterest: [String: Data] = [
+        "featured.json": Fixture.data("featured"),
+        "recent-results.json": Fixture.data("recent-results"),
+        "news.json": Fixture.data("news"),
+    ]
+
+    /// The full manifest fixture with the WP-106 file entries overridden to match
+    /// the served fixtures. Every helper below builds on THIS (not the raw
+    /// fixture), so "unchanged" files keep identical hashes across baseline and
+    /// any single-file mutation — the scoping/diff assertions stay honest.
+    static func canonicalManifestData() -> Data {
+        // swiftlint:disable:next force_try
+        let base = try! SportivistaJSON.decoder.decode(Manifest.self, from: Fixture.data("manifest"))
+        var files = base.files
+        for (filename, content) in newFilesOfInterest {
+            files[filename] = Manifest.FileEntry(bytes: content.count, sha256: content.sha256Hex, sourceLastUpdated: nil)
+        }
+        let manifest = Manifest(generatedAt: base.generatedAt, schemaVersion: base.schemaVersion, files: files)
+        // swiftlint:disable:next force_try
+        return try! encoder.encode(manifest)
+    }
+
+    /// Decodes the canonical manifest, replaces exactly one file's entry
     /// (computing its sha256/bytes from `newContent`), and re-encodes.
-    /// Returns the new manifest's raw bytes alongside the content that must
-    /// be stubbed as that file's own HTTP response for the manifest to be
-    /// internally consistent.
     static func manifestFixture(replacing filename: String, with newContent: Data) throws -> Data {
-        let baseManifest = try SportivistaJSON.decoder.decode(Manifest.self, from: Fixture.data("manifest"))
+        let baseManifest = try SportivistaJSON.decoder.decode(Manifest.self, from: canonicalManifestData())
         var files = baseManifest.files
         files[filename] = Manifest.FileEntry(bytes: newContent.count, sha256: newContent.sha256Hex, sourceLastUpdated: nil)
         let manifest = Manifest(generatedAt: baseManifest.generatedAt, schemaVersion: baseManifest.schemaVersion, files: files)
@@ -52,24 +82,32 @@ enum SyncTestSupport {
         }
     }
 
-    /// Runs an initial, "everything is new" sync against the real manifest +
-    /// events/entities/tracked/interests fixtures, on a fresh cache. This is
-    /// the baseline every other scenario builds on (a changed manifest, a
-    /// dropped connection, a corrupt download all assume something was
-    /// already successfully synced once).
+    /// The files (of interest) a first, "everything is new" sync applies — the
+    /// events/entities/tracked WP-11 fixtures plus the WP-106 Nyheter-board
+    /// files. interests.json is deliberately NOT here: WP-106 dropped it from
+    /// `defaultFilesOfInterest`, so it is never fetched even though the manifest
+    /// still lists it.
+    static let baselineFileBodies: [String: Data] = [
+        "events.json": Fixture.data("events"),
+        "entities.json": Fixture.data("entities"),
+        "tracked.json": Fixture.data("tracked"),
+        "featured.json": Fixture.data("featured"),
+        "recent-results.json": Fixture.data("recent-results"),
+        "news.json": Fixture.data("news"),
+    ]
+
+    /// The filenames of `baselineFileBodies`, sorted — the expected
+    /// `.changedFiles` payload of a baseline sync.
+    static let baselineChangedFiles: [String] = baselineFileBodies.keys.sorted()
+
+    /// Runs an initial, "everything is new" sync against the canonical manifest +
+    /// the baseline fixtures, on a fresh cache. This is the baseline every other
+    /// scenario builds on (a changed manifest, a dropped connection, a corrupt
+    /// download all assume something was already successfully synced once).
     @discardableResult
     static func performBaselineSync(cache: CacheStore, etag: String = "W/\"v1\"") async -> SyncResult {
         MockURLProtocol.reset()
-        stubSuccessfulSync(
-            manifestBody: Fixture.data("manifest"),
-            etag: etag,
-            fileBodies: [
-                "events.json": Fixture.data("events"),
-                "entities.json": Fixture.data("entities"),
-                "tracked.json": Fixture.data("tracked"),
-                "interests.json": Fixture.data("interests"),
-            ]
-        )
+        stubSuccessfulSync(manifestBody: canonicalManifestData(), etag: etag, fileBodies: baselineFileBodies)
         let client = SyncClient(baseURL: baseURL, session: MockURLProtocol.mockedSession(), cache: cache)
         return await client.sync()
     }

--- a/ios/SportivistaUITests/NewsBoardUITests.swift
+++ b/ios/SportivistaUITests/NewsBoardUITests.swift
@@ -1,0 +1,29 @@
+//
+//  NewsBoardUITests.swift
+//  SportivistaUITests
+//
+//  WP-106 — UI smoke for the Nyheter board: switch the root segmented control
+//  to «Nyheter» and confirm the board renders (the NYTT section header + the
+//  quiet «Det du følger» link atop it). In its own file (not WP-104's
+//  MainFlowsUITests) so parallel waves never touch the same file. Runs against
+//  the deterministic uitest harness (a seeded FK Lyn Oslo follow, no network).
+//
+
+import XCTest
+
+final class NewsBoardUITests: SportivistaUITestCase {
+
+	func testSwitchToNyheterShowsBoard() {
+		let app = launchApp(state: "agenda")
+
+		// The root segmented control offers «Uka | Nyheter» as words.
+		let nyheter = app.buttons["Nyheter"]
+		assertExists(nyheter, "the root segmented control should offer a «Nyheter» segment")
+		nyheter.tap()
+
+		// The board's NYTT section header is always present (even when empty), and
+		// the quiet «Det du følger» link sits atop it.
+		assertExists(app.staticTexts["news.section.nytt"], "the Nyheter board should show its NYTT section header")
+		assertExists(app.buttons["news.followedLink"], "the board should offer the «Det du følger» link")
+	}
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -226,6 +226,16 @@ targets:
       # these up via `path: Sportivista`; the widget deliberately does NOT (memory is
       # app-only — the widget has no network/personal-context code).
       - path: Sportivista/Memory
+      # WP-106: the Nyheter board — the pure lens/board builders (NewsLens/
+      # NewsBoard) + the SwiftUI view — compiled directly into the hostless
+      # bundle so NewsLensTests/NewsBoardTests drive the matching + section
+      # assembly with no running app (same "no @testable import" pattern). App +
+      # SportivistaDeviceDev pick these up via `path: Sportivista`; the widget
+      # deliberately does NOT (the board is app-only — profile lens + UI + the
+      # FollowedListView link, none of which the widget compiles). The Nyheter
+      # models (NewsItem/FeaturedBrief/RecentResults) live in Sportivista/Models
+      # instead, so the widget-shared DataStore that loads them still compiles.
+      - path: Sportivista/News
       # WP-31: the first-run onboarding — pure gate/starter-pack logic + the
       # SwiftUI flow — compiled directly into the hostless bundle (same "no
       # @testable import" pattern). App + SportivistaDeviceDev pick these up via


### PR DESCRIPTION
Bølge 2 av FASE 0H: fyller `News/`-skallet fra WP-104 med den **endelige fire-seksjons-tavla** per `design/specs/assistent-nyheter-v0.md` og `DESIGN.md § Nyheter`. Avhenger av WP-103/104/105 (alle merget til main).

## Hva

**Data**
- `Models/NewsItem` (+`NewsFeed`), `Models/FeaturedBrief`, `Models/RecentResults` (+`FootballResult`) — widget-trygge Codable som den delte `DataStore` leser via nye `loadNews`/`loadFeatured`/`loadRecentResults`.
- `SyncClient.defaultFilesOfInterest` fikk `news.json` + `featured.json` + `recent-results.json`, og **mistet død `interests.json`** (WP-96-avpublisert — on-device-profilen, ikke en synket interests.json, er personaliseringskilden).

**News/ (ny)**
- `NewsLens` — klient-linsen: vis når `entityIds ∩ fulgte ≠ ∅` ELLER `sport` matcher en fulgt hel-sport/kategori-regel (gjenbruker profilens rule-semantikk + `SportVocabulary`; ingen ny fuzzy). `matchesEvent` gjenbruker `FeedCompiler`-haystacken for FREMOVER.
- `NewsBoard` — ren fire-seksjons-bygger: brief-headline · linse-matchet NYTT (nyest-først, capped) · RESULTAT for fulgte lag med spoiler-flagg fra `SpoilerShield` · FREMOVER via `FeedCompiler.isEventInWindow` utover 7-dagers horisont (aldri manuelt datofilter).
- `NewsView` — fire seksjoner + stille «Det du følger»-lenke til WP-105s `FollowedListView`; NYTT-rader åpner kilden UT (`Link ↗`, DSM art. 15 — aldri innbakt artikkeltekst); RESULTAT bak «Vis resultat» (`eye.slash`-reveal, samme mekanisme som event-detaljen); proveniens-ⓘ på briefen. Ingen uleste-tellere, ingen egen refresh, aldri spinner.

**Demo + skjermkatalog**
- Demo-modus `news` (`Demo/NewsDemoSeed`) + lagt i `design/screens/generate.sh` MODES og README-tabellen.

**Build**
- `project.yml`: `Sportivista/News` lagt i test-targetet (widget ekskluderer det bevisst; modellene ligger i `Models/` så den delte `DataStore` fortsatt kompilerer i widgeten).

## Felter jeg fant og brukte
- **featured.json**: `mode` (`morning`/`evening`) + `blocks:[{type:"headline",text}]` → seksjon 1 bruker headline-blokkens `text`.
- **recent-results.json**: sport-nøklede arrays; brukte `football[]` (`homeTeam`/`awayTeam`/`homeScore`/`awayScore`/`date`/`league`/`venue`/`recapHeadline`/`isFavorite`). NB: football-`date` er **uten sekunder** (`2026-07-18T21:00Z`) — parses lenient i modellen så den delte dekoderen ikke kaster.

## Verifisert (kjørt selv)
- Full unit-suite: **562 tester, 1 skipped, 0 feil**.
- Alle 4 schemes bygger (Sportivista, Widget, DeviceDev, UITests).
- UI-røyk grønn: `NewsBoardUITests` (bytt til Nyheter → se NYTT-seksjon + «Det du følger») + `FollowedListUITests` (WP-105-regresjon).

PLAN: WP-106 ⬜ → 🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)