### PR TITLE
WP-111: web — deltaker-visning, editorial-ferskhetsvakt, Om-lesbarhet, headere

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -115,7 +115,7 @@ mennesket, aldri av en agent.
 | WP-108 | Visuell affordanse: kapsel-anker + ekte Capsule + sport-symbol per rad (eier-dogfooding bygg 6) | 0H+ | WP-106 | ✅ #324 merget 19.07 |
 
 | WP-110 | Pipeline-vakter: sjakk-falsk-positiv + kontrakter | 0I | — | ⬜ |
-| WP-111 | Web: deltaker-visning + ferskhetsvakt + «Om»-lesbarhet + Zenji-headere | 0I | — | ⬜ |
+| WP-111 | Web: deltaker-visning + ferskhetsvakt + «Om»-lesbarhet + Zenji-headere | 0I | — | 🔬 |
 | WP-112 | iOS: perf-port-robusthet + deltaker-visning i agendaraden | 0I | — | ⬜ |
 | WP-113 | Sikkerhet: preview-deploy-injeksjon + CI-skrivevakt (BESKYTTEDE STIER — eier merger) | 0I | — | ⬜ |
 | WP-114 | Dok-resynk etter 19.07-gjennomgangen | 0I | — | ⬜ |

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -1,4 +1,4 @@
-/* Zenji — the agenda. One quiet list, grouped by day. The flat row language of
+/* Sportivista — the agenda. One quiet list, grouped by day. The flat row language of
    DESIGN.md: hairlines, one amber dot for must-see, a ticking clock the only
    motion. No cards, no washes, no left-stripes, no chips, no chevrons, no emoji
    in the chrome. Each row answers only: when · what · where to watch. */

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -1,4 +1,4 @@
-/* Zenji — calm single-column frame. One narrow reading column everywhere (max
+/* Sportivista — calm single-column frame. One narrow reading column everywhere (max
    640, centered); no dashboard grid, no competing panels. Mobile-first. */
 
 .wrap {

--- a/docs/js/chrome.js
+++ b/docs/js/chrome.js
@@ -1,4 +1,4 @@
-// Zenji — shell chrome: the ticking clock, the date stamp, the footer (freshness
+// Sportivista — shell chrome: the ticking clock, the date stamp, the footer (freshness
 // + staleness), the quiet AI-budget line, and the iOS install hint.
 // Extends window.Dashboard.prototype (see js/dashboard.js). Loads AFTER dashboard.js.
 Object.assign(window.Dashboard.prototype, {

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -1,4 +1,4 @@
-// Zenji — a calm overview of the sport you follow.
+// Sportivista — a calm overview of the sport you follow.
 // One question, answered quietly: what's on, when (Oslo), and where to watch.
 // One list, grouped by day. No dashboard, no noise.
 //
@@ -108,8 +108,26 @@ class Dashboard {
 	renderTodayLine() {
 		const el = document.getElementById('hero-headline');
 		if (!el) return;
-		const headline = this.featured?.blocks?.find((b) => b.type === 'headline')?.text || this.heroFallback();
-		el.innerHTML = this.emphasize(escapeHtml(headline));
+		el.innerHTML = this.emphasize(escapeHtml(this.heroHeadline()));
+	}
+
+	/** The editorial headline when it's fresh, else the calm fallback. */
+	heroHeadline() {
+		const headline = this.featuredIsFresh()
+			? this.featured?.blocks?.find((b) => b.type === 'headline')?.text
+			: null;
+		return headline || this.heroFallback();
+	}
+
+	/** featured.json is trustworthy only while it's recent (~20h). A quota-skipped
+	 *  editorial run leaves yesterday's brief in place; showing it on, say, finale
+	 *  day ("finalen venter i morgen") is a factual error. No/undateable generatedAt
+	 *  ⇒ not fresh (fall back) — we won't stand behind a brief we can't date. */
+	featuredIsFresh() {
+		const ts = this.featured?.generatedAt;
+		if (!ts) return false;
+		const age = Date.now() - new Date(ts).getTime();
+		return Number.isFinite(age) && age < 20 * SS_CONSTANTS.MS_PER_HOUR;
 	}
 
 	/** Calm fallback when the editorial agent hasn't written a headline yet. */
@@ -173,10 +191,25 @@ class Dashboard {
 		return this.osloTime(start);
 	}
 
+	/** A head-to-head read off `participants` (exactly two named sides, no home/away
+	 *  pair): the escaped "Spania – Argentina" string, else null. Deliberately fires
+	 *  only for two — a golf/CS2 field of four is a tournament, not a matchup, and
+	 *  must keep its own title rather than becoming a name list. */
+	participantMatchup(e) {
+		if (e.homeTeam && e.awayTeam) return null;
+		const names = (Array.isArray(e.participants) ? e.participants : [])
+			.map((p) => (p && p.name) || (typeof p === 'string' ? p : ''))
+			.filter(Boolean);
+		if (names.length !== 2) return null;
+		return `${escapeHtml(ssShortName(names[0]))} – ${escapeHtml(ssShortName(names[1]))}`;
+	}
+
 	eventTitle(e) {
 		if (e.homeTeam && e.awayTeam) {
 			return `${escapeHtml(ssShortName(e.homeTeam))} – ${escapeHtml(ssShortName(e.awayTeam))}`;
 		}
+		const matchup = this.participantMatchup(e);
+		if (matchup) return matchup;
 		return escapeHtml(e.title);
 	}
 
@@ -185,7 +218,14 @@ class Dashboard {
 	 *  channel). Parts are joined by a quiet middot. */
 	eventMeta(e, trailing) {
 		const parts = [];
-		const title = (e.homeTeam && e.awayTeam) ? '' : (e.title || '');
+		const hasHomeAway = !!(e.homeTeam && e.awayTeam);
+		const participantLed = !hasHomeAway && !!this.participantMatchup(e);
+		// When a matchup (home/away OR a 2-participant head-to-head) leads the row, the
+		// event's generic title (e.g. "VM-finalen 2026") is no longer the heading — it
+		// drops to a quiet context part, but only when nothing else (tournament/round)
+		// would otherwise carry it, so we never lose it yet never repeat it.
+		const title = (hasHomeAway || participantLed) ? '' : (e.title || '');
+		if (participantLed && e.title && !e.tournament && !e.round) parts.push(escapeHtml(e.title));
 		if (e.tournament && e.tournament !== title) parts.push(escapeHtml(e.tournament));
 		if (e.round) parts.push(`<span class="ev-round">${escapeHtml(e.round)}</span>`);
 		if (trailing) parts.push(trailing);

--- a/docs/js/detail.js
+++ b/docs/js/detail.js
@@ -1,4 +1,4 @@
-// Zenji — progressive disclosure: the extra context shown when a row is tapped
+// Sportivista — progressive disclosure: the extra context shown when a row is tapped
 // (calm — hidden by default). The agenda's row toggle (bindAgendaExpand) lives in
 // dashboard.js and calls eventDetail() from here.
 // Extends window.Dashboard.prototype (see js/dashboard.js). Loads AFTER dashboard.js.
@@ -73,6 +73,27 @@ Object.assign(window.Dashboard.prototype, {
 		);
 	},
 
+	/** Split a summary into calm, escaped paragraphs so the "Om" section isn't one
+	 *  wall of text. Explicit blank lines (\n\n) split first; otherwise a block of
+	 *  more than two sentences is grouped into runs of two. Sentence boundaries are
+	 *  only period/!/? followed by whitespace + a capital — so "kl. 21.00", "UCI
+	 *  2.Pro" and "29. juli" stay intact. */
+	aboutParagraphs(text) {
+		const raw = String(text || '').trim();
+		if (!raw) return [];
+		const blocks = raw.split(/\n\s*\n/).map((b) => b.replace(/\s+/g, ' ').trim()).filter(Boolean);
+		const out = [];
+		for (const block of blocks) {
+			const sentences = block
+				.split(/(?<=[.!?…][»")'”’]?)\s+(?=[A-ZÆØÅ])/)
+				.map((s) => s.trim())
+				.filter(Boolean);
+			if (sentences.length <= 2) { out.push(block); continue; }
+			for (let i = 0; i < sentences.length; i += 2) out.push(sentences.slice(i, i + 2).join(' '));
+		}
+		return out.map((p) => escapeHtml(p));
+	},
+
 	eventDetail(e) {
 		if (e.isSeries) return this.seriesDetail(e);
 		const rows = [];
@@ -85,12 +106,18 @@ Object.assign(window.Dashboard.prototype, {
 		add('Ledende', this.golfContext(e));
 		if (e.sport === 'f1') this.addF1Context(add);
 		if (e.venue && e.venue !== 'TBD') add('Arena', escapeHtml(e.venue));
+		// Key facts as their own quiet lines where the fields exist (never a wall).
+		if (e.round) add('Runde', escapeHtml(e.round));
+		if (e.surface) add('Underlag', escapeHtml(e.surface));
+		if (e.format) add('Format', escapeHtml(e.format));
 		if (e.sport === 'golf' && (e.norwegianPlayers?.length || e.featuredGroups?.length)) {
 			this.addGolfField(e, add);
 		} else if (e.norwegianPlayers?.length) {
 			add('Norske', escapeHtml(e.norwegianPlayers.map((p) => p.name || p).join(', ')));
 		}
-		if (e.summary) add('Om', escapeHtml(e.summary));
+		// "Om" — the summary, structured into calm paragraphs instead of one wall.
+		// First paragraph carries the "Om" label; the rest continue under a blank key.
+		this.aboutParagraphs(e.summary).forEach((p, i) => add(i === 0 ? 'Om' : '', p));
 
 		const streams = Array.isArray(e.streaming) ? e.streaming : [];
 		if (streams.length) {

--- a/docs/js/followed.js
+++ b/docs/js/followed.js
@@ -1,4 +1,4 @@
-// Zenji — the entity-first "when's X next?" index: the compact "Dine neste" glance
+// Sportivista — the entity-first "when's X next?" index: the compact "Dine neste" glance
 // at the top and the "Hva vi følger" disclosure at the bottom.
 // Extends window.Dashboard.prototype (see js/dashboard.js). Loads AFTER dashboard.js.
 Object.assign(window.Dashboard.prototype, {

--- a/docs/js/live.js
+++ b/docs/js/live.js
@@ -1,4 +1,4 @@
-// Zenji — live now: the quiet "Direkte nå" line + client-side ESPN live polling.
+// Sportivista — live now: the quiet "Direkte nå" line + client-side ESPN live polling.
 // Extends window.Dashboard.prototype (see js/dashboard.js). Loads AFTER dashboard.js.
 Object.assign(window.Dashboard.prototype, {
 

--- a/docs/js/shared-constants.js
+++ b/docs/js/shared-constants.js
@@ -1,4 +1,4 @@
-// Zenji Shared Constants & Utilities
+// Sportivista Shared Constants & Utilities
 // Canonical source of truth for values shared between client (dashboard.js) and server (helpers.js).
 // Loaded as the first <script> tag — all symbols are globals.
 

--- a/docs/js/theme.js
+++ b/docs/js/theme.js
@@ -1,4 +1,4 @@
-// Zenji Theme — the ONE theme implementation, shared by all pages (WP-46).
+// Sportivista Theme — the ONE theme implementation, shared by all pages (WP-46).
 // A single quantized glyph cycles system → dark → light → system (DESIGN.md,
 // BINDING). 'system' clears data-theme so prefers-color-scheme decides; the
 // glyph shows the current quantized state: ◐ system · ● dark · ○ light.

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
-// Zenji v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-5';
+// Sportivista v2 Service Worker — fresh data always, network-first shell
+const CACHE_NAME = 'sportivista-v1-6';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -79,6 +79,141 @@ describe("agenda event row", () => {
 	});
 });
 
+// WP-111: an event that carries `participants` but no homeTeam/awayTeam (e.g. the
+// VM final: participants Spania/Argentina, generic title "VM-finalen 2026") must
+// show the matchup — the participants are the "hva", the generic title mere context.
+describe("head-to-head participants render as the row matchup", () => {
+	const base = { id: "vm", sport: "football", time: soon(), tournament: "FIFA World Cup", round: "Finale", title: "VM-finalen 2026", importance: 5, streaming: [{ platform: "NRK 1", url: "https://tv.nrk.no/direkte" }] };
+
+	it("shows the two participants as the title instead of the generic name", () => {
+		const html = dash.eventTitle({ ...base, participants: [{ name: "Spania" }, { name: "Argentina" }] });
+		expect(html).toContain("Spania");
+		expect(html).toContain("Argentina");
+		expect(html).toContain("–");            // the two sides, joined
+		expect(html).not.toContain("VM-finalen"); // generic title no longer leads
+	});
+
+	it("keeps the generic title's context (tournament + round + channel) in the meta", () => {
+		const html = dash.eventRow({ ...base, participants: [{ name: "Spania" }, { name: "Argentina" }] });
+		expect(html).toContain("Spania");
+		expect(html).toContain("Argentina");
+		expect(html).toContain("FIFA World Cup"); // tournament survives as context
+		expect(html).toContain("Finale");          // round survives
+		expect(html).toContain("NRK 1");           // where to watch
+		expect(html).not.toContain("VM-finalen");
+	});
+
+	it("keeps the generic title as context when nothing else (tournament/round) carries it", () => {
+		const html = dash.eventRow({ id: "p2", sport: "football", time: soon(), title: "Treningskamp", participants: [{ name: "Norge" }, { name: "Brasil" }] });
+		expect(html).toContain("Norge");
+		expect(html).toContain("Brasil");
+		expect(html).toContain("Treningskamp"); // preserved in meta — no tournament/round to carry it
+	});
+
+	it("does NOT turn a 4-team field (a tournament, not a match) into a name list", () => {
+		const e = { id: "ewc", sport: "esports", time: soon(), title: "Esports World Cup 2026 – CS2 (gruppespill)", tournament: "Esports World Cup 2026", participants: [{ name: "Team Vitality" }, { name: "Natus Vincere" }, { name: "FaZe Clan" }, { name: "Team Falcons" }] };
+		const html = dash.eventTitle(e);
+		expect(html).toContain("Esports World Cup 2026");
+		expect(html).not.toContain("Team Vitality");
+		expect(html).not.toContain("Natus Vincere");
+	});
+
+	it("leaves a single-participant event on its own title (not a lone name)", () => {
+		const html = dash.eventTitle({ id: "arn", sport: "cycling", time: soon(), title: "Arctic Race of Norway 2026", participants: [{ name: "Uno-X Mobility" }] });
+		expect(html).toContain("Arctic Race of Norway 2026");
+		expect(html).not.toContain("Uno-X Mobility");
+	});
+
+	it("prefers homeTeam/awayTeam over participants when both exist", () => {
+		const html = dash.eventTitle({ homeTeam: "Liverpool FC", awayTeam: "Arsenal FC", participants: [{ name: "Spania" }, { name: "Argentina" }] });
+		expect(html).toContain("Liverpool");
+		expect(html).toContain("Arsenal");
+		expect(html).not.toContain("Spania");
+	});
+
+	it("escapes HTML in participant names", () => {
+		const html = dash.eventTitle({ sport: "football", title: "x", participants: [{ name: "<script>alert(1)</script>" }, { name: "B" }] });
+		expect(html).not.toContain("<script>alert");
+	});
+});
+
+// WP-111: editorial (featured.json) is a "nice extra" that can be quota-skipped for
+// a day. A stale brief is a factual error on the hero (19.07: yesterday's "finalen
+// venter i morgen" stayed up all through finale day). Discard anything > ~20h old.
+describe("editorial freshness guard on the hero headline", () => {
+	const HOUR = 3600000;
+	const brief = (ageHours) => ({
+		generatedAt: new Date(Date.now() - ageHours * HOUR).toISOString(),
+		blocks: [{ type: "headline", text: "Finalen venter i kveld." }],
+	});
+
+	it("uses a fresh editorial headline (generatedAt within ~20h)", () => {
+		dash.featured = brief(3);
+		expect(dash.featuredIsFresh()).toBe(true);
+		expect(dash.heroHeadline()).toContain("Finalen venter");
+	});
+
+	it("discards a stale headline (> 20h) and falls back to the calm default", () => {
+		dash.featured = brief(30);
+		expect(dash.featuredIsFresh()).toBe(false);
+		expect(dash.heroHeadline()).toBe(dash.heroFallback());
+		expect(dash.heroHeadline()).not.toContain("Finalen venter");
+	});
+
+	it("treats a featured brief with no generatedAt as untrustworthy (fall back)", () => {
+		dash.featured = { blocks: [{ type: "headline", text: "Udatert." }] };
+		expect(dash.featuredIsFresh()).toBe(false);
+		expect(dash.heroHeadline()).toBe(dash.heroFallback());
+	});
+
+	it("falls back when there is no featured brief at all", () => {
+		dash.featured = null;
+		expect(dash.featuredIsFresh()).toBe(false);
+		expect(dash.heroHeadline()).toBe(dash.heroFallback());
+	});
+});
+
+// WP-111: the "Om" section was one wall of text. Structure it into calm paragraphs
+// and surface key facts as their own quiet lines — without splitting abbreviations.
+describe("«Om» readability — paragraphs, not a wall", () => {
+	it("splits a multi-sentence summary into separate paragraph rows", () => {
+		const summary = "Første setning her. Andre setning her. Tredje setning kommer. Fjerde runder av.";
+		const paras = dash.aboutParagraphs(summary);
+		expect(paras.length).toBeGreaterThan(1); // not one wall
+		const detail = dash.eventDetail({ sport: "football", title: "x", summary });
+		expect(detail).toContain('<span class="d-k">Om</span>');
+		expect((detail.match(/class="d-v"/g) || []).length).toBeGreaterThan(2); // Hvorfor + ≥2 paragraphs
+	});
+
+	it("does not split inside abbreviations/numbers like «kl. 21.00» or «29. juli»", () => {
+		const summary = "Kampen vises på NRK1 (kl. 21.00 norsk tid). Løpet går 29. juli i Aalborg.";
+		const paras = dash.aboutParagraphs(summary);
+		expect(paras.length).toBe(1); // two real sentences (≤2) → one calm block
+		expect(paras[0]).toContain("kl. 21.00");
+		expect(paras[0]).toContain("29. juli");
+	});
+
+	it("renders key-fact lines (Runde/Underlag/Format) where the fields exist", () => {
+		const detail = dash.eventDetail({ sport: "tennis", title: "x", round: "Semifinale", surface: "Grus", format: "Best av 5", summary: "Kort." });
+		expect(detail).toContain("Runde");
+		expect(detail).toContain("Semifinale");
+		expect(detail).toContain("Underlag");
+		expect(detail).toContain("Grus");
+		expect(detail).toContain("Format");
+		expect(detail).toContain("Best av 5");
+	});
+
+	it("returns nothing for an empty or missing summary", () => {
+		expect(dash.aboutParagraphs("")).toEqual([]);
+		expect(dash.aboutParagraphs(null)).toEqual([]);
+	});
+
+	it("escapes HTML inside summary paragraphs", () => {
+		const detail = dash.eventDetail({ sport: "football", title: "x", summary: "<script>alert(1)</script> Andre setning." });
+		expect(detail).not.toContain("<script>alert");
+	});
+});
+
 describe("cancelled / postponed matches stay on the board, labelled", () => {
 	it("shows a cancelled match faded with an 'Avlyst' label instead of a channel", () => {
 		const html = dash.eventRow({ id: "c", sport: "football", title: "Barcelona vs X", time: soon(), status: "cancelled", streaming: [{ platform: "TV3" }] });


### PR DESCRIPTION
FASE 0I, bølge 1. Fikser VM-finale-hullet + tre småløft i `docs/`. Disjunkte filer fra WP-110/112/113/114. Ingen design-omlegging, ingen CSS-token-endringer (WP-117/120 eier design).

## Hva
1. **Deltaker-visning i agendaraden** (`dashboard.js`) — et event med `participants` men uten `homeTeam/awayTeam` og med nøyaktig **2** deltakere rendres nå som matchup i radtittelen (VM-finalen: «Spania – Argentina» i stedet for den generiske «VM-finalen 2026»). Den generiske tittelen faller til stille kontekst i meta-linja — men bare når verken `tournament` eller `round` allerede bærer den, så den aldri mistes og aldri gjentas. Gaten er bevisst **kun 2**: en golf-/CS2-turnering med 4 deltakere (Esports World Cup) beholder tittelen og blir aldri en navneliste; ett-deltaker-event (Uno-X) beholder også tittelen. `homeTeam/awayTeam` vinner fortsatt over `participants`. `escapeHtml` på alt (ny `participantMatchup(e)`-hjelper).
2. **Editorial-ferskhetsvakt** (`renderTodayLine` → ny `heroHeadline()`/`featuredIsFresh()`) — `featured.json` med `generatedAt` eldre enn ~20 t (eller helt uten `generatedAt`) forkastes → `heroFallback()`. Hindrer faktafeil-headline når editorial kvote-hoppes (19.07 sto gårsdagens «finalen venter i morgen» hele finaledagen).
3. **«Om»-lesbarhet** (`detail.js`, ny `aboutParagraphs()`) — summary splittes i rolige avsnitt (`\n\n` først, ellers 2-setnings-grupper); setningsgrensen er kun `.!?` + mellomrom + stor forbokstav, så «kl. 21.00», «UCI 2.Pro» og «29. juli» aldri splittes. Nøkkelfakta (Runde/Underlag/Format) rendres som egne stille linjer der feltene finnes. `escapeHtml`-disiplin beholdt.
4. **Headere + cache** — «Zenji»→«Sportivista» i de 10 kommentar-headerne i `docs/` (sw.js, css/cards.css, css/layout.css, js/{theme,chrome,shared-constants,live,followed,dashboard,detail}.js); `sw.js` CACHE_NAME `sportivista-v1-5`→`v1-6`.

PLAN.md WP-111 flippet ⬜→🔬.

## Verifisering
- `npx vitest run --maxWorkers=1`: **644 passerte / 44 filer** (629→644; 15 nye i `tests/dashboard-cards.test.js`: deltaker-matchup, 4-/1-deltaker-gate, home/away-prioritet, escape, ferskhetsvakt fersk/gammel/udatert/ingen, Om-avsnittsplitt + abbreviasjons-integritet + nøkkelfakta-linjer).
- `npm run screenshot` begge temaer (640px, full-page) — **ikke committet** (bevis-policy regel 8). Begge renders rolig og uendret i struktur; eneste synlige atferdsendring er at helten nå viser den rolige fallback-linja i stedet for den ~2 dager gamle briefen (ferskhetsvakta virker som tiltenkt). Agendaen uendret; «100 Thieves – Falcons» viser at matchup-rendering fungerer. Ingen utilsiktede visuelle endringer.
- Sanity: `aboutParagraphs` på den ekte Arctic-Race-summaryen → 3 avsnitt, «UCI 2.Pro»/«kl. 21.00»/«29. juli» intakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)