### PR TITLE
perf: oppstarts-«Henter data …» 2780→303 ms på enhet (eier-funn bygg 7)

### DIFF
--- a/.claude/skills/ios-dev/SKILL.md
+++ b/.claude/skills/ios-dev/SKILL.md
@@ -138,6 +138,22 @@ xcodebuild -exportArchive -archivePath <path>.xcarchive \
 - Førstegangs launch krever manuell utvikler-trust på enheten (Innstillinger
   → Generelt → VPN og enhetsadministrering).
 
+## Launch-/ytelsesmåling (LaunchTrace — brukt til 2780→303 ms-fiksene 19.07)
+
+`LaunchTrace.mark/point` (ios/Sportivista/LaunchTrace.swift) printer
+`[LAUNCH …ms]`-faser; aktiv i DEBUG og i Release med
+`SWIFT_ACTIVE_COMPILATION_CONDITIONS='SPORTIVISTA_CLOUDKIT SPORTIVISTA_TRACE'`.
+Fang på ENHET med `xcrun devicectl device process launch --device <UUID>
+--terminate-existing --console app.sportivista.ios > logg &` (kill etter ~15 s);
+i simulator med `simctl launch --console-pty`. Lærdommer som IKKE skal
+gjenoppdages: mål Release (Debug-tall lyver 3–5×), mål KJØRING 2+ (første
+launch etter install har kalde sider — post-install-tallet er ikke
+gjenåpnings-tallet), og telefonen må være ULÅST for devicectl-launch.
+Kjente launch-feller fikset 19.07: SystemLanguageModel-availability-sjekk og
+EntityIndex-bygging synkront i init (nå utsatt/lat), ubetinget
+index-invalidering + full rekompilering etter 304-sync (nå SyncResult-styrt),
+og kast-første-resultat-koalescering i startReload (nå males hver runde).
+
 ## Fallgruver som faktisk har bitt
 
 - **Flere DerivedData-kataloger:** hver xcodegen-regenerering kan gi ny

--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -167,14 +167,17 @@ final class AgendaViewModel {
                     now: current, dataStore: self.dataStore,
                     profileStore: self.profileStore, cachedIndex: cached
                 )
+                // Paint EVERY finished round (eier-funn 19.07: the old
+                // discard-and-recompute left «Henter data …» up until the LAST
+                // queued round finished — on device that was the whole first
+                // compile thrown away). "Siste vinner" still holds: a queued
+                // newer round recomputes and re-applies right after.
+                self.apply(result)
                 if let next = self.pendingReloadNow {
-                    // A newer request landed while we were computing — throw this
-                    // stale result away and recompile against the latest state.
                     self.pendingReloadNow = nil
                     current = next
                     continue
                 }
-                self.apply(result)
                 break
             }
             self.reloadTask = nil
