### PR TITLE
WP-107: Nyheter-bytte-jank + oppstarts-«Henter data» (eier-dogfooding bygg 6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -111,7 +111,7 @@ mennesket, aldri av en agent.
 | WP-104 | Assistent-inngang: segmented rot «Uka/Nyheter» + kapsel-knapp + samtaleark | 0H | WP-99 | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
 | WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
 | WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | ✅ #321 merget 19.07 — FASE 0H KOMPLETT |
-| WP-107 | Ytelse: Nyheter-bytte-jank + oppstarts-«Henter data» (eier-dogfooding bygg 6) | 0H+ | WP-106 | ⬜ |
+| WP-107 | Ytelse: Nyheter-bytte-jank + oppstarts-«Henter data» (eier-dogfooding bygg 6) | 0H+ | WP-106 | 🔬 PR åpen — TO rotårsaker: (1) Nyheter-jank: `NewsView` bygde tavla i `.task` SYNKRONT på MainActor ved HVERT segmentbytte (fem disk-lesinger+dekoding + `EntityIndex`-bygg + `NewsBoard.build`) fordi `@State board` døde med view-en; målt ~343 ms/bygg (Debug/sim, fixtures) — en synlig frys per bytte. Fiks: ny `@Observable NewsModel` eid av `ContentView` (overlever bytter), bygger OFF main (`nonisolated async`, delt `MainThreadGuard`), koalescerer, og bygger KUN når tavla er stale (profil-endring / fullført synk) — et rent bytte er no-op (0 ms hovedtråd). (2) oppstart-«Henter data …»: `refresh()` gjorde to synkrone full-`events.json`-dekodinger på hovedtråden (previous/newEvents) som stjal main akkurat når den off-main agenda-reloaden ville hoppe tilbake og male — flyttet til `Task.detached`. 5 nye unit-tester (no-rebuild-på-bytte, markStale, koalescering, off-main-guard); vektorer + NewsBoard/NewsLens-gulltester urørt (ingen matching-endring) |
 | WP-108 | Visuell affordanse: kapsel-anker + ekte Capsule + sport-symbol per rad (eier-dogfooding bygg 6) | 0H+ | WP-106 | ⬜ |
 
 ---

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -49,6 +49,10 @@ struct ContentView: View {
 
     @State private var agenda: AgendaViewModel
     @State private var assistant: AssistantViewModel
+    /// WP-107 — the Nyheter board's model, owned HERE (not inside NewsView) so it
+    /// survives root-segment switches: the board stays built, and a switch back to
+    /// Nyheter is instant instead of re-running the disk-read/decode/compile.
+    @State private var news: NewsModel
     /// WP-104 — the root's two sides (Claude Design-handoff): a segmented with
     /// ORDS under the header — «Uka» (the agenda) vs «Nyheter» (the news board).
     @State private var rootTab: RootTab = .uka
@@ -141,6 +145,8 @@ struct ContentView: View {
         #else
         self._assistant = State(initialValue: AssistantViewModel(dataStore: dataStore, profileStore: profileStore))
         #endif
+        // WP-107 — the shared Nyheter model reads the SAME cache + profile store.
+        self._news = State(initialValue: NewsModel(dataStore: dataStore, profileStore: profileStore))
 
         // WP-31 — first-run decision, made before the first frame so there's no
         // flash of the agenda before the overlay. A SPORTIVISTA_DEMO launch never auto-
@@ -210,7 +216,7 @@ struct ContentView: View {
                     AgendaView(viewModel: agenda, onFollow: follow, onOpen: { assistant.recordOpened($0) },
                                openEventID: $requestedEventID)
                 case .nyheter:
-                    NewsView(dataStore: dataStore, profileStore: profileStore, assistant: assistant)
+                    NewsView(news: news, assistant: assistant)
                 }
             }
             // Liquid Glass (iOS 26): the assistant capsule is the app's ONE custom
@@ -284,7 +290,13 @@ struct ContentView: View {
         .task {
             // Recompile the agenda the instant the assistant applies a change
             // (move 4). Set here (not in init) so it can capture `agenda`.
-            assistant.onProfileChanged = { agenda.reloadFromCache(now: Date()) }
+            // WP-107: the Nyheter board re-lenses on the SAME change (off-main),
+            // so a just-added follow is reflected even while Nyheter is off-screen
+            // — the board is ready the next time the user switches to it.
+            assistant.onProfileChanged = {
+                agenda.reloadFromCache(now: Date())
+                news.rebuild()
+            }
             // WP-66 — the assistant's command arm's HOST-owned side effects
             // (theme override, re-onboarding, the confirmed reset, opening an
             // event's detail). VM-owned effects run inside the view model.
@@ -583,7 +595,13 @@ struct ContentView: View {
         let demoMode = ProcessInfo.processInfo.environment["SPORTIVISTA_DEMO"]
         if demoMode == "lens" || demoMode == "filter" || demoMode == UITestSeed.demoMode { return }
         #endif
-        let previousEvents = dataStore.loadEvents()
+        // WP-107: decode the pre-sync events OFF the main actor. This was a
+        // synchronous full-events.json decode ON the main thread, fired right
+        // after the first cache paint was scheduled — it stole the main thread
+        // exactly when the off-main agenda reload wanted to hop back and apply,
+        // so "Henter data …" lingered longer than it needed to at every launch.
+        let dataStore = self.dataStore
+        let previousEvents = await Task.detached { dataStore.loadEvents() }.value
         _ = await syncClient.sync()
         // WP-60: this view drives its own sync (it also reconciles notifications
         // below), so it must invalidate the agenda's cached entity index too —
@@ -592,12 +610,20 @@ struct ContentView: View {
         agenda.reloadFromCache(now: Date())
         #if DEBUG
         // The screenshot harness must not trip the first-launch notification
-        // permission alert over the design it's capturing.
+        // permission alert over the design it's capturing (and must keep the
+        // seeded Nyheter board — so no post-sync news rebuild in a demo run).
         if ProcessInfo.processInfo.environment["SPORTIVISTA_DEMO"] != nil { return }
         #endif
+        // WP-107: the sync may have rewritten news/featured/results/events — rebuild
+        // the Nyheter board (off-main) so it is fresh and ready before the user ever
+        // switches to it.
+        news.rebuild()
+        // WP-107: decode the post-sync events off the main actor too (was a second
+        // synchronous full-decode on main).
+        let newEvents = await Task.detached { dataStore.loadEvents() }.value
         await notificationPlanner.reconcile(
             previousEvents: previousEvents,
-            newEvents: dataStore.loadEvents(),
+            newEvents: newEvents,
             interests: dataStore.loadInterests() ?? Interests(),
             lastSync: dataStore.lastSync,
             // WP-66 — honour the assistant-set notification lead-time preference.

--- a/ios/Sportivista/News/NewsModel.swift
+++ b/ios/Sportivista/News/NewsModel.swift
@@ -1,0 +1,147 @@
+//
+//  NewsModel.swift
+//  Sportivista
+//
+//  WP-107 — the Nyheter board's LIVING model, owned once by ContentView so it
+//  SURVIVES root-segment switches («Uka ⇄ Nyheter»). Before WP-107 the board
+//  was `@State` inside NewsView, so every switch tore the view (and its state)
+//  down and `.task` rebuilt the whole board — five disk reads + JSON decodes +
+//  an EntityIndex build + NewsBoard.build — SYNCHRONOUSLY on the main actor,
+//  every single time. That was the "merkbar lag hver gang man bytter til
+//  Nyheter" the owner saw on build 6.
+//
+//  This model fixes both halves of that:
+//    1. It lives at ContentView scope, so `board` persists across switches —
+//       NewsView renders the previous board immediately (never a blank/hitch).
+//    2. The heavy build runs OFF the main actor (`computeBoard` is
+//       `nonisolated async`, guarded by the shared `MainThreadGuard`), and only
+//       when the board is actually STALE — a profile change or a completed sync
+//       marks it stale; a plain tab switch does NOT rebuild.
+//
+//  Same coalescing shape as AgendaViewModel (WP-60): one compute at a time, a
+//  request that lands mid-compute schedules exactly one trailing rebuild against
+//  the latest state ("siste vinner"). The board it produces is byte-for-byte the
+//  same `NewsBoard.build` output — no matching/lens change, so the NewsBoard /
+//  NewsLens golden tests stay valid.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class NewsModel {
+	/// The four-section board the view renders. Persists across segment switches
+	/// (this model outlives NewsView), so a switch back to Nyheter shows the last
+	/// board instantly instead of `.empty` while a rebuild runs.
+	private(set) var board: NewsBoard = .empty
+
+	private let dataStore: DataStore
+	private let profileStore: ProfileStore
+
+	/// True until the first build, then flipped back to true only by `markStale`
+	/// (a profile change / a completed sync). `rebuildIfStale` — the tab-switch
+	/// entry point — is a no-op while this is false, which is what removes the
+	/// per-switch work.
+	private var needsRebuild = true
+	/// The single in-flight build; coalesces a burst into one trailing rebuild.
+	private var buildTask: Task<Void, Never>?
+	/// The `now` of the most recent request that arrived mid-build ("siste vinner").
+	private var pendingNow: Date?
+
+	#if DEBUG
+	/// How many times the compute pipeline actually ran — the proof that a plain
+	/// tab switch does NOT rebuild (NewsModelTests reads this).
+	private(set) var buildCount = 0
+	#endif
+
+	init(dataStore: DataStore = DataStore(), profileStore: ProfileStore = ProfileStore()) {
+		self.dataStore = dataStore
+		self.profileStore = profileStore
+	}
+
+	// MARK: - Triggers
+
+	/// Mark the board out of date. Called when the follow-profile changes or a
+	/// sync brought fresh news/results/events — the two things that can change the
+	/// board's content. The next `rebuildIfStale` (or an explicit `rebuild`) picks
+	/// it up.
+	func markStale() { needsRebuild = true }
+
+	/// The tab-switch entry point (`NewsView.task`). Rebuilds ONLY when the board
+	/// is stale — the first appearance, or after `markStale`. A plain switch onto
+	/// an already-current board is a no-op, so switching tabs never re-runs the
+	/// disk-read/decode/compile that caused the lag.
+	func rebuildIfStale(now: Date = Date()) {
+		guard needsRebuild else { return }
+		rebuild(now: now)
+	}
+
+	/// Force a rebuild now, off the main actor. Used when the profile changed or a
+	/// sync completed (ContentView drives these), so the board is ready before the
+	/// user ever switches to Nyheter. Clears the stale flag and coalesces.
+	func rebuild(now: Date = Date()) {
+		needsRebuild = false
+		guard buildTask == nil else {
+			pendingNow = now
+			return
+		}
+		startBuild(now: now)
+	}
+
+	/// Await any in-flight (coalesced) build — tests use this to wait until the
+	/// board has actually been recomputed and applied.
+	func awaitQuiescent() async {
+		while let task = buildTask { await task.value }
+	}
+
+	// MARK: - Coalescing loop (mirrors AgendaViewModel.startReload)
+
+	private func startBuild(now: Date) {
+		buildTask = Task { @MainActor in
+			var current = now
+			while true {
+				#if DEBUG
+				self.buildCount &+= 1
+				#endif
+				let result = await Self.computeBoard(dataStore: self.dataStore, profileStore: self.profileStore, now: current)
+				if let next = self.pendingNow {
+					self.pendingNow = nil
+					current = next
+					continue
+				}
+				self.board = result
+				break
+			}
+			self.buildTask = nil
+		}
+	}
+
+	// MARK: - Off-main build
+
+	/// The off-main entry: `nonisolated async` so awaiting it from the main actor
+	/// runs the body on the cooperative pool and transfers the fresh board back.
+	nonisolated static func computeBoard(dataStore: DataStore, profileStore: ProfileStore, now: Date) async -> sending NewsBoard {
+		computeBoardSync(dataStore: dataStore, profileStore: profileStore, now: now)
+	}
+
+	/// The five cache reads + decodes + EntityIndex build + NewsBoard.build — the
+	/// exact work NewsView.rebuild used to do on the main actor. WP-107 keeps it
+	/// OFF the main actor; the shared `MainThreadGuard` (WP-60) trips in DEBUG if a
+	/// regression ever runs it on main. Reads the profile + spoiler shield from the
+	/// SAME on-disk sync-state NewsView.rebuild read, so the board is identical.
+	nonisolated static func computeBoardSync(dataStore: DataStore, profileStore: ProfileStore, now: Date) -> sending NewsBoard {
+		MainThreadGuard.assertOffMain("NewsModel build (cache read + JSON decode + NewsBoard.build)")
+		let syncState = profileStore.loadSyncState()
+		return NewsBoard.build(
+			news: dataStore.loadNews(),
+			featured: dataStore.loadFeatured(),
+			results: dataStore.loadRecentResults(),
+			events: dataStore.loadEvents(),
+			entities: dataStore.loadEntities(),
+			profile: syncState.profile,
+			shield: SpoilerShield(memory: MemoryState(from: syncState)),
+			now: now
+		)
+	}
+}

--- a/ios/Sportivista/News/NewsView.swift
+++ b/ios/Sportivista/News/NewsView.swift
@@ -17,23 +17,31 @@
 //       detail sheet uses).
 //    4. FREMOVER — followed events beyond the near horizon (forvarsler).
 //
-//  Pure data (NewsBoard.build) is computed off the cache on appear and whenever
-//  the follow-profile changes (a just-added follow re-lenses the board). No
-//  spinner ever (DESIGN § Bevegelse); amber is the one accent.
+//  Pure data (NewsBoard.build) is computed OFF the main actor by NewsModel and
+//  cached there (WP-107) — this view is a thin renderer over `news.board`. The
+//  model outlives the view (ContentView owns it), so a segment switch shows the
+//  last board instantly and only rebuilds when the board is actually stale (a
+//  profile change or a completed sync). No spinner ever (DESIGN § Bevegelse);
+//  amber is the one accent.
 //
 
 import SwiftUI
 
 struct NewsView: View {
-	let dataStore: DataStore
-	let profileStore: ProfileStore
+	/// WP-107 — the shared, ContentView-owned board model. It survives root-segment
+	/// switches, so `news.board` is already built when the user comes back to
+	/// Nyheter (no per-switch disk-read/decode/compile on the main actor).
+	var news: NewsModel
 	/// WP-105 — the shared assistant view model, only so the «Det du følger»
 	/// link can push FollowedListView (the same list Deg homes). The board reads
 	/// its lens from the profile, never drives the assistant.
 	var assistant: AssistantViewModel
 
-	@State private var board: NewsBoard = .empty
 	@State private var provenanceShown = false
+
+	/// The board the model currently holds — a plain accessor so the section
+	/// builders below read exactly as before.
+	private var board: NewsBoard { news.board }
 
 	var body: some View {
 		List {
@@ -47,25 +55,12 @@ struct NewsView: View {
 		.scrollContentBackground(.hidden)
 		.background(SportivistaTokens.background)
 		.accessibilityIdentifier("news.board")
-		.task { rebuild() }
-		// A just-confirmed follow (from the assistant, the agenda swipe, or Deg)
-		// re-lenses the board immediately — the same shared profile the agenda
-		// recompiles against.
-		.onChange(of: assistant.profile) { _, _ in rebuild() }
-	}
-
-	private func rebuild() {
-		let syncState = profileStore.loadSyncState()
-		board = NewsBoard.build(
-			news: dataStore.loadNews(),
-			featured: dataStore.loadFeatured(),
-			results: dataStore.loadRecentResults(),
-			events: dataStore.loadEvents(),
-			entities: dataStore.loadEntities(),
-			profile: syncState.profile,
-			shield: SpoilerShield(memory: MemoryState(from: syncState)),
-			now: Date()
-		)
+		// Only rebuilds when the board is stale (first appearance / after a
+		// profile change or sync marked it). A plain switch onto an already-current
+		// board is a no-op — the fix for the per-switch lag. Profile changes and
+		// completed syncs are driven from ContentView (which owns the model), so
+		// the board re-lenses even while Nyheter is off-screen.
+		.task { news.rebuildIfStale() }
 	}
 
 	// MARK: - «Det du følger» link (quiet, atop the board)

--- a/ios/SportivistaTests/NewsModelTests.swift
+++ b/ios/SportivistaTests/NewsModelTests.swift
@@ -1,0 +1,121 @@
+//
+//  NewsModelTests.swift
+//  SportivistaTests
+//
+//  WP-107 — proves the two behavioural guarantees of moving the Nyheter board
+//  build off the main actor and up to a segment-surviving model:
+//
+//    1. NO REBUILD ON A PLAIN SWITCH — `rebuildIfStale` builds once (the first
+//       appearance), then is a NO-OP on every further call until something marks
+//       the board stale. That is what removes the per-switch lag: coming back to
+//       Nyheter renders the cached `board` with zero disk-read/decode/compile.
+//       `markStale` (a profile change / a completed sync) re-arms exactly one
+//       rebuild; a burst coalesces ("siste vinner").
+//    2. MAIN-THREAD GUARD — the build pipeline (cache read + JSON decode +
+//       EntityIndex + NewsBoard.build) trips the shared `MainThreadGuard` when
+//       forced on the main thread, and runs silently off it.
+//
+//  The board's CONTENT (lens filtering, sections, spoiler flags) is exercised
+//  bit-for-bit by NewsBoardTests / NewsLensTests; this file is strictly about
+//  WHERE and HOW OFTEN the build runs.
+//
+
+import XCTest
+
+@MainActor
+final class NewsModelTests: XCTestCase {
+
+	private let now = ISO8601DateFormatter().date(from: "2026-07-19T12:00:00Z")!
+
+	private func tempCacheWithFixtures() throws -> CacheStore {
+		let cache = CacheStore(rootDirectory: FileManager.default.temporaryDirectory
+			.appendingPathComponent("sportivista-wp107-\(UUID().uuidString)", isDirectory: true))
+		try cache.write(Fixture.data("news"), filename: "news.json")
+		try cache.write(Fixture.data("featured"), filename: "featured.json")
+		try cache.write(Fixture.data("recent-results"), filename: "recent-results.json")
+		try cache.write(Fixture.data("events"), filename: "events.json")
+		try cache.write(Fixture.data("entities"), filename: "entities.json")
+		return cache
+	}
+
+	private func tempProfileStore() -> ProfileStore {
+		ProfileStore(directory: FileManager.default.temporaryDirectory
+			.appendingPathComponent("sportivista-wp107-\(UUID().uuidString)", isDirectory: true))
+	}
+
+	private func makeModel(cache: CacheStore, profileStore: ProfileStore) -> NewsModel {
+		NewsModel(dataStore: DataStore(cache: cache), profileStore: profileStore)
+	}
+
+	// MARK: - No rebuild on a plain tab switch
+
+	func test_rebuildIfStale_buildsOnceThenNoOps() async throws {
+		let model = makeModel(cache: try tempCacheWithFixtures(), profileStore: tempProfileStore())
+
+		// First appearance: the board is stale (never built), so it builds once.
+		model.rebuildIfStale(now: now)
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.buildCount, 1, "the first appearance builds the board once")
+
+		// Every further switch onto an unchanged board is a NO-OP — the fix for
+		// the per-switch lag.
+		for _ in 0..<5 { model.rebuildIfStale(now: now) }
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.buildCount, 1, "switching back to Nyheter does NOT rebuild an up-to-date board")
+	}
+
+	func test_markStale_reArmsExactlyOneRebuild() async throws {
+		let model = makeModel(cache: try tempCacheWithFixtures(), profileStore: tempProfileStore())
+
+		model.rebuildIfStale(now: now)
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.buildCount, 1)
+
+		// A profile change / completed sync marks the board stale — the next
+		// switch rebuilds exactly once, then goes quiet again.
+		model.markStale()
+		model.rebuildIfStale(now: now)
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.buildCount, 2, "markStale re-arms one rebuild")
+
+		model.rebuildIfStale(now: now)
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.buildCount, 2, "and only one — a further switch is a no-op again")
+	}
+
+	func test_burstOfRebuilds_coalesces() async throws {
+		let model = makeModel(cache: try tempCacheWithFixtures(), profileStore: tempProfileStore())
+
+		// A burst fired in one run-loop tick (e.g. several onProfileChanged in a
+		// starter-pack apply): the first starts the in-flight build, the rest only
+		// mark "build once more when done" — so ≤2 builds, never N.
+		for _ in 0..<8 { model.rebuild(now: now) }
+		await model.awaitQuiescent()
+		XCTAssertLessThanOrEqual(model.buildCount, 2, "a burst coalesces to at most two builds")
+	}
+
+	// MARK: - Off-main guarantee
+
+	func test_guard_tripsWhenBuildRunsOnMainThread() throws {
+		let dataStore = DataStore(cache: try tempCacheWithFixtures())
+		let profileStore = tempProfileStore()
+
+		// This test runs on the main thread, so calling the synchronous core here
+		// is exactly the regression the guard must catch.
+		let violations = MainThreadGuard.recordViolationsForTesting {
+			_ = NewsModel.computeBoardSync(dataStore: dataStore, profileStore: profileStore, now: now)
+		}
+		XCTAssertFalse(violations.isEmpty, "the Nyheter build on the main thread must trip the WP-107 guard")
+	}
+
+	func test_computeBoard_runsOffMain_withoutTripping() async throws {
+		let dataStore = DataStore(cache: try tempCacheWithFixtures())
+		let profileStore = tempProfileStore()
+
+		// The default guard mode TRAPS on a main-thread violation. `computeBoard`
+		// is nonisolated async, so awaiting it from this @MainActor test hops off
+		// the main actor — reaching the assertion (no crash) proves it ran off-main.
+		let board = await NewsModel.computeBoard(dataStore: dataStore, profileStore: profileStore, now: now)
+		_ = board // content is covered by NewsBoardTests; here we only prove it ran.
+	}
+}

--- a/ios/SportivistaUITests/MainFlowsUITests.swift
+++ b/ios/SportivistaUITests/MainFlowsUITests.swift
@@ -374,9 +374,13 @@ final class MainFlowsUITests: SportivistaUITestCase {
 		// Uka is the default: the seeded football row is on the board.
 		assertExists(agendaRow(UITestFixture.footballTitle, in: app), "Uka shows the agenda by default")
 
-		// Switch to Nyheter — the shell placeholder shows; the agenda row is gone.
+		// Switch to Nyheter — the WP-106 four-section board shows (its always-present
+		// NYTT header + the «Det du følger» link); the agenda row is gone. (WP-107:
+		// updated from the retired WP-104 «news.placeholder» shell to the real board
+		// identifiers WP-106 shipped.)
 		app.buttons["Nyheter"].tap()
-		assertExists(app.staticTexts["news.placeholder"], "the Nyheter side shows the WP-106 shell placeholder")
+		assertExists(app.staticTexts["news.section.nytt"], "the Nyheter side shows the WP-106 board (NYTT header)")
+		assertExists(app.buttons["news.followedLink"], "the Nyheter board offers the «Det du følger» link")
 		XCTAssertFalse(agendaRow(UITestFixture.footballTitle, in: app).exists, "the agenda is not shown on the Nyheter side")
 
 		// The capsule stays pinned on both sides (bunnen tilhører hjelperen alene).


### PR DESCRIPTION
## WP-107 — iOS-ytelse (eier-dogfooding, bygg 1.0.1(6))

To eier-symptomer fra fysisk-iPhone-dogfooding, begge sporet til rotårsak (ikke antatt):

### (a) Merkbar lag ved HVERT bytte til Nyheter-fanen
**Rotårsak:** `NewsView` bygde tavla i `.task` **synkront på MainActor hver gang view-en dukket opp** — fem disk-lesinger + JSON-dekodinger + `EntityIndex`-bygg + `NewsBoard.build` — fordi `@State board` døde med view-en ved segmentbytte og ble gjenskapt ved retur.
**Målt:** ~343 ms per bygg (Debug/sim, docs/data-fixtures; `avg=342.6ms min=292.6 max=463.9` over 20 kjøringer) — en synlig frys på hovedtråden per bytte. Enhet er tregere.
**Fiks:** ny `@Observable NewsModel` **eid av `ContentView`** så den overlever segmentbytter. Den bygger **off main** (`nonisolated async`, delt `MainThreadGuard` fra WP-60), **koalescerer** (siste vinner), og bygger **kun når tavla er stale** (profil-endring / fullført synk). Et rent bytte er **no-op (0 ms hovedtråd)** og viser forrige tavle umiddelbart — aldri blank/hitch. `NewsView` er nå en tynn renderer over `news.board`. En profil-endring re-linser tavla via `ContentView.onProfileChanged` selv mens Nyheter er off-screen, så den er klar ved neste bytte.

### (b) «Henter data …» synlig «litt tid» ved HVER app-åpning
**Rotårsak:** `ContentView.refresh()` gjorde **to synkrone full-`events.json`-dekodinger på hovedtråden** (`previousEvents` + `newEvents` for notifikasjons-avstemming) rett etter at den off-main agenda-reloaden var planlagt — de stjal hovedtråden akkurat når reloaden ville hoppe tilbake og male, så `lastSync == nil`-plassholderen hang lengre enn nødvendig.
**Fiks:** begge flyttet til `Task.detached` (off main). Cachet agenda males først; «Henter data …» synes nå kun ved ekte førstegangsstart uten cache.

### Kontrakt bevart
Ingen matching-/synk-/manifest-endring: `NewsBoard.build`-utdata er byte-likt, så de gylne feed-vektorene + `NewsBoard`/`NewsLens`-gulltestene er urørt. Ingen endring i AgendaView-radstruktur, Assistant/**, Profile/** (WP-108-naboens flater). ContentView-endringene holder seg til hosting/livssyklus-linjene.

## Tester
- **5 nye unit-tester** (`NewsModelTests`): no-rebuild-på-bytte, `markStale` re-armer nøyaktig én, burst koalescerer til ≤2, main-thread-guard trips på main + kjører stille off main.
- Oppdaterte én **stale WP-104-UI-assert** i `MainFlowsUITests.testRootSegmentedSwitchesToNyheter`: `news.placeholder` (skallet ble fjernet i WP-106) → WP-106-tavlas `news.section.nytt` + `news.followedLink`. (Denne feilet uansett før WP-107.)

## Verifisering
- Unit-suite (Sportivista): **567/0** (1 skip = opt-in FM-eval).
- UI-suite (SportivistaUITests): **18/0** (kjørt isolert på egen sim — de 3 første «feilene» var sim-kollisjon med en parallell søster-kjøring på delt simulator, grønne ved isolasjon).
- Bygg: `SportivistaWidgetExtension` ✅, `SportivistaDeviceDev` (signert, widget embedet) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)