### PR TITLE
WP-110: pipeline-vakter — sjakk-falsk-positiv katalog-gatet + kontrakter

### DIFF
--- a/.claude/skills/source-quirks/SKILL.md
+++ b/.claude/skills/source-quirks/SKILL.md
@@ -62,3 +62,23 @@ rather than deleting it — the history is useful.
 - **Observed:** 2026-07-05 (British Grand Prix, Silverstone, race Sun 5 Jul — absent
   from the board; only Belgian 17 Jul + Hungarian 24 Jul present).
   **Evidence:** https://www.formula1.com/en/racing/2026
+
+### cyclingstage.com — Grand Tour / stage-race times (medium)
+- **Quirk:** the times cyclingstage.com lists are the **on-road stage schedule**
+  (roll-out / départ réel / expected finish), NOT the **Norwegian broadcast start**.
+  For a Tour de France stage that is often 1–3 h apart: the racing starts around
+  midday while TV 2 Play joins later. The two time semantics look identical (both a
+  "start time"), so a naive lift puts the wrong clock on the board.
+- **Symptom on the board:** the event's `time` disagrees with what verify sees from
+  the broadcaster — `calibration.json` shows cyclingstage.com's `time` field agreeing
+  on only **3 of 11 checks** (reliability ~0.38) while its `existence` field agrees
+  2/2. The source is right about WHAT is happening and roughly WHEN it races, but
+  wrong about when a Norwegian viewer should tune in.
+- **Compensate:** the board's contract is **broadcast times** (when can I watch on
+  TV 2 Play). Take the start time + streaming from **letour.fr / the TV 2 Play guide**
+  (or the official race site), and use cyclingstage.com only for **stage facts** —
+  stage number, route, distance, start/finish towns, flat/mountain/ITT profile. Never
+  copy its clock onto `time` for a Norwegian audience without a broadcaster cross-check.
+- **Observed:** 2026-07 Tour de France window, 11 time checks (3 agreed) in
+  `calibration.json`; corrections logged with no field disagreement on existence.
+  **Evidence:** https://www.letour.fr/en/ · https://play.tv2.no/

--- a/PLAN.md
+++ b/PLAN.md
@@ -114,7 +114,7 @@ mennesket, aldri av en agent.
 | WP-107 | Ytelse: Nyheter-bytte-jank + oppstarts-«Henter data» (eier-dogfooding bygg 6) | 0H+ | WP-106 | ✅ #323 merget 19.07 |
 | WP-108 | Visuell affordanse: kapsel-anker + ekte Capsule + sport-symbol per rad (eier-dogfooding bygg 6) | 0H+ | WP-106 | ✅ #324 merget 19.07 |
 
-| WP-110 | Pipeline-vakter: sjakk-falsk-positiv + kontrakter | 0I | — | ⬜ |
+| WP-110 | Pipeline-vakter: sjakk-falsk-positiv + kontrakter | 0I | — | 🔬 PR åpnet 20.07 — dropped-in-build katalog-gatet (delt `makeCoverageGate` i helpers, build-events + gap-detektor deler én gate; Sant Martí-anomali borte, øvrige gaps uendret); usage-gate-kommentar oppdatert (token wiret); cyclingstage-tidssemantikk-quirk lagt til; scout/self-repair logg-kontrakt strammet (logg+commit på HVER kjøring) |
 | WP-111 | Web: deltaker-visning + ferskhetsvakt + «Om»-lesbarhet + Zenji-headere | 0I | — | 🔬 |
 | WP-112 | iOS: perf-port-robusthet + deltaker-visning i agendaraden | 0I | — | ⬜ |
 | WP-113 | Sikkerhet: preview-deploy-injeksjon + CI-skrivevakt (BESKYTTEDE STIER — eier merger) | 0I | — | ⬜ |

