### PR TITLE
WP-112: iOS — perf-port robust mot delt runner + deltaker-visning i agendaraden

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -116,7 +116,7 @@ mennesket, aldri av en agent.
 
 | WP-110 | Pipeline-vakter: sjakk-falsk-positiv + kontrakter | 0I | — | ⬜ |
 | WP-111 | Web: deltaker-visning + ferskhetsvakt + «Om»-lesbarhet + Zenji-headere | 0I | — | 🔬 |
-| WP-112 | iOS: perf-port-robusthet + deltaker-visning i agendaraden | 0I | — | ⬜ |
+| WP-112 | iOS: perf-port-robusthet + deltaker-visning i agendaraden | 0I | — | 🔬 |
 | WP-113 | Sikkerhet: preview-deploy-injeksjon + CI-skrivevakt (BESKYTTEDE STIER — eier merger) | 0I | — | ⬜ |
 | WP-114 | Dok-resynk etter 19.07-gjennomgangen | 0I | — | ⬜ |
 | WP-115 | iOS: in-app nyhetsbrowser (SFSafariViewController) | 0I | WP-106 | ⬜ bølge 2 |
@@ -191,6 +191,20 @@ forsøk der ALLE må feile (ekte O(n²) feiler deterministisk; runner-støy gjø
 visning, de fem predikatene og vektorene urørt). **Ikke-mål:** ingen endring i
 matching/kompilering. **Aksept:** full unit-suite grønn, 4 schemes bygger,
 13/14 vektorer bit-like, perf-suiten kjørt 3× lokalt uten flake.
+🔬 **Implementert (branch wp-112-ios-perfport-deltakere):** (1) perf-porten:
+`interleavedMinTimes` måler small+large BACK-TO-BACK per iterasjon (deler
+øyeblikkslast → forholdstallet er lastuavhengig), og ratio-sjekken kjører opptil
+3 forsøk der bare ALLE-over-tak feiler (ekte O(n²) er deterministisk hvert forsøk,
+ett runner-hikk absorberes av neste rene forsøk) — begrunnelsen står i
+testkommentaren. (2) `AgendaFormat.title(...)` tar nå `participants` og fikk
+`matchupTitle`: nøyaktig 2 ikke-tomme deltakere + generisk tittel (som ikke
+allerede navngir begge) ⇒ «Spania – Argentina», 1 eller 3+ (golffelt/CS2-
+gruppespill) beholder tittelen. `makeItem` løfter matchup-en til tittelen og
+demoter den generiske tittelen til dempet meta-linje (VM-finalen 2026 bevares);
+live-linja, widgeten og detaljarket sender også `participants` (én delt ren
+visnings-funksjon). De fem predikatene + gylne vektorene urørt. Nye tester:
+AgendaFormatTests (7 title-caser) + AgendaViewModelTests (matchup-rad + team-
+regresjonsvakt); `EventBuilder` fikk `participants`/`round`.
 
 ### WP-113 · Sikkerhet: preview-deploy-injeksjon + CI-skrivevakt (BESKYTTEDE STIER)
 **Mål:** lukk RCE-vektoren og håndhevingsgapet fra sikkerhetsgjennomgangen.

--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -598,7 +598,7 @@ final class AgendaViewModel {
             guard let id = fe.id, let event = lookup[id] else { return nil }
             return AgendaLiveRow(
                 id: id,
-                title: AgendaFormat.title(homeTeam: fe.homeTeam, awayTeam: fe.awayTeam, fallback: fe.title),
+                title: AgendaFormat.title(homeTeam: fe.homeTeam, awayTeam: fe.awayTeam, participants: fe.participants, fallback: fe.title),
                 channelLabel: AgendaFormat.channelLabel(event.streaming)
             )
         }
