### PR TITLE
WP-108: visuell affordanse — kapsel-anker + ekte Capsule + sport-symbol per rad

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -112,7 +112,7 @@ mennesket, aldri av en agent.
 | WP-105 | «Det du følger» + Legg til-søk (interesser uten assistent, 3b) | 0H | — | ✅ bølge 1 merget 19.07 (#318/#319/#320) |
 | WP-106 | Nyheter-v0-klienten (fire-seksjons-tavla) | 0H | WP-103, WP-104, WP-105 | ✅ #321 merget 19.07 — FASE 0H KOMPLETT |
 | WP-107 | Ytelse: Nyheter-bytte-jank + oppstarts-«Henter data» (eier-dogfooding bygg 6) | 0H+ | WP-106 | 🔬 PR åpen — TO rotårsaker: (1) Nyheter-jank: `NewsView` bygde tavla i `.task` SYNKRONT på MainActor ved HVERT segmentbytte (fem disk-lesinger+dekoding + `EntityIndex`-bygg + `NewsBoard.build`) fordi `@State board` døde med view-en; målt ~343 ms/bygg (Debug/sim, fixtures) — en synlig frys per bytte. Fiks: ny `@Observable NewsModel` eid av `ContentView` (overlever bytter), bygger OFF main (`nonisolated async`, delt `MainThreadGuard`), koalescerer, og bygger KUN når tavla er stale (profil-endring / fullført synk) — et rent bytte er no-op (0 ms hovedtråd). (2) oppstart-«Henter data …»: `refresh()` gjorde to synkrone full-`events.json`-dekodinger på hovedtråden (previous/newEvents) som stjal main akkurat når den off-main agenda-reloaden ville hoppe tilbake og male — flyttet til `Task.detached`. 5 nye unit-tester (no-rebuild-på-bytte, markStale, koalescering, off-main-guard); vektorer + NewsBoard/NewsLens-gulltester urørt (ingen matching-endring) |
-| WP-108 | Visuell affordanse: kapsel-anker + ekte Capsule + sport-symbol per rad (eier-dogfooding bygg 6) | 0H+ | WP-106 | ⬜ |
+| WP-108 | Visuell affordanse: kapsel-anker + ekte Capsule + sport-symbol per rad (eier-dogfooding bygg 6) | 0H+ | WP-106 | 🔬 |
 
 ---
 

--- a/ios/Sportivista/Agenda/AgendaView.swift
+++ b/ios/Sportivista/Agenda/AgendaView.swift
@@ -256,6 +256,7 @@ struct EventRowView: View {
             // HStack reserve the column's full width first, RowBody takes the rest.
             TimeColumn(text: row.timeLabel)
                 .layoutPriority(1)
+            SportSymbolView(sport: row.event.sport)
             RowBody(title: row.title, meta: row.metaLabel, channel: row.channelLabel)
             TrailingMarkers(reminder: row.mustWatch, aiResearch: row.isAIResearch)
         }
@@ -273,6 +274,7 @@ struct SeriesRowView: View {
             MustSeeDot(on: false) // series rows are never visually accented (FeedCompiler.isMustSee)
             TimeColumn(text: row.timeLabel) // WP-99: see EventRowView — priority so a wide window never draws over the title
                 .layoutPriority(1)
+            SportSymbolView(sport: row.nextStage.sport)
             RowBody(title: row.summaryLabel, meta: nil, channel: row.channelLabel)
             TrailingMarkers(reminder: row.mustWatch, aiResearch: row.isAIResearch)
         }
@@ -356,6 +358,28 @@ private struct MustSeeDot: View {
             .fill(on ? SportivistaTokens.accent : Color.clear)
             .frame(width: 6, height: 6)
             .padding(.top, 7)
+            .accessibilityHidden(true)
+    }
+}
+
+/// The quiet per-sport SF Symbol (DESIGN § Radens anatomi, rev. 19.07 eier-funn):
+/// sits between the time column and the title so "what kind of event" (cycling vs
+/// football) reads at a glance without parsing the meta text. `tertiaryLabel`,
+/// NEVER coloured (the amber budget is untouched — the must-see dot is the row's
+/// only accent), never emoji/logo. A fixed width keeps every title aligned
+/// regardless of glyph width; scales with Dynamic Type. Hidden from VoiceOver —
+/// the sport is already carried by the title/meta line, so this is a purely
+/// visual at-a-glance aid (same policy as `MustSeeDot`). One canonical table
+/// (`SportSymbol`) shared with the detail sheet and the Nyheter rows.
+private struct SportSymbolView: View {
+    let sport: String
+
+    var body: some View {
+        Image(systemName: SportSymbol.name(for: sport))
+            .font(.sportivista(.subheadline))
+            .foregroundStyle(SportivistaTokens.tertiaryLabel)
+            .frame(width: 20, alignment: .center)
+            .padding(.top, 2)
             .accessibilityHidden(true)
     }
 }