--- a/scripts/agents/scout.md
+++ b/scripts/agents/scout.md
@@ -24,8 +24,17 @@ Noise (never escalate): match results, transfer gossip, injuries without
 schedule impact, opinion pieces, anything already reflected in events.json.
 
 ## Act
+
+**Every run leaves a record — no exceptions.** You MUST append a log entry AND
+commit + push `docs/data/scout-log.json` on EVERY run, including a quiet one where
+you escalate nothing. The committed log is the proof the watchtower ran; a run that
+ends without a new committed entry is indistinguishable from the scout being asleep.
+(On 18–19 Jul ~half the hourly runs left no log — that must not recur.) "Quiet" is a
+verdict you record and commit, never a reason to skip the write.
+
 1. Read the inputs. Think briefly.
-2. Append your verdict to `docs/data/scout-log.json` (keep last 100 entries):
+2. Append your verdict to `docs/data/scout-log.json` (keep last 100 entries) — do
+   this on every run, quiet or escalate:
    `{ "runAt": ISO, "verdict": "quiet" | "escalate", "reason": "...", "signals": ["..."] }`
 3. **Escalation cap: max 2 escalations per calendar day (UTC).** Count today's
    `"escalate"` entries in scout-log.json before escalating — if already 2, log
@@ -38,7 +47,10 @@ schedule impact, opinion pieces, anything already reflected in events.json.
    this agent lacks `actions: write` and the dispatch 403s (this is the bug WP-91
    fixed; the sentinel file is the working path). Still include what you saw in the
    log entry so the research agent's next run can find it.
-5. Commit only `docs/data/scout-log.json`:
+5. Commit only `docs/data/scout-log.json` — ALWAYS, as the final step of every run
+   (quiet runs included; this is the step that was being skipped):
    `git add docs/data/scout-log.json && git commit -m "scout: <verdict>" && git push || (git pull --rebase origin main && git push)`
 
-Be fast. If nothing stands out in 2-3 minutes, log "quiet" and stop.
+Be fast. If nothing stands out in 2-3 minutes, still append the "quiet" entry and
+run the commit + push in step 5 before you stop — logging without committing does
+not count as a completed run.

--- a/scripts/agents/self-repair.md
+++ b/scripts/agents/self-repair.md
@@ -46,10 +46,19 @@ If the only correct fix touches a protected path, still make it — it'll wait f
 review; say so in the PR body. Never edit `interests.json` at all.
 
 ## Output
+
+**Write the run log on EVERY run — no exceptions**, including a clean run where
+nothing is broken (`action: "none"`), an abandoned fix, or a skipped one. Write it to
+`docs/data/self-repair-log.json` on the DEFAULT branch working tree (not inside your
+fix branch); the workflow's "Commit run log" step then persists it to `main` on every
+run — but only if you actually wrote it, so a no-op run with no log write leaves no
+trace that the mechanic ran (the improve agent mines this log as evidence). A quiet
+run is a logged run, never a silent one.
+
 - `docs/data/self-repair-log.json`:
   `{ "runAt": ISO, "action": "opened-pr"|"none"|"skipped-existing-pr"|"abandoned", "pr": <url|null>, "diagnosed": "…", "fixed": ["…"], "autoMergeEligible": bool, "notes": ["…"] }`