@@ -636,12 +636,21 @@ final class AgendaViewModel {
             // happen if a caller hand-built a FeedEvent bypassing
             // EventBridge) safely drops the row rather than crashing.
             guard let id = feedEvent.id, let event = lookup[id] else { return nil }
-            let title = AgendaFormat.title(homeTeam: feedEvent.homeTeam, awayTeam: feedEvent.awayTeam, fallback: feedEvent.title)
+            let title = AgendaFormat.title(homeTeam: feedEvent.homeTeam, awayTeam: feedEvent.awayTeam, participants: feedEvent.participants, fallback: feedEvent.title)
+            // WP-112: when a head-to-head matchup from `participants` was promoted
+            // to the title (a generic "VM-finalen 2026" → "Spania – Argentina"),
+            // keep the ORIGINAL title as the dempet context line so the competition
+            // isn't lost — otherwise the usual tournament meta. A home/away rename
+            // keeps the tournament meta (teams present → the title still changed,
+            // but that path already carries its tournament), so the promotion is
+            // detected by "no teams AND the title changed".
+            let hasTeams = !(feedEvent.homeTeam ?? "").isEmpty && !(feedEvent.awayTeam ?? "").isEmpty
+            let metaTournament = (!hasTeams && title != feedEvent.title) ? feedEvent.title : event.tournament
             return .event(AgendaEventRow(
                 id: id,
                 timeLabel: AgendaFormat.timeLabel(time: feedEvent.time, endTime: feedEvent.endTime),
                 title: title,
-                metaLabel: AgendaFormat.metaLabel(tournament: event.tournament, title: title),
+                metaLabel: AgendaFormat.metaLabel(tournament: metaTournament, title: title),
                 channelLabel: AgendaFormat.channelLabel(event.streaming),
                 isMustSee: mustSee,
                 mustWatch: mustWatch,

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -34,7 +34,7 @@ struct EventDetailSheet: View {
     private var event: Event { row.event }
 
     private var titleText: String {
-        AgendaFormat.title(homeTeam: event.homeTeam, awayTeam: event.awayTeam, fallback: event.title)
+        AgendaFormat.title(homeTeam: event.homeTeam, awayTeam: event.awayTeam, participants: event.participants, fallback: event.title)
     }
 
     var body: some View {

--- a/ios/Sportivista/Feed/AgendaFormat.swift
+++ b/ios/Sportivista/Feed/AgendaFormat.swift
@@ -67,13 +67,38 @@ enum AgendaFormat {
     // MARK: - "Hva" — the title column
 
     /// Team-vs-team events read as "Home – Away" (en dash, matching
-    /// dashboard.js's eventTitle); anything else (golf, chess, a stage race
-    /// stage, …) falls back to the event's own title.
-    static func title(homeTeam: String?, awayTeam: String?, fallback: String) -> String {
-        guard let home = homeTeam, !home.isEmpty, let away = awayTeam, !away.isEmpty else {
-            return fallback
+    /// dashboard.js's eventTitle). An event that instead carries a two-sided
+    /// `participants` matchup but no home/away teams (the AI-research
+    /// head-to-head shape — "VM-finalen 2026" with participants Spania/Argentina)
+    /// reads as the matchup itself, but ONLY when the title is GENERIC (does not
+    /// already name both sides). Anything else — golf and other many-sided fields,
+    /// a single-entry stage-race participant, chess — falls back to the event's
+    /// own title (a field of names must never become a list). Pure display: the
+    /// five feed predicates and the golden vectors never see this.
+    static func title(homeTeam: String?, awayTeam: String?, participants: [Participant] = [], fallback: String) -> String {
+        if let home = homeTeam, !home.isEmpty, let away = awayTeam, !away.isEmpty {
+            return "\(home) – \(away)"
         }
-        return "\(home) – \(away)"
+        if let matchup = matchupTitle(participants: participants, title: fallback) {
+            return matchup
+        }
+        return fallback
+    }
+
+    /// "A – B" when `participants` is EXACTLY a two-sided matchup of non-empty
+    /// names that the generic `title` does not already carry — else nil (not a
+    /// head-to-head, or the title already names both sides). Head-to-head only:
+    /// one participant, or three-plus (a golf field, a CS2 group stage), is never
+    /// a matchup, so the many-participant case keeps the event's own title.
+    static func matchupTitle(participants: [Participant], title: String) -> String? {
+        guard participants.count == 2 else { return nil }
+        let names = participants.map { $0.name.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+        guard names.count == 2 else { return nil }
+        // Title already names both sides → it isn't generic; keep the richer title.
+        if names.allSatisfy({ title.range(of: $0, options: .caseInsensitive) != nil }) {
+            return nil
+        }
+        return "\(names[0]) – \(names[1])"
     }
 
     /// The quiet meta line under the title (DESIGN.md "Radens anatomi":

--- a/ios/Sportivista/Widget/WidgetTimelineBuilder.swift
+++ b/ios/Sportivista/Widget/WidgetTimelineBuilder.swift
@@ -95,7 +95,7 @@ enum WidgetTimelineBuilder {
                 date: tick,
                 hasHighlight: true,
                 timeLabel: AgendaFormat.timeLabel(time: hit.feed.time, endTime: hit.feed.endTime),
-                title: AgendaFormat.title(homeTeam: hit.feed.homeTeam, awayTeam: hit.feed.awayTeam, fallback: hit.feed.title),
+                title: AgendaFormat.title(homeTeam: hit.feed.homeTeam, awayTeam: hit.feed.awayTeam, participants: hit.feed.participants, fallback: hit.feed.title),
                 channelLabel: AgendaFormat.channelLabel(hit.event.streaming),
                 isMustSee: FeedCompiler.isMustSee(hit.feed, interests: interests)
             )

--- a/ios/SportivistaTests/AgendaFormatTests.swift
+++ b/ios/SportivistaTests/AgendaFormatTests.swift
@@ -60,6 +60,66 @@ final class AgendaFormatTests: XCTestCase {
         XCTAssertEqual(AgendaFormat.title(homeTeam: "Lyn", awayTeam: nil, fallback: "Lyn – Sogndal"), "Lyn – Sogndal")
     }
 
+    // MARK: - title with head-to-head participants (WP-112 — the "VM-finale" hole)
+
+    func testTitle_twoParticipantsGenericTitle_isMatchup() {
+        // The VM-finale shape: participants Spania/Argentina under a generic
+        // "VM-finalen 2026", no home/away teams → the matchup becomes the title.
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: nil, awayTeam: nil, participants: [Participant(name: "Spania"), Participant(name: "Argentina")], fallback: "VM-finalen 2026"),
+            "Spania – Argentina"
+        )
+    }
+
+    func testTitle_teamsWinOverParticipants() {
+        // Explicit home/away teams still take precedence over participants.
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: "Lyn", awayTeam: "Sogndal", participants: [Participant(name: "A"), Participant(name: "B")], fallback: "irrelevant"),
+            "Lyn – Sogndal"
+        )
+    }
+
+    func testTitle_singleParticipant_keepsTitle() {
+        // A lone participant (a cycling team entry) is NOT a head-to-head.
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: nil, awayTeam: nil, participants: [Participant(name: "Uno-X Mobility")], fallback: "Arctic Race of Norway 2026"),
+            "Arctic Race of Norway 2026"
+        )
+    }
+
+    func testTitle_manyParticipants_keepsTitle_neverANameList() {
+        // A four-team CS2 group stage (or a golf field) must never become a name
+        // list — the many-participant case keeps the event's own title.
+        let field = [Participant(name: "Team Vitality"), Participant(name: "Natus Vincere"), Participant(name: "FaZe Clan"), Participant(name: "Team Falcons")]
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: nil, awayTeam: nil, participants: field, fallback: "Esports World Cup 2026 – CS2 (gruppespill)"),
+            "Esports World Cup 2026 – CS2 (gruppespill)"
+        )
+    }
+
+    func testTitle_titleAlreadyNamesBothSides_keepsTitle() {
+        // A non-generic title that already carries both names is left alone (no
+        // redundant re-write, keeps any extra framing the title adds).
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: nil, awayTeam: nil, participants: [Participant(name: "Spania"), Participant(name: "Argentina")], fallback: "Spania mot Argentina (finale)"),
+            "Spania mot Argentina (finale)"
+        )
+    }
+
+    func testTitle_participantWithEmptyName_notTreatedAsMatchup() {
+        // A malformed pair with an empty side is not a matchup → keep the title.
+        XCTAssertEqual(
+            AgendaFormat.title(homeTeam: nil, awayTeam: nil, participants: [Participant(name: "Spania"), Participant(name: "   ")], fallback: "VM-finalen 2026"),
+            "VM-finalen 2026"
+        )
+    }
+
+    func testMatchupTitle_directHelper() {
+        XCTAssertEqual(AgendaFormat.matchupTitle(participants: [Participant(name: "Spania"), Participant(name: "Argentina")], title: "VM-finalen 2026"), "Spania – Argentina")
+        XCTAssertNil(AgendaFormat.matchupTitle(participants: [Participant(name: "Spania")], title: "Noe"))
+        XCTAssertNil(AgendaFormat.matchupTitle(participants: [], title: "Noe"))
+    }
+
     // MARK: - metaLabel (the quiet second line, "ved behov")
 
     func testMetaLabel_tournamentDistinctFromTitle_isShown() {

--- a/ios/SportivistaTests/AgendaMatchingPerfTests.swift
+++ b/ios/SportivistaTests/AgendaMatchingPerfTests.swift
@@ -75,21 +75,42 @@ final class AgendaMatchingPerfTests: XCTestCase {
         return events
     }
 
-    /// Best-of-`iterations` wall time for one `buildSections` (min discards
-    /// scheduler noise — the standard way to read a micro-benchmark).
-    private func minBuildSectionsTime(events: [Event], index: EntityIndex, iterations: Int = 5) -> TimeInterval {
+    /// Wall time for ONE `buildSections`, asserting the fixture compiled.
+    private func oneBuildSectionsTime(events: [Event], index: EntityIndex, interests: Interests) -> TimeInterval {
+        let start = DispatchTime.now().uptimeNanoseconds
+        let sections = AgendaViewModel.buildSections(
+            events: events, interests: interests, now: Self.now, index: index, followedIds: []
+        )
+        let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
+        XCTAssertFalse(sections.isEmpty, "the synthetic fixture must compile into a non-empty board")
+        return elapsed
+    }
+
+    /// One scale to benchmark — its events + the matching index.
+    private struct Scale { let events: [Event]; let index: EntityIndex }
+
+    /// Best-of-`iterations` wall times for the small and large scales, measured
+    /// **INTERLEAVED**: within each iteration the small compile is timed and then
+    /// IMMEDIATELY the large one, and `min` is taken per scale across iterations
+    /// (min discards scheduler noise — the standard way to read a micro-benchmark).
+    ///
+    /// Why interleave instead of two separate 5-iteration blocks (the WP-61
+    /// original): on a SHARED CI runner a burst of neighbour load can land during
+    /// one measurement block and not the other, inflating only that block's `min`
+    /// and skewing the ratio. Timing both scales back-to-back each iteration makes
+    /// them share the same instantaneous machine state, so transient load lifts
+    /// BOTH and the ratio stays honest — while a genuine O(n²) regression makes
+    /// the large scale ~4× the small in EVERY iteration regardless of load. (See
+    /// the 19.07 incident documented in the ratio test below.)
+    private func interleavedMinTimes(small: Scale, large: Scale, iterations: Int = 5) -> (small: TimeInterval, large: TimeInterval) {
         let interests = Interests(followBroadly: ["football"])
-        var best = Double.infinity
+        var bestSmall = Double.infinity
+        var bestLarge = Double.infinity
         for _ in 0..<iterations {
-            let start = DispatchTime.now().uptimeNanoseconds
-            let sections = AgendaViewModel.buildSections(
-                events: events, interests: interests, now: Self.now, index: index, followedIds: []
-            )
-            let elapsed = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
-            XCTAssertFalse(sections.isEmpty, "the synthetic fixture must compile into a non-empty board")
-            best = min(best, elapsed)
+            bestSmall = min(bestSmall, oneBuildSectionsTime(events: small.events, index: small.index, interests: interests))
+            bestLarge = min(bestLarge, oneBuildSectionsTime(events: large.events, index: large.index, interests: interests))
         }
-        return best
+        return (bestSmall, bestLarge)
     }
 
     // MARK: - The O(n²) guard (machine-independent)
@@ -99,28 +120,50 @@ final class AgendaMatchingPerfTests: XCTestCase {
         // roughly doubles the time. A regression to the per-name scan makes it
         // O(events × entities): the 2× scale would ~QUADRUPLE. The 3.0 ceiling
         // sits above linear-plus-noise and well below the ~4× of a quadratic.
-        let smallEvents = makeEvents(eventCount: 250, entityCount: 1_000)
-        let smallIndex = makeIndex(entityCount: 1_000)
-        let largeEvents = makeEvents(eventCount: 500, entityCount: 2_000)
-        let largeIndex = makeIndex(entityCount: 2_000)
+        let small = Scale(events: makeEvents(eventCount: 250, entityCount: 1_000), index: makeIndex(entityCount: 1_000))
+        let large = Scale(events: makeEvents(eventCount: 500, entityCount: 2_000), index: makeIndex(entityCount: 2_000))
 
         // Warm caches / JIT-equivalent first pass, then measure.
-        _ = minBuildSectionsTime(events: smallEvents, index: smallIndex, iterations: 1)
-        _ = minBuildSectionsTime(events: largeEvents, index: largeIndex, iterations: 1)
+        _ = interleavedMinTimes(small: small, large: large, iterations: 1)
 
-        let small = minBuildSectionsTime(events: smallEvents, index: smallIndex)
-        let large = minBuildSectionsTime(events: largeEvents, index: largeIndex)
-        let ratio = large / max(small, 1e-9)
-
-        print("WP-61 buildSections: small(250ev/1000ent)=\(String(format: "%.2f", small * 1000)) ms, large(500ev/2000ent)=\(String(format: "%.2f", large * 1000)) ms, ratio=\(String(format: "%.2f", ratio))")
-
-        XCTAssertLessThan(ratio, 3.0, "doubling scale must stay ~linear (got \(String(format: "%.2f", ratio))×) — a quadratic regression in matching would be ~4×")
-        // Generous absolute sanity cap so a catastrophic regression fails even if
-        // the ratio test somehow doesn't. The tight < 50 ms acceptance target is
-        // read from the printed figure above and documented in the PR (a hard
-        // 50 ms CI assertion would flake under concurrent xcodebuild load).
-        XCTAssertLessThan(large, 0.15, "scaled compile ran in \(String(format: "%.1f", large * 1000)) ms — far above the < 50 ms target, likely a matching regression")
+        // Robustness on a SHARED runner (19.07 incident): CI read a spurious
+        // 6.03× ratio on byte-identical code that measured 2.26× locally — the
+        // runner was 2.3× slower AND a load burst fell between the two separate
+        // sequential measurement blocks the WP-61 original used. Two changes make
+        // the guard immune WITHOUT weakening the O(n²) catch: (a) each measurement
+        // is now INTERLEAVED (see `interleavedMinTimes`), so both scales share the
+        // same instantaneous load and the ratio is load-independent; and (b) the
+        // ratio check runs up to `maxAttempts` times and only FAILS when EVERY
+        // attempt breaches the ceiling. A real quadratic regression is
+        // deterministic — it breaches on every attempt — whereas a one-off runner
+        // hiccup that skews a single attempt is absorbed by the next clean one.
+        let maxAttempts = 3
+        let ceiling = 3.0
+        var attempts: [(small: TimeInterval, large: TimeInterval, ratio: Double)] = []
+        for attempt in 1...maxAttempts {
+            let (s, l) = interleavedMinTimes(small: small, large: large)
+            let ratio = l / max(s, 1e-9)
+            attempts.append((s, l, ratio))
+            print("WP-61 buildSections attempt \(attempt)/\(maxAttempts): small(250ev/1000ent)=\(ms(s)) ms, large(500ev/2000ent)=\(ms(l)) ms, ratio=\(fmt(ratio))")
+            if ratio < ceiling {
+                // A clean attempt clears the guard — stop retrying. Also read the
+                // generous absolute sanity cap off this clean attempt so a
+                // catastrophic regression fails even if the ratio somehow doesn't.
+                // The tight < 50 ms acceptance target is read from the printed
+                // figure and documented in the PR (a hard 50 ms CI assertion would
+                // flake under concurrent xcodebuild load).
+                XCTAssertLessThan(l, 0.15, "scaled compile ran in \(ms(l)) ms — far above the < 50 ms target, likely a matching regression")
+                return
+            }
+        }
+        // Every attempt breached the ceiling → a real, deterministic regression,
+        // not runner noise (which would have produced at least one clean attempt).
+        let last = attempts[maxAttempts - 1]
+        XCTFail("doubling scale stayed above the ~linear ceiling on all \(maxAttempts) attempts (last \(fmt(last.ratio))×, small=\(ms(last.small)) ms large=\(ms(last.large)) ms) — a quadratic regression in matching would be ~4×")
     }
+
+    private func ms(_ seconds: TimeInterval) -> String { String(format: "%.2f", seconds * 1000) }
+    private func fmt(_ ratio: Double) -> String { String(format: "%.2f", ratio) }
 
     // MARK: - Recorded baselines (measure {})
 

--- a/ios/SportivistaTests/AgendaViewModelTests.swift
+++ b/ios/SportivistaTests/AgendaViewModelTests.swift
@@ -206,6 +206,46 @@ final class AgendaViewModelTests: XCTestCase {
         XCTAssertFalse(row.title.contains("juli"), "no date text may leak into the title")
     }
 
+    // MARK: - WP-112: head-to-head participant display (the "VM-finale" hole)
+
+    func testBuildSections_headToHeadParticipants_showsMatchupAndKeepsGenericTitleAsMeta() {
+        // The VM-finale hole: the participants (Spania/Argentina) existed in the
+        // data but a generic "VM-finalen 2026" title hid them. The row now leads
+        // with the matchup and demotes the generic title to the quiet context
+        // line, so nothing is lost. Pure display — relevance/compile untouched
+        // (FeedVectorTests is the guarantee the golden vectors stay bit-identical).
+        let now = iso("2026-07-19T08:00:00Z")
+        let event = EventBuilder.make(
+            sport: "football", title: "VM-finalen 2026", time: "2026-07-19T19:00:00Z",
+            tournament: "FIFA World Cup", streaming: [["platform": "NRK 1"]],
+            participants: ["Spania", "Argentina"], round: "Finale"
+        )
+        let interests = Interests(followBroadly: ["football"])
+
+        let sections = AgendaViewModel.buildSections(events: [event], interests: interests, now: now)
+        guard case .event(let row) = allItems(sections).first else { return XCTFail("expected one event row") }
+        XCTAssertEqual(row.title, "Spania – Argentina", "the matchup leads the row")
+        XCTAssertEqual(row.metaLabel, "VM-finalen 2026", "the generic title is preserved as the quiet context line")
+        XCTAssertEqual(row.channelLabel, "NRK 1")
+    }
+
+    func testBuildSections_teamMatch_stillUsesTournamentMeta_notPromoted() {
+        // A normal home/away team match is NOT the promoted path: the title is
+        // the teams and the meta stays the tournament (regression guard so the
+        // WP-112 meta-promotion only fires for the participant matchup case).
+        let now = iso("2026-07-13T08:00:00Z")
+        let event = EventBuilder.make(
+            sport: "football", title: "Lyn mot Sogndal", time: "2026-07-13T18:00:00Z",
+            homeTeam: "Lyn", awayTeam: "Sogndal", tournament: "Eliteserien"
+        )
+        let interests = Interests(followBroadly: ["football"])
+
+        let sections = AgendaViewModel.buildSections(events: [event], interests: interests, now: now)
+        guard case .event(let row) = allItems(sections).first else { return XCTFail("expected one event row") }
+        XCTAssertEqual(row.title, "Lyn – Sogndal")
+        XCTAssertEqual(row.metaLabel, "Eliteserien", "team matches keep the tournament meta, never the title")
+    }
+
     // MARK: - WP-14.1: the "live now" line (DESIGN.md §4)
 
     func testLiveRows_ongoingEvent_isLiveWithChannel() {

--- a/ios/SportivistaTests/EventBuilder.swift
+++ b/ios/SportivistaTests/EventBuilder.swift
@@ -26,6 +26,8 @@ enum EventBuilder {
         streaming: [[String: Any]] = [],
         norwegian: Bool = false,
         norwegianPlayers: [[String: Any]] = [],
+        participants: [String] = [],
+        round: String? = nil,
         isFavorite: Bool = false,
         importance: Int? = nil,
         source: String? = nil,
@@ -45,6 +47,8 @@ enum EventBuilder {
         if let tournament { dict["tournament"] = tournament }
         if !streaming.isEmpty { dict["streaming"] = streaming }
         if !norwegianPlayers.isEmpty { dict["norwegianPlayers"] = norwegianPlayers }
+        if !participants.isEmpty { dict["participants"] = participants.map { ["name": $0] } }
+        if let round { dict["round"] = round }
         if let importance { dict["importance"] = importance }
         if let source { dict["source"] = source }
         if let confidence { dict["confidence"] = confidence }


### PR DESCRIPTION
## WP-112 · FASE 0I bølge 1

To ting, begge iOS-side.

### 1. Perf-porten robust mot delt runner
`AgendaMatchingPerfTests.test_buildSections_scalesLinearly_notQuadratically` feilet falskt på main 19.07: CI målte 6,03× på byte-identisk kode som målte 2,26× lokalt (rød runner 2,3× tregere; small- og large-blokkene ble målt sekvensielt, så vedvarende nabolast mellom blokkene sprengte ratioen).

Fikset UTEN å svekke O(n²)-vakten:
- **Interleaving** — `interleavedMinTimes` måler small + large BACK-TO-BACK per iterasjon, så begge skalaer deler samme øyeblikkslast. Forbigående last løfter BEGGE → forholdstallet er lastuavhengig. `min` per skala over 5 iterasjoner.
- **3-forsøks-retry** — ratio-sjekken kjøres opptil 3 ganger; testen feiler bare når ALLE forsøk bryter 3,0-taket. Ekte kvadratisk regresjon er deterministisk (bryter hvert forsøk); et enkelt runner-hikk absorberes av neste rene forsøk.
- Begrunnelsen (inkl. 19.07-hendelsen) står i testkommentaren.

**Lokalt, 3 kjøringer sekvensielt:** ratio **2,13 / 2,14 / 2,15** — alle rene på forsøk 1, ingen flake. Large-skala ~15 ms (≪ 50 ms-målet).

### 2. Deltaker-visning i agendaraden (VM-finale-hullet)
`events.json` hadde f.eks. VM-finalen med `participants: [Spania, Argentina]` men appen viste bare «VM-finalen 2026».

- `AgendaFormat.title(...)` tar nå `participants`; ny `matchupTitle`: **nøyaktig 2** ikke-tomme deltakere under en **generisk** tittel (som ikke allerede navngir begge) ⇒ «Spania – Argentina». 1 eller 3+ deltakere (golffelt, CS2-gruppespill) beholder tittelen — **aldri en navneliste**.
- `makeItem` løfter matchup-en til tittelen og demoter den generiske tittelen til den dempede meta-linja (VM-finalen 2026 bevares, ingenting går tapt). Team-kamper (home/away) beholder turnering-metaen — regresjonsvakt i test.
- Live-linja, widgeten og detaljarket sender også `participants` (én delt, ren visnings-funksjon).
- **Ren VISNING:** de fem FeedCompiler-predikatene og de gylne vektorene er urørt (bit-like).

### Verifisering (ios-dev-matrisen)
- **iOS unit-suite:** 582 tester grønne (1 skip), 0 feil — inkl. FeedVectorTests (vektorer bit-like) + de nye title/rad-testene.
- **4 schemes bygger:** Sportivista (test), SportivistaWidgetExtension, SportivistaUITests, SportivistaDeviceDev — alle BUILD/TEST SUCCEEDED.
- **Perf-suiten 3× lokalt:** 2,13 / 2,14 / 2,15, ingen flake.
- **JS:** `npx vitest run --maxWorkers=1` — 44 filer / 628 tester grønne (urørt).

### Tester
7 nye `AgendaFormat`-title-caser, matchup-rad + team-regresjonsvakt i `AgendaViewModelTests`, `participants`/`round` lagt til `EventBuilder`.

PLAN.md WP-112 ⬜→🔬 (union-merge bevarte WP-111s 🔬).

🤖 Generated with [Claude Code](https://claude.com/claude-code)