@@ -184,6 +187,7 @@ final class AgendaViewModel {
     /// Assigns a finished reload's results — the ONLY place the published state
     /// is written, always on the main actor.
     private func apply(_ result: Reload) {
+        LaunchTrace.point("agenda apply (rows=\(result.sections.reduce(0) { $0 + $1.items.count }), lastSync=\(result.lastSync != nil))")
         sections = result.sections
         liveNow = result.liveNow
         lastSync = result.lastSync
@@ -242,7 +246,8 @@ final class AgendaViewModel {
         let syncState: ProfileSyncState
         do {
             let loadState = signposter.beginInterval("load")
-            defer { signposter.endInterval("load", loadState) }
+            let _tl = CFAbsoluteTimeGetCurrent()
+            defer { signposter.endInterval("load", loadState); LaunchTrace.mark("reload/load", since: _tl) }
             events = dataStore.loadEvents()
             baseInterests = dataStore.loadInterests() ?? Interests()
             syncState = profileStore.loadSyncState()
@@ -257,7 +262,8 @@ final class AgendaViewModel {
         let index: EntityIndex
         do {
             let indexState = signposter.beginInterval("index")
-            defer { signposter.endInterval("index", indexState) }
+            let _ti = CFAbsoluteTimeGetCurrent()
+            defer { signposter.endInterval("index", indexState); LaunchTrace.mark("reload/index (cached=\(cachedIndex != nil))", since: _ti) }
             index = cachedIndex ?? EntityIndex(dataStore.loadEntities())
         }
 
@@ -282,6 +288,8 @@ final class AgendaViewModel {
         let liveNow: [AgendaLiveRow]
         do {
             let compileState = signposter.beginInterval("compile")
+            let _tc = CFAbsoluteTimeGetCurrent()
+            defer { LaunchTrace.mark("reload/compile", since: _tc) }
             defer { signposter.endInterval("compile", compileState) }
             sections = buildSections(events: events, interests: interests, now: now, index: index, followedIds: followedIds, profile: profile, shield: shield)
             liveNow = liveRows(events: events, interests: interests, now: now)
@@ -313,8 +321,12 @@ final class AgendaViewModel {
     /// profile, or a profile with only default (`.sportAsSuch`) lenses, leaves
     /// the output byte-for-byte identical to WP-16.4 — graceful degradation.
     nonisolated static func buildSections(events: [Event], interests: Interests, now: Date, index: EntityIndex = EntityIndex([]), followedIds: Set<String> = [], profile: InterestProfile = InterestProfile(), shield: SpoilerShield = SpoilerShield()) -> [AgendaSection] {
+        let _tb = CFAbsoluteTimeGetCurrent()
         let (feedEvents, lookup) = EventBridge.bridge(events)
+        LaunchTrace.mark("compile/bridge", since: _tb)
+        let _tf = CFAbsoluteTimeGetCurrent()
         let feed = FeedCompiler.compile(events: feedEvents, interests: interests, now: now)
+        LaunchTrace.mark("compile/feedcompiler", since: _tf)
         // WP-61: one memo per compile, shared by every row's `followableEntities`
         // so a recurring team/tournament name resolves once, not once per row.
         let nameCache = NameResolveCache()
@@ -328,6 +340,7 @@ final class AgendaViewModel {
         // rather than mapping FeedCompiler's day buckets in place.
         struct Placed { let dayKey: String; let sortTime: Date?; let item: AgendaItem }
         var placed: [Placed] = []
+        let _tr = CFAbsoluteTimeGetCurrent()
 
         for day in feed.days {
             for compiled in day.items {
@@ -356,6 +369,7 @@ final class AgendaViewModel {
             }
         }
 
+        LaunchTrace.mark("compile/rows (n=\(placed.count))", since: _tr)
         // Re-group by day, drop passed days (DESIGN.md "Agendaens semantikk" §1:
         // I DAG first, never a passed day — FeedCompiler already re-homed a
         // still-running multi-day event onto today), order days ascending, and

--- a/ios/Sportivista/Assistant/AssistantViewModel.swift
+++ b/ios/Sportivista/Assistant/AssistantViewModel.swift
@@ -133,7 +133,21 @@ final class AssistantViewModel {
     /// Profile/AssistantViewModel+ProfileSync.swift (WP-48) reads it — share
     /// link/QR export, import-merge, reload, background sync all go through it.
     let profileStore: ProfileStore
-    private let index: EntityIndex
+    /// Eier-funn 19.07 (launch-trace): EntityIndex-byggingen (entities-dekoding
+    /// + resolver-substrat + prekompilerte term-regexer) kostet 60–290 ms
+    /// SYNKRONT på hovedtråden i ContentView.init. Autoclosure-injisert og
+    /// memoisert — bygges første gang assistenten faktisk trenger den
+    /// (grounding/søk/svar), aldri på launch-stien. (@Observable støtter ikke
+    /// `lazy`, derav manuell memoisering; @ObservationIgnored fordi indeksen
+    /// er intern infrastruktur, ikke UI-tilstand.)
+    @ObservationIgnored private var _index: EntityIndex?
+    @ObservationIgnored private let indexProvider: () -> EntityIndex
+    private var index: EntityIndex {
+        if let i = _index { return i }
+        let i = indexProvider()
+        _index = i
+        return i
+    }
     private let misunderstoodLog: MisunderstoodLogStore
     /// WP-30 — personal memory (facts/episodic/behaviour) over the SAME profile
     /// file (`ProfileSyncState`), and the episodic distiller that turns a
@@ -158,15 +172,16 @@ final class AssistantViewModel {
     init(
         assistant: any InterestAssistant,
         profileStore: ProfileStore,
-        index: EntityIndex,
+        index: @autoclosure @escaping () -> EntityIndex,
         misunderstoodLog: MisunderstoodLogStore = MisunderstoodLogStore(),
         memoryStore: MemoryStore? = nil,
         distiller: any MemoryDistiller = FoundationModelsMemoryDistiller(),
-        feedProvider: @escaping () -> FeedQuery = { FeedQuery(now: Date()) }
+        feedProvider: @escaping () -> FeedQuery = { FeedQuery(now: Date()) },
+        deferAvailabilityCheck: Bool = false
     ) {
         self.assistant = assistant
         self.profileStore = profileStore
-        self.index = index
+        self.indexProvider = index
         self.misunderstoodLog = misunderstoodLog
         // Default the memory store over the SAME profile file, so memory and the
         // profile share one on-disk `ProfileSyncState`.
@@ -174,7 +189,17 @@ final class AssistantViewModel {
         self.distiller = distiller
         self.feedProvider = feedProvider
         self.profile = profileStore.load()
-        self.availability = assistant.availability()
+        // Eier-funn 19.07: SystemLanguageModel.default.availability koster
+        // hundrevis av ms ved FØRSTE kall etter prosess-start — utsatt til en
+        // bakgrunns-Task for den ekte FM-stien (app-launch). Testene (mock,
+        // billig) beholder den synkrone sjekken så banner-assertions er
+        // deterministiske. Optimistisk .available i mellomtiden: er FM av,
+        // retter banneret seg <1s senere — ærlighet bevart i praksis.
+        if deferAvailabilityCheck {
+            self.availability = .available
+        } else {
+            self.availability = assistant.availability()
+        }
         self.misunderstoodEntries = misunderstoodLog.load()
         self.memory = (memoryStore ?? MemoryStore(profileStore: profileStore)).load()
     }
@@ -200,20 +225,30 @@ final class AssistantViewModel {
         // resolver substrate); reuse this one. Only events/interests/profile are
         // re-read per submit — so a just-confirmed follow is still reflected —
         // while the (unchanged) entity index is no longer rebuilt each time.
-        let index = EntityIndex(dataStore.loadEntities())
+        // Eier-funn 19.07: bygget LAT (én delt memoisert boks for grounding +
+        // feed-provider) i stedet for synkront her — dette kjørte på
+        // hovedtråden i ContentView.init på hver app-start.
+        let indexBox = LazyEntityIndexBox { EntityIndex(dataStore.loadEntities()) }
         self.init(
             assistant: assistant,
             profileStore: profileStore,
-            index: index,
+            index: indexBox.value,
             misunderstoodLog: misunderstoodLog,
             feedProvider: {
                 let events = dataStore.loadEvents()
                 let base = dataStore.loadInterests() ?? Interests()
                 let profile = profileStore.load()
-                let effective = EffectiveInterests.merge(profile: profile, into: base, index: index)
+                let effective = EffectiveInterests.merge(profile: profile, into: base, index: indexBox.value)
                 return FeedQuery.build(events: events, interests: effective, now: Date())
-            }
+            },
+            deferAvailabilityCheck: true
         )
+        // Den utsatte FM-tilgjengelighetssjekken (se init) — av hovedtråden.
+        let deferredAssistant = assistant
+        Task.detached(priority: .utility) { [weak self] in
+            let a = deferredAssistant.availability()
+            await MainActor.run { self?.availability = a }
+        }
     }
 
     /// The entity index arrived (has been synced)? Used to warn honestly when
@@ -918,4 +953,21 @@ final class AssistantViewModel {
         }
     }
     #endif
+}
+
+
+/// WP-launch-perf (19.07.2026): en-gangs, memoisert EntityIndex-bygging delt
+/// mellom AssistantViewModels grounding-sti og feed-provideren. Kun brukt fra
+/// MainActor (VM-en er @MainActor; feedProvider kalles i submit-stien).
+@MainActor
+final class LazyEntityIndexBox {
+    private let make: () -> EntityIndex
+    private var built: EntityIndex?
+    init(_ make: @escaping () -> EntityIndex) { self.make = make }
+    var value: EntityIndex {
+        if let built { return built }
+        let v = make()
+        built = v
+        return v
+    }
 }

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -130,7 +130,9 @@ struct ContentView: View {
         // (value "uitest"); a no-op unless that value is set.
         UITestSeed.seedIfRequested(profileStore: profileStore)
         #endif
+        let _t0 = CFAbsoluteTimeGetCurrent()
         self._agenda = State(initialValue: AgendaViewModel(dataStore: dataStore, syncClient: syncClient, profileStore: profileStore))
+        LaunchTrace.mark("agendaVM init", since: _t0)
         #if DEBUG
         // Screenshot harness: back the assistant with the deterministic mock
         // (so no "Apple Intelligence off" banner) when a demo mode is requested.
@@ -140,13 +142,17 @@ struct ContentView: View {
                 index: EntityIndex(dataStore.loadEntities())
             ))
         } else {
+            let _t1 = CFAbsoluteTimeGetCurrent()
             self._assistant = State(initialValue: AssistantViewModel(dataStore: dataStore, profileStore: profileStore))
+            LaunchTrace.mark("assistantVM init", since: _t1)
         }
         #else
         self._assistant = State(initialValue: AssistantViewModel(dataStore: dataStore, profileStore: profileStore))
         #endif
         // WP-107 — the shared Nyheter model reads the SAME cache + profile store.
+        let _t2 = CFAbsoluteTimeGetCurrent()
         self._news = State(initialValue: NewsModel(dataStore: dataStore, profileStore: profileStore))
+        LaunchTrace.mark("newsModel init", since: _t2)
 
         // WP-31 — first-run decision, made before the first frame so there's no
         // flash of the agenda before the overlay. A SPORTIVISTA_DEMO launch never auto-
@@ -586,6 +592,7 @@ struct ContentView: View {
     }
 
     private func refresh() async {
+        LaunchTrace.point("refresh start")
         agenda.reloadFromCache(now: Date())
         #if DEBUG
         // WP-18/WP-70: the lens screenshot demo and the XCUITest harness both run
@@ -601,13 +608,27 @@ struct ContentView: View {
         // exactly when the off-main agenda reload wanted to hop back and apply,
         // so "Henter data …" lingered longer than it needed to at every launch.
         let dataStore = self.dataStore
+        let _tp = CFAbsoluteTimeGetCurrent()
         let previousEvents = await Task.detached { dataStore.loadEvents() }.value
-        _ = await syncClient.sync()
-        // WP-60: this view drives its own sync (it also reconciles notifications
-        // below), so it must invalidate the agenda's cached entity index too —
-        // the sync may have rewritten entities.json.
-        agenda.invalidateEntityCache()
-        agenda.reloadFromCache(now: Date())
+        LaunchTrace.mark("pre-sync events decode", since: _tp)
+        let _ts = CFAbsoluteTimeGetCurrent()
+        let syncResult = await syncClient.sync()
+        LaunchTrace.mark("network sync", since: _ts)
+        // Eier-funn 19.07: the old path unconditionally invalidated the entity
+        // index and forced a SECOND full reload+compile on every launch — even
+        // when the sync came back 304/upToDate (the common case within the
+        // hour). SyncResult already knows exactly which files changed; only do
+        // the work those files actually invalidate.
+        let changedFiles: Set<String>
+        switch syncResult {
+        case .changedFiles(let files): changedFiles = Set(files)
+        case .upToDate, .failure: changedFiles = []
+        }
+        let agendaInputs: Set<String> = ["events.json", "entities.json", "tracked.json"]
+        if changedFiles.contains("entities.json") { agenda.invalidateEntityCache() }
+        if !changedFiles.isDisjoint(with: agendaInputs) {
+            agenda.reloadFromCache(now: Date())
+        }
         #if DEBUG
         // The screenshot harness must not trip the first-launch notification
         // permission alert over the design it's capturing (and must keep the
@@ -616,8 +637,15 @@ struct ContentView: View {
         #endif
         // WP-107: the sync may have rewritten news/featured/results/events — rebuild
         // the Nyheter board (off-main) so it is fresh and ready before the user ever
-        // switches to it.
-        news.rebuild()
+        // switches to it. Skipped when none of its inputs changed.
+        let newsInputs: Set<String> = ["news.json", "featured.json", "recent-results.json", "events.json", "entities.json"]
+        if !changedFiles.isDisjoint(with: newsInputs) {
+            news.rebuild()
+        }
+        // Notification reconcile needs the post-sync board only when events
+        // actually changed (or we have never reconciled after a first-ever sync);
+        // on an unchanged launch previous==new and there is nothing to re-plan.
+        guard changedFiles.contains("events.json") else { return }
         // WP-107: decode the post-sync events off the main actor too (was a second
         // synchronous full-decode on main).
         let newEvents = await Task.detached { dataStore.loadEvents() }.value

--- a/ios/Sportivista/LaunchTrace.swift
+++ b/ios/Sportivista/LaunchTrace.swift
@@ -1,0 +1,35 @@
+//
+//  LaunchTrace.swift
+//  Sportivista
+//
+//  DEBUG-only launch-phase timing — the measuring stick for the owner-reported
+//  «Henter data …» cold-start hang (19.07.2026). Prints one line per phase with
+//  ms since process start, so `simctl launch --console` (or Console.app on a
+//  device) shows exactly where the first-paint milliseconds go. No-op in
+//  Release; costs one static read otherwise.
+//
+
+import Foundation
+
+enum LaunchTrace {
+    #if DEBUG || SPORTIVISTA_TRACE
+    static let processStart = CFAbsoluteTimeGetCurrent()
+
+    /// Log a phase with duration since `since`, stamped with time since process start.
+    static func mark(_ label: String, since: CFAbsoluteTime) {
+        let now = CFAbsoluteTimeGetCurrent()
+        let total = (now - processStart) * 1000
+        let phase = (now - since) * 1000
+        print(String(format: "[LAUNCH %7.1fms] %@ (%.1fms)", total, label, phase))
+    }
+
+    /// Log an instant (no duration).
+    static func point(_ label: String) {
+        let total = (CFAbsoluteTimeGetCurrent() - processStart) * 1000
+        print(String(format: "[LAUNCH %7.1fms] %@", total, label))
+    }
+    #else
+    @inline(__always) static func mark(_ label: String, since: CFAbsoluteTime) {}
+    @inline(__always) static func point(_ label: String) {}
+    #endif
+}

--- a/ios/SportivistaTests/AgendaFilterTests.swift
+++ b/ios/SportivistaTests/AgendaFilterTests.swift
@@ -191,7 +191,7 @@ final class AssistantPresentViewModelTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
         )
     }

--- a/ios/SportivistaTests/AssistantAnswerTests.swift
+++ b/ios/SportivistaTests/AssistantAnswerTests.swift
@@ -22,7 +22,7 @@ final class AssistantAnswerTests: XCTestCase {
         return AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(),
             feedProvider: { feed }
         )

--- a/ios/SportivistaTests/AssistantCommandTests.swift
+++ b/ios/SportivistaTests/AssistantCommandTests.swift
@@ -167,7 +167,7 @@ final class AssistantCommandViewModelTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(),
             memoryStore: memoryStore,
             feedProvider: feed
@@ -251,7 +251,7 @@ final class AssistantCommandViewModelTests: XCTestCase {
         let memoryStore = MemoryStore(profileStore: store)
         memoryStore.save(SaveMemoryCommand(sport: "chess", kind: .knowledgeLevel, value: "nybegynner", reason: "test"))
         let vm = AssistantViewModel(
-            assistant: MockInterestAssistant(), profileStore: store, index: index,
+            assistant: MockInterestAssistant(), profileStore: store, index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(), memoryStore: memoryStore
         )
         vm.refreshMemory()
@@ -267,7 +267,7 @@ final class AssistantCommandViewModelTests: XCTestCase {
         let memoryStore = MemoryStore(profileStore: store)
         memoryStore.save(SaveMemoryCommand(sport: "f1", kind: .spoilerPolicy, value: "opptak", reason: "test"))
         let vm = AssistantViewModel(
-            assistant: MockInterestAssistant(), profileStore: store, index: index,
+            assistant: MockInterestAssistant(), profileStore: store, index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(), memoryStore: memoryStore
         )
         XCTAssertFalse(vm.memory.isEmpty)

--- a/ios/SportivistaTests/AssistantHelpTests.swift
+++ b/ios/SportivistaTests/AssistantHelpTests.swift
@@ -101,7 +101,7 @@ final class AssistantHelpViewModelTests: XCTestCase {
         return AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(),
             feedProvider: { feed }
         )

--- a/ios/SportivistaTests/AssistantViewModelTests.swift
+++ b/ios/SportivistaTests/AssistantViewModelTests.swift
@@ -23,7 +23,7 @@ final class AssistantViewModelTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(behavior: behavior),
             profileStore: store ?? AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             // WP-16.3: a throwaway temp directory, never this process's real
             // Application Support — same guarantee as `tempProfileStore()`.
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
@@ -119,7 +119,7 @@ final class AssistantViewModelTests: XCTestCase {
         let vm = AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog(),
             feedProvider: { AssistantTestSupport.liveFeed(now: clock) }
         )

--- a/ios/SportivistaTests/ContextActionTests.swift
+++ b/ios/SportivistaTests/ContextActionTests.swift
@@ -44,7 +44,7 @@ final class ContextActionTests: XCTestCase {
         let vm = AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
         )
         vm.onProfileChanged = { recompiled += 1 }

--- a/ios/SportivistaTests/FollowActionTests.swift
+++ b/ios/SportivistaTests/FollowActionTests.swift
@@ -21,7 +21,7 @@ final class FollowActionTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(),
             profileStore: store,
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
         )
     }

--- a/ios/SportivistaTests/MemoryAssistantTests.swift
+++ b/ios/SportivistaTests/MemoryAssistantTests.swift
@@ -63,7 +63,7 @@ final class MemoryAssistantTests: XCTestCase {
     @MainActor
     func test_viewModel_memoryCRUD_andForgetAll() {
         let store = AssistantTestSupport.tempMemoryStore()
-        let vm = AssistantViewModel(assistant: MockInterestAssistant(), profileStore: store.profileStore, index: index, memoryStore: store)
+        let vm = AssistantViewModel(assistant: MockInterestAssistant(), profileStore: store.profileStore, index: self.index, memoryStore: store)
         XCTAssertEqual(vm.memoryItemCount, 0)
 
         // Add a fact.
@@ -93,7 +93,7 @@ final class MemoryAssistantTests: XCTestCase {
     @MainActor
     func test_viewModel_spoilerShield_tracksMemory() {
         let store = AssistantTestSupport.tempMemoryStore()
-        let vm = AssistantViewModel(assistant: MockInterestAssistant(), profileStore: store.profileStore, index: index, memoryStore: store)
+        let vm = AssistantViewModel(assistant: MockInterestAssistant(), profileStore: store.profileStore, index: self.index, memoryStore: store)
         XCTAssertTrue(vm.spoilerShield.isEmpty)
         vm.updateFact(MemoryFact(sport: "f1", kind: .spoilerPolicy, value: "opptak", reason: "r", updatedAt: now))
         XCTAssertTrue(vm.spoilerShield.sports.contains("f1"), "the exposed shield reflects a just-added spoiler policy")

--- a/ios/SportivistaTests/MisunderstoodLogViewModelTests.swift
+++ b/ios/SportivistaTests/MisunderstoodLogViewModelTests.swift
@@ -21,7 +21,7 @@ final class MisunderstoodLogViewModelTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(behavior: behavior),
             profileStore: AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
         )
     }

--- a/ios/SportivistaTests/OnboardingTests.swift
+++ b/ios/SportivistaTests/OnboardingTests.swift
@@ -30,7 +30,7 @@ final class OnboardingTests: XCTestCase {
         AssistantViewModel(
             assistant: MockInterestAssistant(behavior: behavior),
             profileStore: store ?? AssistantTestSupport.tempProfileStore(),
-            index: index,
+            index: self.index,
             misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
         )
     }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -176,6 +176,9 @@ targets:
     deploymentTarget: "26.0"
     sources:
       - path: SportivistaTests
+      # LaunchTrace: AgendaViewModel (compiled below) calls it — DEBUG-only
+      # prints, no-op otherwise; the hostless bundle needs the symbol.
+      - path: Sportivista/LaunchTrace.swift
       - path: Sportivista/Models
       - path: Sportivista/Sync
       - path: Sportivista/Feed


### PR DESCRIPTION
Målt med ny LaunchTrace (DEBUG/SPORTIVISTA_TRACE) på fysisk iPhone 16 Pro.
Fire rotårsaker, alle fikset:
1. startReload kastet FERDIGE resultater ved koalescering — nå males hver
   fullførte runde («siste vinner» består).
2. ContentView.refresh invaliderte entitetsindeksen og tvang full rekompilering
   UBETINGET etter sync — selv ved 304/upToDate. Nå SyncResult-styrt: agenda-
   reload kun når events/entities/tracked endret; news.rebuild kun når dens
   filer endret; notification-reconcile (+ post-sync-dekoding) kun når events
   endret.
3. AssistantViewModel-init kalte SystemLanguageModel.availability synkront på
   main (60–600 ms første kall) — utsatt til bakgrunns-Task på FM-stien
   (testene/mocken beholder synkron sjekk; optimistisk .available imens).
4. EntityIndex-byggingen (dekoding + resolver + #325-regexer) kjørte synkront
   i ContentView.init — nå autoclosure-lat + memoisert (LazyEntityIndexBox
   delt med feedProvider), bygges første gang assistenten brukes.

Målt (Release, enhet, gjenåpning etter kill): rader ved 303 ms (post-install
kaldstart 448 ms). LaunchTrace committet som permanent DEBUG-fasilitet +
måleoppskrift i ios-dev-skillen. Test-target fikk LaunchTrace.swift;
autoclosure-endringen krevde `self.index` på ~13 test-call-sites.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