-- If nothing is broken, write `action: "none"` and stop. If an open `self-repair/`
-  PR already exists, stop (`skipped-existing-pr`).
+- If nothing is broken, write `action: "none"` (still write the log) and stop. If an
+  open `self-repair/` PR already exists, write `action: "skipped-existing-pr"` and stop.
 
 ## Hard constraints
 - NEVER edit `scripts/config/interests.json` (user-owned).

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -2,7 +2,7 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { readJsonIfExists, rootDataPath, MS_PER_DAY, matchInterest, mustWatchEntity, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
+import { readJsonIfExists, rootDataPath, MS_PER_DAY, makeCoverageGate, mustWatchEntity, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
 import { resolveStreaming } from "./lib/norwegian-rights.js";
 import { writeManifest } from "./build-manifest.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
@@ -546,68 +546,16 @@ if (keptConfirmed > 0) {
 // calendar bell (see mustWatchEntity), which stays an owner artifact.
 const catalog = readJsonIfExists(path.join(configDir, "catalog.json")) || {};
 const interests = readJsonIfExists(path.join(configDir, "interests.json")) || {};
-// Sports covered WHOLESALE (every in-sport event stays) — catalog tier1. NB:
-// chess and esports are deliberately NOT here — Sportivista covers them through a
-// named-entity catalog (elite tournaments + top players / tier-1 teams), not
-// wholesale, so they are entity-gated below. Default mirrors the pre-WP-96
-// followBroadly set for a catalog-less run (tests, first build).
-const coveredBroadly = new Set(
-	(catalog.tier1 || ["football", "golf", "f1", "cycling", "biathlon", "cross-country", "alpine", "nordic", "ski jumping"]).map((s) => s.toLowerCase())
-);
-// Entity-gated sports (WP-92 gate, now catalog-keyed): sports we cover ONLY
-// through the named catalog long-tail, never wholesale. For these a sport-scoped
-// catalog-entity match is REQUIRED — the norwegian / favorite / importance /
-// ai-research shortcuts do NOT apply. Without this a minor open with a lone
-// Norwegian club player (the live "XXVI Obert Internacional Sant Martí" case) or
-// a CS2 match between two uncovered teams slips onto the board, because such
-// events are often flagged norwegian:true or arrive as source:"ai-research".
-// tier1 still wins (checked first). The entity NAMES live in catalog.json.
-const ENTITY_GATED_SPORTS = new Set(["chess", "esports"]);
-const catalogEntities = [
-	...(catalog.tier2?.teams || []),
-	...(catalog.tier2?.athletes || []),
-	...(catalog.tier2?.tournaments || []),
-];
-
-// The haystack the coverage matcher scans (mirrors helpers.js mustWatchEntity):
-// title + tournament + home/away + Norwegian players + participants.
-// Deliberately excludes venue.
-function relevanceHaystack(e) {
-	return [e.title, e.tournament, e.homeTeam, e.awayTeam,
-		...(e.norwegianPlayers || []).map((p) => p?.name || p),
-		...(e.participants || []).map((p) => p?.name || p)].join(" ");
-}
-
-// isCovered — "does Sportivista cover this event?" (server scope). Structurally
-// identical to the pre-WP-96 isRelevant, but keyed off catalog.json instead of
-// interests.json. The per-user "is this relevant to ME?" decision is NOT made
-// here any more — it is the client lens's job (FeedCompiler.isRelevant), which
-// still reads a personal profile. The golden feed-vectors' `relevant` set pins
-// that (unchanged) client lens; this server filter is a superset upstream of it
-// (see tests/fixtures/feed-vectors/DIVERGENCES.md §6 + the isCovered tests in
-// tests/build-events.test.js).
-function isCovered(e) {
-	const sport = (e.sport || "").toLowerCase();
-	// (1) Wholesale-covered sport → in. Checked first so it wins over the gate.
-	if (coveredBroadly.has(sport)) return true;
-	const hay = relevanceHaystack(e);
-	// (2) Entity-gated sport (chess/esports): a SPORT-SCOPED catalog-entity match
-	// is the only way in — no norwegian/favorite/importance/ai-research blanket.
-	// Sport-scoping stops a cross-sport entity from admitting it (e.g. a chess
-	// event held in the city of Barcelona must not match the football club
-	// "Barcelona").
-	if (ENTITY_GATED_SPORTS.has(sport)) {
-		return matchInterest(hay, catalogEntities, { sport: e.sport }) != null;
-	}
-	// (3) Any other non-broad sport (e.g. tennis): a Norwegian / favorite /
-	// high-importance event stays. ai-research is NOT a blanket pass on its own —
-	// an AI-found event must ALSO be a tier1 sport (at (1)) or match a catalog
-	// entity (at (4)).
-	if (e.norwegian || e.isFavorite || (e.importance || 0) >= 4) return true;
-	// (4) Catalog-entity match, UNSCOPED (a deliberate divergence from the bell —
-	// see tests/fixtures/feed-vectors/DIVERGENCES.md §1).
-	return matchInterest(hay, catalogEntities) != null;
-}
+// isCovered — "does Sportivista cover this event?" (server scope), keyed off
+// catalog.json (WP-96). The logic (tier1 wholesale; chess/esports entity-gated via a
+// SPORT-SCOPED catalog-entity match; other non-broad sports kept only by
+// norwegian/favorite/importance≥4 or an unscoped catalog-entity match — the Sant
+// Martí class is dropped, ai-research is no blanket pass) now lives in
+// helpers.makeCoverageGate. It was extracted (WP-110) so THIS board filter and
+// detect-coverage-gaps.js's dropped-in-build anomaly share ONE gate and can't drift:
+// an event the catalog never covers is a legitimate build drop, not a source
+// anomaly. See tests/build-events.test.js + tests/fixtures/feed-vectors/DIVERGENCES.md §6.
+const isCovered = makeCoverageGate(catalog);
 
 // Keep events from the last 14 days + upcoming, and only those the catalog covers
 const cutoff = Date.now() - 14 * MS_PER_DAY;

--- a/scripts/detect-coverage-gaps.js
+++ b/scripts/detect-coverage-gaps.js
@@ -23,7 +23,7 @@
 import fs from "fs";
 import path from "path";
 import { pathToFileURL } from "url";
-import { readJsonIfExists, rootDataPath, writeJsonPretty, iso, MS_PER_DAY, containsName, normalizeText, normalizeEntity, entityTerms, isEventInWindow } from "./lib/helpers.js";
+import { readJsonIfExists, rootDataPath, writeJsonPretty, iso, MS_PER_DAY, containsName, normalizeText, normalizeEntity, entityTerms, isEventInWindow, makeCoverageGate } from "./lib/helpers.js";
 
 // Re-export so existing importers (tests) keep resolving containsName from here.
 export { containsName };
@@ -186,8 +186,19 @@ export function detectGaps({ rss, events, interests, tracked, now = Date.now() }
  * we only look closer at a sport when the board has NOTHING upcoming for it, then
  * name why (fetcher missing / empty / dropping events). `sources` maps sport key →
  * parsed data file (or null if absent).
+ *
+ * WP-110: the "dropped-in-build" (high) signal is CATALOG-GATED with the SAME
+ * `isCovered` build-events.js uses. Entity-gated sports (chess/esports) are covered
+ * only through the named catalog long-tail, so a minor open with a lone club player
+ * (the "Sant Martí" class) legitimately never reaches the board — that is a correct
+ * build drop, NOT the build dropping something it should keep. Counting it as
+ * dropped-in-build fired a chronic HIGH false positive every hour. So a source-file
+ * event only counts toward this signal if the catalog actually covers it. `isCovered`
+ * defaults to a permissive gate (cover everything) so callers that don't pass one keep
+ * the pre-WP-110 behaviour; main() passes the real catalog gate. File events carry no
+ * `sport` field (build-events stamps it from the filename), so we force it here too.
  */
-export function detectSourceAnomalies({ sources, events, now = Date.now() }) {
+export function detectSourceAnomalies({ sources, events, now = Date.now(), isCovered = () => true }) {
 	const anomalies = [];
 	for (const sport of EXPECTED_SPORT_FILES) {
 		const onBoard = countSportEventsWithin(events, sport, now, UPCOMING_DAYS);
@@ -199,11 +210,14 @@ export function detectSourceAnomalies({ sources, events, now = Date.now() }) {
 			continue;
 		}
 		const fileEvents = (data.tournaments || []).flatMap((t) => t.events || []);
-		const upcomingInFile = fileEvents.filter((e) =>
-			isEventInWindow(e, now - MS_PER_DAY, now + UPCOMING_DAYS * MS_PER_DAY)
+		// Only events the BUILD would actually KEEP count as "dropped" — an uncovered
+		// event (Sant Martí chess/esports) is a legitimate drop, not a build bug.
+		const droppableUpcoming = fileEvents.filter((e) =>
+			isEventInWindow(e, now - MS_PER_DAY, now + UPCOMING_DAYS * MS_PER_DAY) &&
+			isCovered({ ...e, sport })
 		).length;
-		if (upcomingInFile > 0) {
-			anomalies.push({ sport, issue: "dropped-in-build", detail: `${upcomingInFile} upcoming ${sport} event(s) in the source file but 0 on the board — build/normalisation may be dropping them`, severity: "high", detectedAt: iso(now) });
+		if (droppableUpcoming > 0) {
+			anomalies.push({ sport, issue: "dropped-in-build", detail: `${droppableUpcoming} upcoming ${sport} event(s) in the source file but 0 on the board — build/normalisation may be dropping them`, severity: "high", detectedAt: iso(now) });
 		} else if (fileEvents.length === 0) {
 			anomalies.push({ sport, issue: "file-empty", detail: `docs/data/${sport}.json has no events and none on the board — source may be down or changed`, severity: "low", detectedAt: iso(now) });
 		}
@@ -393,11 +407,15 @@ function main() {
 		: interestsSeed;
 	const tracked = readJsonIfExists(path.join(configDir, "tracked.json"));
 	const sources = readSources(dataDir);
+	// WP-110: gate the dropped-in-build anomaly with the SAME coverage gate the
+	// build uses, so an event the catalog never covers (the Sant Martí chess class)
+	// is not mis-read as "the build dropped it".
+	const isCovered = makeCoverageGate(catalog);
 
 	const gaps = detectGaps({ rss, events, interests, tracked });
 	const trackedClaims = detectTrackedClaims({ tracked, events });
 	const allGaps = [...gaps, ...trackedClaims];
-	const anomalies = detectSourceAnomalies({ sources, events });
+	const anomalies = detectSourceAnomalies({ sources, events, isCovered });
 	writeJsonPretty(path.join(dataDir, "coverage-gaps.json"), {
 		generatedAt: iso(),
 		gapCount: allGaps.length,

--- a/scripts/lib/helpers.js
+++ b/scripts/lib/helpers.js
@@ -151,6 +151,69 @@ export function mustWatchEntity(event, interests) {
 	return matchInterest(hay, notifyEntities(interests), { sport: event.sport });
 }
 
+// --- Server coverage gate (WP-96 / WP-110) ---
+// "Does Sportivista COVER this event?" — the server-scope filter keyed off
+// catalog.json ("hva vi DEKKER", never one person's follows). Extracted here
+// (WP-110) so build-events.js (the board filter) and detect-coverage-gaps.js (its
+// dropped-in-build anomaly) ask the EXACT same question and cannot drift: an event
+// the catalog never covers is a legitimate build drop, not a "source dropped it"
+// anomaly — that drift is exactly what produced the chronic "Sant Martí" chess
+// HIGH false positive. See build-events.js + tests/build-events.test.js.
+
+/** Sports covered WHOLESALE by default when catalog.tier1 is absent (tests, first build). */
+export const DEFAULT_TIER1_SPORTS = ["football", "golf", "f1", "cycling", "biathlon", "cross-country", "alpine", "nordic", "ski jumping"];
+
+/**
+ * Sports covered ONLY through the named catalog long-tail, never wholesale: a
+ * SPORT-SCOPED catalog-entity match is required — the norwegian / favorite /
+ * importance / ai-research shortcuts do NOT apply. Without this a minor open with a
+ * lone Norwegian club player (the "Sant Martí" case) or a CS2 match between two
+ * uncovered teams slips through, because such events are often norwegian:true or
+ * arrive as source:"ai-research".
+ */
+export const ENTITY_GATED_SPORTS = new Set(["chess", "esports"]);
+
+/**
+ * The haystack the coverage matcher scans: title + tournament + home/away +
+ * Norwegian players + participants. Deliberately excludes venue (mirrors
+ * mustWatchEntity, so a chess event in the CITY of Barcelona doesn't match the
+ * football club).
+ */
+export function coverageHaystack(e) {
+	return [e.title, e.tournament, e.homeTeam, e.awayTeam,
+		...((e.norwegianPlayers || []).map((p) => p?.name || p)),
+		...((e.participants || []).map((p) => p?.name || p))].join(" ");
+}
+
+/**
+ * Build the server coverage gate from catalog.json: returns `isCovered(event)`.
+ *   (1) wholesale-covered sport (tier1) → in, checked first so it wins over the gate;
+ *   (2) entity-gated sport (chess/esports) → only a SPORT-SCOPED catalog-entity match
+ *       admits it (sport-scoping stops a cross-sport entity — a chess event in the
+ *       city of Barcelona must not match the football club "Barcelona");
+ *   (3) any other non-broad sport (e.g. tennis) → a Norwegian / favorite /
+ *       high-importance (≥4) event stays; ai-research is NOT a blanket pass on its own;
+ *   (4) else an UNSCOPED catalog-entity match.
+ */
+export function makeCoverageGate(catalog = {}) {
+	const coveredBroadly = new Set((catalog?.tier1 || DEFAULT_TIER1_SPORTS).map((s) => s.toLowerCase()));
+	const catalogEntities = [
+		...(catalog?.tier2?.teams || []),
+		...(catalog?.tier2?.athletes || []),
+		...(catalog?.tier2?.tournaments || []),
+	];
+	return function isCovered(e) {
+		const sport = (e.sport || "").toLowerCase();
+		if (coveredBroadly.has(sport)) return true;
+		const hay = coverageHaystack(e);
+		if (ENTITY_GATED_SPORTS.has(sport)) {
+			return matchInterest(hay, catalogEntities, { sport: e.sport }) != null;
+		}
+		if (e.norwegian || e.isFavorite || (e.importance || 0) >= 4) return true;
+		return matchInterest(hay, catalogEntities) != null;
+	};
+}
+
 // --- Participation normalization (WP-04) ---
 // Canonical form, enforced everywhere in the pipeline: `norwegianPlayers` and
 // `participants` are always an array of { name, ... } objects — never bare

--- a/scripts/usage-gate.js
+++ b/scripts/usage-gate.js
@@ -20,12 +20,14 @@
  * also fails/is unavailable. The decision always reports which source it used:
  * fresh | cached-fresh | cached-stale-fetch-unavailable | none.
  *
- * NB: the live read here needs CLAUDE_CODE_OAUTH_TOKEN in this step's env. Today
- * only usage-monitor.yml's step exports it; the agent workflows (research/verify/
- * scout) do not pass it to the usage-gate step, so `fetchFresh` is a no-op there
- * until a workflow change adds it — `.github/workflows/**` is a protected path,
- * out of scope for this change (see PR notes). Until then this degrades exactly
- * to the previous cached/fail-open behaviour, which is safe.
+ * NB: the live read here needs CLAUDE_CODE_OAUTH_TOKEN in this step's env. This is
+ * now wired: EVERY agent workflow's `id: usage` step exports it (same read-only
+ * secret usage-monitor.yml uses), so `fetchFresh` performs a real fresh reading
+ * when the cached snapshot is older than FRESH_MS — the >10-min live path is live,
+ * not a no-op. Absent the token (a local run, or any future caller that omits it)
+ * `fetchFresh` is null and the gate degrades to the cached/fail-open behaviour,
+ * which is safe. (WP-110 fixed this stale comment; the token wiring itself landed
+ * with the WP-94 follow-up.)
  */
 import fs from "fs";
 import path from "path";

--- a/tests/detect-coverage-gaps.test.js
+++ b/tests/detect-coverage-gaps.test.js
@@ -12,6 +12,7 @@ import {
 	entryClaimTerms,
 	parseNorwegianDates,
 } from "../scripts/detect-coverage-gaps.js";
+import { makeCoverageGate } from "../scripts/lib/helpers.js";
 
 const NOW = Date.parse("2026-07-03T12:00:00Z");
 const interests = { alwaysTrack: { athletes: ["Viktor Hovland"], teams: ["Lyn"], tournaments: [] } };
@@ -229,6 +230,55 @@ describe("detectSourceAnomalies", () => {
 		const f1 = a.find((x) => x.sport === "f1");
 		expect(f1?.issue).toBe("dropped-in-build");
 		expect(f1?.severity).toBe("high");
+	});
+
+	// WP-110 · the catalog gate. chess/esports are entity-gated: an event the
+	// catalog never covers (a minor open with a lone club player — the "Sant Martí"
+	// class) is a LEGITIMATE build drop, so it must NOT surface as dropped-in-build.
+	// This was a chronic HIGH false positive firing every pipeline cycle.
+	describe("dropped-in-build is catalog-gated (Sant Martí false positive)", () => {
+		const catalog = {
+			tier1: ["football", "golf", "f1", "cycling"],
+			tier2: { athletes: [{ name: "Magnus Carlsen", aliases: ["Carlsen"], sport: "chess" }] },
+		};
+		const isCovered = makeCoverageGate(catalog);
+
+		it("does NOT flag an uncovered entity-gated chess event the build correctly drops", () => {
+			const s = healthy();
+			// A minor Norwegian chess open, one club player, no catalog entity — the
+			// build's isCovered drops it, so it is not a source anomaly. (Source-file
+			// events carry no `sport` field; the gate forces it from the file key.)
+			s.chess = { tournaments: [{ events: [{
+				title: "Round 6 – XXVI Obert Internacional Sant Martí 2026",
+				time: "2026-07-05T10:00:00Z",
+				norwegian: true,
+				participants: [{ name: "Johan-Sebastian Christiansen" }],
+			}] }] };
+			const board = boardWithAll().filter((e) => e.sport !== "chess");
+			const a = detectSourceAnomalies({ sources: s, events: board, isCovered, now: NOW });
+			expect(a.find((x) => x.sport === "chess")).toBeUndefined();
+		});
+
+		it("STILL flags a catalog-covered entity-gated event dropped from the board", () => {
+			const s = healthy();
+			// Names a tracked catalog athlete → the build should keep it, so its
+			// absence from the board is a real drop worth flagging.
+			s.chess = { tournaments: [{ events: [{
+				title: "Norway Chess 2026 – Carlsen vs Nakamura",
+				time: "2026-07-05T10:00:00Z",
+				participants: [{ name: "Magnus Carlsen" }, { name: "Hikaru Nakamura" }],
+			}] }] };
+			const board = boardWithAll().filter((e) => e.sport !== "chess");
+			const a = detectSourceAnomalies({ sources: s, events: board, isCovered, now: NOW });
+			expect(a.find((x) => x.sport === "chess")?.issue).toBe("dropped-in-build");
+		});
+
+		it("still flags a tier1 sport dropped from the board (gate is a no-op for wholesale sports)", () => {
+			const s = healthy();
+			const board = boardWithAll().filter((e) => e.sport !== "f1");
+			const a = detectSourceAnomalies({ sources: s, events: board, isCovered, now: NOW });
+			expect(a.find((x) => x.sport === "f1")?.issue).toBe("dropped-in-build");
+		});
 	});
 });
 


### PR DESCRIPTION
## WP-110 · Pipeline-vakter — sjakk-falsk-positiv katalog-gatet + kontrakter

Fjerner den kroniske HIGH-falsk-positiven i dekningsvakten og tetter tre småkontrakter (FASE 0I, bølge 1). Ingen workflow-/beskyttede-stier-endringer.

### Hva / hvorfor

**1) `detect-coverage-gaps` «dropped-in-build» er nå katalog-gatet (kjernefiksen).**
Anomalien flagget HVER time at `chess dropped-in-build HIGH` fordi kildefila `docs/data/chess.json` inneholder «XXVI Obert Internacional Sant Martí» — et entitetsgatet sjakk-event uten katalog-treff som `build-events` *med rette* dropper. Vakten sammenlignet rå kildefil mot tavla uten å spørre «dekker vi dette?», så en legitim build-drop så ut som at bygget mistet noe.
- Løsning uten drift: `isCovered`-logikken (tier1 wholesale · chess/esports sport-scopet entitetsgate · norwegian/favorite/importance≥4 · unscoped katalog-treff) er ekstrahert til **`helpers.makeCoverageGate(catalog)`**. `build-events.js` (tavle-filteret) og `detect-coverage-gaps.js` (dropped-in-build) deler nå ÉN gate — kan ikke drifte fra hverandre. `build-events` netto −50 linjer, oppførsel uendret.
- `dropped-in-build` teller nå bare kildefil-events gaten faktisk dekker (sporten tvinges fra filnavnet, slik bygget gjør). `file-empty`/`file-missing` er urørt (rå kilde-helse).
- Regresjonstester i `detect-coverage-gaps.test.js`: Sant Martí flagges ikke; et katalog-dekket sjakk-event (Carlsen) som mangler flagges fortsatt; tier1 uendret.

**2) `usage-gate.js` — utdatert kommentar oppdatert.** Kommentaren hevdet at kun `usage-monitor.yml` eksporterer `CLAUDE_CODE_OAUTH_TOKEN`, så live-avlesningen var no-op i agentene. Verifisert: hvert agent-`id: usage`-steg eksporterer nå tokenet, så >10-min-live-stien er reell. Kun kommentar (ingen atferdsendring).

**3) `source-quirks` skill — ny cyclingstage.com-entry.** cyclingstage.com sitt tidsfelt er etappe-/veiskjema (départ/mål), ikke norsk sendetid — kun 3/11 enige på tid i `calibration.json` (rel. ~0.38), mens `existence` er 2/2. Kompensasjon: ta sendetid + streaming fra letour.fr / TV 2 Play, bruk cyclingstage kun for etappefakta. Følger skillens entry-format.

**4) `scout.md` + `self-repair.md` — strammet loggkontrakt.** Loggen SKAL skrives OG committes på HVER kjøring, også quiet/none (scout hoppet over ~50 % av kjøringene 18.–19.07 — en run uten committet logg ser ut som at vakttårnet sov). Scout committer selv; self-repair skriver på default-treet som workflowens «Commit run log»-steg persisterer.

### Verifisering
- `npx vitest run --maxWorkers=1` grønn: **44 filer / 647 tester** (inkl. 3 nye WP-110-regresjonstester).
- `node scripts/build-events.js && node scripts/validate-events.js` grønn (45 events, 0 feil) — refaktorert build uendret.
- Sandbox-kjøring av gap-detektoren mot dagens data (`SPORTSYNC_DATA_DIR` mot /tmp-kopi, ikke repoets `docs/data`): **chess-anomali 1→0**, `gaps`-arrayet **byte-identisk** (ignorert `detectedAt`), ingen øvrige anomalier berørt.
- Ingen `docs/data/`-endringer i commiten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