--- a/ios/Sportivista/Assistant/AssistantCapsule.swift
+++ b/ios/Sportivista/Assistant/AssistantCapsule.swift
@@ -27,6 +27,15 @@ struct AssistantCapsule: View {
         HStack(spacing: 10) {
             Button(action: onOpen) {
                 HStack(spacing: 10) {
+                    // Rev. 19.07 eier-funn: without a leading anchor the grey
+                    // placeholder reads as a dead text field. The assistant symbol
+                    // (secondaryLabel, matching the prompt — never amber; the mic
+                    // keeps the one accent) is the Maps-pattern anchor DESIGN
+                    // § Hjelperen now requires.
+                    Image(systemName: SportSymbol.assistant)
+                        .font(.sportivista(.subheadline))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                        .accessibilityHidden(true)
                     Text(AssistantViewModel.capsulePrompt)
                         .font(.sportivista(.subheadline))
                         .foregroundStyle(SportivistaTokens.secondaryLabel)
@@ -53,9 +62,10 @@ struct AssistantCapsule: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)
-        // Liquid Glass (iOS 26): the platform's own control material — a rounded
-        // rect (calm, matches the old command-line shape) over the agenda.
-        .glassEffect(.regular, in: .rect(cornerRadius: 26))
+        // Liquid Glass (iOS 26): the platform's own control material — a TRUE
+        // capsule (DESIGN § Hjelperen, rev. 19.07 eier-funn: "i EKTE Capsule-form",
+        // not the old rect-26 that only approximated one) over the agenda.
+        .glassEffect(.regular, in: .capsule)
         .padding(.horizontal, 10)
         .padding(.bottom, 4)
     }

--- a/ios/Sportivista/Models/SportSymbol.swift
+++ b/ios/Sportivista/Models/SportSymbol.swift
@@ -1,0 +1,93 @@
+//
+//  SportSymbol.swift
+//  Sportivista
+//
+//  WP-108 — the app's ONE canonical SF Symbol registry (owner dogfooding
+//  finding: "it isn't intuitive which SPORT a row is about without reading the
+//  meta text"). DESIGN.md § Radens anatomi (rev. 19.07): one quiet SF Symbol per
+//  sport, `tertiaryLabel`, fixed width, NEVER coloured, never emoji/logo —
+//  shared by the agenda row, the detail sheet and the Nyheter rows so the whole
+//  app names a sport the same way.
+//
+//  Kept dependency-free (pure Swift, no SwiftUI/UIKit, no SportVocabulary) on
+//  purpose: this file lands in the app, the widget AND the test target via
+//  `path: Sportivista/Models` in project.yml, and SportVocabulary/NewsLens are
+//  NOT in the widget target. Callers pass `Event.sport`, which the pipeline
+//  already emits as a canonical English tag (build-entities.js); a small alias
+//  set + lowercasing makes the lookup robust without reaching for the assistant
+//  vocabulary.
+//
+//  Every symbol name here is verified to exist on iOS by SportSymbolTests, which
+//  instantiates `UIImage(systemName:)` for the whole table + the assistant role
+//  (an unknown name renders as an empty image — the test is the guard).
+//
+//  Symbol choices where SF Symbols has no dedicated glyph (documented, not
+//  guessed):
+//   • chess → `crown` — SF Symbols ships no chess-piece glyph; the king's crown
+//     is the conventional stand-in and reads distinctly from `flag.checkered`.
+//   • biathlon → `target` — no biathlon glyph exists; `figure.skiing.crosscountry`
+//     would collide with cross-country, so `target` uniquely evokes the
+//     rifle-shooting half that DEFINES the sport (and skyting → blink) for the
+//     Norwegian fan.
+//   • ski jumping + nordic (combined) → `snowflake` — neither has a `figure.*`
+//     glyph; the honest generic-winter mark beats forcing a wrong figure. They
+//     deliberately share it rather than mislabel.
+//
+
+import Foundation
+
+/// The canonical sport → SF Symbol map (+ the assistant entry-point role). The
+/// single home for every app-level SF Symbol *role* so a rebrand or a new sport
+/// is one edit here, not a hunt across views.
+enum SportSymbol {
+    /// The assistant entry-point glyph (WP-108) — the capsule button's leading
+    /// anchor so the grey placeholder no longer reads as a dead text field
+    /// (DESIGN § Hjelperen: "Maps-mønsteret krever ankersymbolet"). `sparkles`
+    /// is the iOS 26 Apple-Intelligence idiom, apt because the assistant IS an
+    /// on-device Foundation Models assistant. Rendered `secondaryLabel` (matching
+    /// the prompt text) — NEVER amber; the trailing `mic` keeps the one accent.
+    static let assistant = "sparkles"
+
+    /// The fallback when a sport has no mapped symbol — a neutral, honest
+    /// "an event" mark (DESIGN § Radens anatomi: "fallback `calendar`").
+    static let fallback = "calendar"
+
+    /// Canonical sport tag → SF Symbol. Keys are the canonical English tags the
+    /// pipeline emits (`Event.sport`); a few common aliases are folded in so a
+    /// non-canonical payload still resolves.
+    private static let table: [String: String] = [
+        // Sports we cover wholesale / with real glyphs
+        "football": "soccerball",
+        "soccer": "soccerball",
+        "golf": "figure.golf",
+        "tennis": "tennisball",
+        "cycling": "figure.outdoor.cycle",
+        "athletics": "figure.run",
+        "f1": "flag.checkered",
+        "formula1": "flag.checkered",
+        "motorsport": "flag.checkered",
+        "esports": "gamecontroller",
+        // Winter sports (WP-64 vocabulary)
+        "cross-country": "figure.skiing.crosscountry",
+        "alpine": "figure.skiing.downhill",
+        "biathlon": "target",           // see file header: shooting half, no collision
+        "ski jumping": "snowflake",     // no figure glyph
+        "nordic": "snowflake",          // nordic combined — no figure glyph
+        // Entity-gated sports (no wholesale coverage) with distinctive marks
+        "chess": "crown"                // see file header: king's crown stand-in
+    ]
+
+    /// The SF Symbol name for a sport tag (canonical or a known alias), else the
+    /// neutral `calendar` fallback. Case/whitespace-insensitive.
+    static func name(for sport: String) -> String {
+        let key = sport.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return table[key] ?? fallback
+    }
+
+    /// The full set of symbol names this registry can emit — the assistant role,
+    /// the fallback, and every table value. The test target instantiates each to
+    /// prove it exists on iOS.
+    static var allSymbolNames: Set<String> {
+        Set(table.values) .union([assistant, fallback])
+    }
+}

--- a/ios/Sportivista/News/NewsView.swift
+++ b/ios/Sportivista/News/NewsView.swift
@@ -216,6 +216,13 @@ private struct NewsPointerRow: View {
 				.truncationMode(.tail)
 				.frame(maxWidth: .infinity, alignment: .leading)
 			HStack(spacing: 6) {
+				// WP-108: the same canonical sport→symbol mark the agenda rows
+				// use (DESIGN § Radens anatomi) — quiet tertiaryLabel, decorative
+				// (the sport word beside it carries it for VoiceOver). Minimal: the
+				// symbol only, the existing sport · source · time line is unchanged.
+				Image(systemName: SportSymbol.name(for: NewsLens.canonicalSport(item.sport)))
+					.foregroundStyle(SportivistaTokens.tertiaryLabel)
+					.accessibilityHidden(true)
 				Text(sportLabel)
 					.foregroundStyle(SportivistaTokens.secondaryLabel)
 				dot

--- a/ios/SportivistaTests/SportSymbolTests.swift
+++ b/ios/SportivistaTests/SportSymbolTests.swift
@@ -1,0 +1,88 @@
+//
+//  SportSymbolTests.swift
+//  SportivistaTests
+//
+//  WP-108 — guard the canonical sport→SF Symbol registry (SportSymbol). The
+//  load-bearing test: `Image(systemName:)` against an unknown name renders an
+//  EMPTY image silently, so a typo in the table would ship an invisible glyph
+//  with no compile error. Here we instantiate `UIImage(systemName:)` for every
+//  name the registry can emit (the whole table + the assistant + fallback
+//  roles) and assert each resolves — this is what makes the choices in
+//  SportSymbol.swift verifiable on iOS.
+//
+//  Also pins the contract the views rely on: canonical sports map to their
+//  documented glyph, aliases fold in, and unknown tags fall back to `calendar`
+//  (never crash, never blank).
+//
+
+import XCTest
+import UIKit
+
+final class SportSymbolTests: XCTestCase {
+
+    /// Every symbol the registry can emit must exist on this iOS — an unknown
+    /// `systemName` yields a nil `UIImage`, which would render as nothing.
+    func testEverySymbolExistsOnThisOS() {
+        for name in SportSymbol.allSymbolNames {
+            XCTAssertNotNil(
+                UIImage(systemName: name),
+                "SF Symbol \"\(name)\" does not exist on this iOS — it would render as an empty glyph"
+            )
+        }
+    }
+
+    /// The assistant + fallback roles are real symbols too (covered by the set
+    /// above, asserted explicitly so a regression names them).
+    func testAssistantAndFallbackSymbolsExist() {
+        XCTAssertNotNil(UIImage(systemName: SportSymbol.assistant))
+        XCTAssertNotNil(UIImage(systemName: SportSymbol.fallback))
+    }
+
+    /// The documented per-sport choices (the ones called out in the file header
+    /// / DESIGN § Radens anatomi).
+    func testCanonicalSportMappings() {
+        XCTAssertEqual(SportSymbol.name(for: "football"), "soccerball")
+        XCTAssertEqual(SportSymbol.name(for: "golf"), "figure.golf")
+        XCTAssertEqual(SportSymbol.name(for: "tennis"), "tennisball")
+        XCTAssertEqual(SportSymbol.name(for: "cycling"), "figure.outdoor.cycle")
+        XCTAssertEqual(SportSymbol.name(for: "f1"), "flag.checkered")
+        XCTAssertEqual(SportSymbol.name(for: "esports"), "gamecontroller")
+        XCTAssertEqual(SportSymbol.name(for: "cross-country"), "figure.skiing.crosscountry")
+        XCTAssertEqual(SportSymbol.name(for: "alpine"), "figure.skiing.downhill")
+        // Documented, no-dedicated-glyph choices:
+        XCTAssertEqual(SportSymbol.name(for: "biathlon"), "target")
+        XCTAssertEqual(SportSymbol.name(for: "chess"), "crown")
+        XCTAssertEqual(SportSymbol.name(for: "ski jumping"), "snowflake")
+        XCTAssertEqual(SportSymbol.name(for: "nordic"), "snowflake")
+    }
+
+    /// Case- and whitespace-insensitive, and known aliases fold in.
+    func testLookupIsRobust() {
+        XCTAssertEqual(SportSymbol.name(for: "Football"), "soccerball")
+        XCTAssertEqual(SportSymbol.name(for: "  golf  "), "figure.golf")
+        XCTAssertEqual(SportSymbol.name(for: "soccer"), "soccerball")
+        XCTAssertEqual(SportSymbol.name(for: "formula1"), "flag.checkered")
+    }
+
+    /// An unknown sport tag falls back to the neutral calendar mark — never a
+    /// blank glyph.
+    func testUnknownSportFallsBack() {
+        XCTAssertEqual(SportSymbol.name(for: "kabaddi"), SportSymbol.fallback)
+        XCTAssertEqual(SportSymbol.name(for: ""), SportSymbol.fallback)
+    }
+
+    /// Coverage guard: every sport the app can display a name for
+    /// (SportVocabulary.sportDisplay — what the agenda/Nyheter rows actually show)
+    /// resolves to a REAL, non-fallback glyph. If a new covered sport is added to
+    /// the vocabulary without a symbol, this fails so the table is kept in sync.
+    func testEveryDisplayedSportHasADedicatedSymbol() {
+        for sport in SportVocabulary.sportDisplay.keys {
+            let symbol = SportSymbol.name(for: sport)
+            XCTAssertNotEqual(
+                symbol, SportSymbol.fallback,
+                "Covered sport \"\(sport)\" has no dedicated symbol in SportSymbol.table — it would show the generic calendar fallback"
+            )
+            XCTAssertNotNil(UIImage(systemName: symbol), "symbol \"\(symbol)\" for \"\(sport)\" must exist")
+        }
+    }
+}


### PR DESCRIPTION
## WP-108 — eier-dogfooding (bygg 6) affordanse-funn

Eieren fant to hull på fysisk enhet, begge lukket mot DESIGN.md § Hjelperen +
§ Radens anatomi (rev. 19.07):

### 1. Kapselen (`AssistantCapsule.swift`)
- **Ledende assistent-symbol** foran teksten: `sparkles` (iOS 26 Apple-Intelligence-idiomet — passende siden hjelperen ER on-device Foundation Models). `secondaryLabel`, matcher prompt-teksten, **aldri amber** — mic-en beholder den ene accenten.
- **Ekte `Capsule()`** i glassEffect-formen (var `rect(cornerRadius: 26)` som bare tilnærmet en kapsel).
- Mic uendret (trailing, accent).

### 2. Sport-symbol per rad (`AgendaView.swift`, `News/NewsView.swift`)
- Ny kanonisk **`SportSymbol`**-tabell (`Sportivista/Models/`) — sport→SF-symbol, delt av agenda-rad, serie-rad og Nyheter-rad. Dependency-fri (ren Swift) så den trygt kompilerer inn i app + widget + testmål.
- Ett stille symbol mellom tid og tittel: `tertiaryLabel`, fast 20pt bredde (titler flukter fortsatt), aldri farget/emoji.
- **Symbolvalg der SF Symbols mangler dedikert glyf (dokumentert, ikke gjettet):**
  - `chess → crown` — kongens krone; skiller seg fra `flag.checkered`.
  - `biathlon → target` — skyte-halvparten som *definerer* sporten; unngår kollisjon med `figure.skiing.crosscountry` (langrenn).
  - `ski jumping` + `nordic (kombinert) → snowflake` — ingen `figure.*`-glyf finnes; ærlig vinter-generisk framfor feil figur.
  - Ellers: football→soccerball, golf→figure.golf, tennis→tennisball, cycling→figure.outdoor.cycle, athletics→figure.run, f1→flag.checkered, esports→gamecontroller, cross-country→figure.skiing.crosscountry, alpine→figure.skiing.downhill, fallback→calendar.

### Kontrakter bevart
- **`TimeColumn.layoutPriority(1)` urørt** — flerdags-golf-radene verifisert riktige (ingen overlapp) i `onboarding-landed`-demoen, begge tema.
- Amber-budsjettet uendret (symbolet er tertiary).
- Nyheter-endringen er minimal (kun symbolet, ingen ny layout).

### Verifisering
- **JS-suite** (CI-gate): 628 ✓
- **iOS unit-suite**: 568 ✓ (7 nye i `SportSymbolTests` — instansierer `UIImage(systemName:)` for hele tabellen + assistent/fallback, så en tom glyf ikke sniker seg forbi kompilatoren; vokter at hver dekket sport har dedikert glyf).
- **Schemes**: Sportivista + SportivistaWidgetExtension + SportivistaDeviceDev bygger.
- **UI-suite**: kapsel/assistent-flytene grønne isolert (`testCapsuleOpensSheetAndLukkCloses`, `testMicCapsuleOpensSheetFocused`, `testFollowExampleRowPrefillsField`).
- **Skjermbilder** (iPhone 17-sim): `onboarding-landed` (golf-rader OK, symboler synlige begge tema), `uitest`, `assistant-sheet` — alle riktige.

### ⚠️ Pre-eksisterende UI-test-feil (ikke WP-108)
`SportivistaUITests/testRootSegmentedSwitchesToNyheter` feiler på `news.placeholder` — WP-106 (allerede på main) erstattet placeholder-skallet med det ekte fire-seksjons-brettet men oppdaterte ikke testen. Bekreftet uavhengig av dette diffet (feiler med endringene stashet). I naboens fil, så urørt her.

PLAN-rad WP-108 ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)