### PR TITLE
WP-114: dok-resynk — CLAUDE.md/ios-README/PLAN-metadata + workflows-koherens ×4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ autopilot, pipeline manifest) with a **lean, reliable design** built on one idea
 Four priorities, in order:
 1. **Correct, complete data** — especially events that static APIs miss
 2. **Dynamic AI research** — scheduled agents with web search find and verify events
-3. **Calm dashboard** — one quiet single-column agenda (max 640px), near-black dark default, PWA
+3. **Calm dashboard** — one quiet single-column agenda (max 640px), true-black dark default, PWA
 4. **Transparent tracking** — AI decides what to track and writes human-readable
    `tracked.json` with a defensible `reason` per entry
 
@@ -64,6 +64,15 @@ Nine workflows run `anthropics/claude-code-action@v1` with a prompt file:
 | **self-repair** | `scripts/agents/self-repair.md` | `claude-opus-4-8` | daily 06:30 UTC | The mechanic: detect real breakage (failed runs, failing tests, validation errors, broken fetchers), fix ON A BRANCH, prove it, open a PR. Workflow re-gates tests and **auto-merges + deploys** — EXCEPT the three protected paths below, which are left open for review. Ignores quota/transient failures |
 | **improve** | `scripts/agents/improve.md` | `claude-opus-4-8` | weekly Mon 07:00 UTC | Evolution: mine the logs for ONE evidenced improvement (source/skill/prompt/threshold/fetcher tuning), open a PR. Workflow re-gates tests and **auto-merges** it (except protected paths). Biased toward sharpening what exists over adding machinery (the v1 lesson) |
 
+### CI, test-gate & release workflows (PR/tag-triggered, no AI)
+
+Beyond the two kinds of scheduled work above, four non-agent workflows back the automation but run no prompt:
+
+- **`ci.yml`** — the universal web test-gate: `npm ci && npm test` (the full vitest suite) on every PR, plus pushes to `main` that touch `scripts/`/`tests/`/`docs/js/`/`package*.json`/`vitest.config.js`. This is the required check (`web-tests`) branch protection enforces; before it existed only the self-fixing loops re-ran the tests (inside `merge-gate.js`) — human/main-loop PRs had no machine gate at all.
+- **`ios-tests.yml`** — the always-reporting iOS test-gate: the Swift unit suite (hostless bundles via the `Sportivista` scheme, incl. the golden vectors that pin JS↔Swift bit-identically) on PRs touching `ios/`. A cheap `detect` job self-skips the macOS job when `ios/` is untouched, so the required check (`ios-tests`) is satisfied without ever standing "expected" forever. macOS runners are free on the public repo; secretless (simulator tests don't sign — `CODE_SIGNING_ALLOWED=NO` is the project default); UI tests run elsewhere (local/agent-driven).
+- **`ios-release.yml`** — the TestFlight release lane (WP-17): from a clean checkout it archives, cloud-signs, and uploads the app to App Store Connect, then records the upload (`scripts/record-testflight.js`; build number from `scripts/next-testflight-build.js` — ASC is the source of truth) and kicks the static pipeline to publish `app-version.json`. Manual (`workflow_dispatch`) or an `ios-v*` tag; needs the three `ASC_*` secrets from an **ADMIN** ASC key (App Manager can't cloud-sign).
+- **`preview-deploy.yml`** — the GitHub Pages deploy (`concurrency: pages-deploy`, never cancel-in-progress): assembles `_site` from `main` plus a `/preview/<branch>/` copy per open PR, then deploys. Triggered by a push to `main` under `docs/**`, by `workflow_call` (how the static pipeline auto-publishes — a `GITHUB_TOKEN` push can't fire the `push` path), by `repository_dispatch`, or manually. Deliberately **not** on `pull_request` (that raced the shared concurrency group → "Deployment failed, try again later").
+
 ### Autonomy model (what ships unattended)
 
 The self-fixing loops (ui-fix, self-repair, improve) each fix on a branch, open a
@@ -88,7 +97,7 @@ commit; a test failure leaves the PR open and fails the run loudly.
 Claude Code Max quota is finite and shared with interactive use. Two mechanisms keep the agents from silently dying when it runs low:
 
 - **Tiered model + deep-tier fallback** — the 4-hourly workhorse runs on `claude-opus-4-8` (`standard` tier): Opus is always available on this OAuth tier, so the action's exit status is trustworthy and there is **no commit-detection heuristic** — a quiet run that finds nothing new is a legitimate no-op, not a failure. The `deep` tier (escalations + weekly sweep) prefers `claude-fable-5`, detects if it produced no commit (unavailable / weekly-quota exhausted — Fable error-reports as job success), and re-runs on `claude-opus-4-8`. Quota exhaustion is handled by `usage-gate.js` (below), **not** by failing on no-commit — so the deep tier does not fail loudly on a quiet run either. (History: an earlier design tried Fable 5 on every run and failed loudly on no-commit; that produced a ~50% false-failure rate — a no-op was misread as quota death. Fable 5 is in fact available on this tier when weekly quota is not exhausted.)
-- **`usage-monitor.yml`** (hourly, no prompt) — runs `scripts/check-usage.js`, which reads REAL account-wide quota. There is no supported quota API for a Max OAuth token, but a **minimal `/v1/messages` call with `CLAUDE_CODE_OAUTH_TOKEN` returns the `anthropic-ratelimit-unified-*` headers** (5h + 7d utilization, reset epochs, allowed/allowed_warning/rejected). It writes `usage-state.json` (green/amber/red + skipAll/skipNiceToHave), **appends the reading to `usage-history.jsonl`** (append-only, trimmed to ~100 days), and rolls that into **`usage-summary.json`** (latest + 24h trend + 7d/30d peak/avg week utilization + hours spent conserving). It then runs `scripts/update-readme-status.js`, which regenerates the **AI-budsjett block in `README.md`** (between `<!-- STATUS:START/END -->` markers) — budget/ops lives in the repo README, not on the calm dashboard. NB: the headers are **account-wide** (shared with interactive use) — this is total quota pressure, not per-agent attribution. The `improve` agent mines `usage-summary.json` (+ `gh run list` for per-agent frequency) to tune schedules/thresholds to the budget.
+- **`usage-monitor.yml`** (hourly 05–22 UTC, cron `20 5-22`, no prompt) — runs `scripts/check-usage.js`, which reads REAL account-wide quota. There is no supported quota API for a Max OAuth token, but a **minimal `/v1/messages` call with `CLAUDE_CODE_OAUTH_TOKEN` returns the `anthropic-ratelimit-unified-*` headers** (5h + 7d utilization, reset epochs, allowed/allowed_warning/rejected). It writes `usage-state.json` (green/amber/red + skipAll/skipNiceToHave), **appends the reading to `usage-history.jsonl`** (append-only, trimmed to ~100 days), and rolls that into **`usage-summary.json`** (latest + 24h trend + 7d/30d peak/avg week utilization + hours spent conserving). It then runs `scripts/update-readme-status.js`, which regenerates the **AI-budsjett block in `README.md`** (between `<!-- STATUS:START/END -->` markers) — budget/ops lives in the repo README, not on the calm dashboard. NB: the headers are **account-wide** (shared with interactive use) — this is total quota pressure, not per-agent attribution. The `improve` agent mines `usage-summary.json` (+ `gh run list` for per-agent frequency) to tune schedules/thresholds to the budget.
 - **Gate** — every agent runs `scripts/usage-gate.js <critical|optional>` as a pre-flight step and only proceeds `if: steps.usage.outputs.run == 'true'`. `critical` (research, verify, scout) skip only when `skipAll` (session near-exhausted / rejected); `optional` (editorial, coverage-critic, visual-qa, **and the self-fixing loops ui-fix, self-repair, improve**) also skip when amber/red. **Fail-open**: missing/stale (>3h)/unparsed state ⇒ run. The dashboard shows a quiet "AI-budsjett" line from `usage-state.json`.
 
 ### Coverage & correctness loops (the core mission)
@@ -163,16 +172,19 @@ no dashboard grid, no competing panels.
 
 **`DESIGN.md` is the normative UI contract** for every surface. Any agent or human
 changing UI reads it first and never deviates without an explicit owner instruction.
-It is now an **Apple-native baseline** (semantic system colours, Dynamic Type, SF
-Symbols, amber as the one accent) that the **iOS app + widget follow**; **web
-(`docs/`) is the deliberate exception until the rebrand** and keeps the v2 **Tekst-TV**
-identity (teletext-rooted): a monospace type stack, amber as the single accent, a
-near-black page, quantized/flat/honest — never faux-analog. The web values below must
-stay verifiable against `base.css`; DESIGN.md is the source of intent behind them.
+It is an **Apple-native baseline** (semantic system colours, Dynamic Type, SF
+Symbols, amber as the one accent) that **every surface now follows** — the iOS app +
+widget and, since the 18.07 reskin (commit `1a5e89d31`), the web (`docs/`) too. **The
+old Tekst-TV exception is CLOSED** (DESIGN.md § Cross-surface, lines 290–297): the
+teletext-rooted identity (a monospace type stack, near-black `#0A0A0C` page, warm
+paper) is retired. Web keeps its own layout details (one column max 640px, the
+day-grouped agenda, the ticking amber clock in the header) but its colours and type
+are now the baseline. The web values below must stay verifiable against `base.css`;
+DESIGN.md is the source of intent behind them.
 
-- `docs/index.html` — shell: header (wordmark · date · theme toggle), one quiet editorial headline line, live-now line (conditional), the agenda, "Hva vi følger" disclosure, footer. `docs/rediger.html` — the follow-request page (see below); `docs/activity.html` — the ops/activity view.
-- `docs/css/` — `base.css` (calm tokens: near-black dark default `#0A0A0C`, warm-paper light `#F5F1E6` via prefers-color-scheme; amber `#FFB000` as the ONLY accent; a **monospace type stack** — `ui-monospace, "SF Mono", Menlo, …` — with tabular numerals; max-width 640px, fixed 120px time column), `layout.css` (single centered column, all breakpoints), `cards.css` (agenda rows, day groups)
-- `docs/js/` — the `Dashboard` class is split along its seams across a shared prototype (window-global, no build step): `dashboard.js` (~446 lines: lifecycle + hero + the day-grouped agenda), `live.js` (ESPN live polling, 60s), `detail.js` (expand/detail + AI-provenance modal), `followed.js` ("Hva vi følger" disclosure), `chrome.js` (clock/date/footer/usage/install-hint). `theme.js` is the shared 3-step theme toggle (system → dark → light) used on all pages; `shared-constants.js` holds shared utilities (time windows, escaping, name matching) that mirror the server helpers; `edit.js` drives `rediger.html`.
+- `docs/index.html` — shell: header (wordmark · date · theme toggle), one quiet editorial headline line, live-now line (conditional), the agenda, "Dette dekker vi" disclosure, footer. `docs/rediger.html` — the follow-request page (see below); `docs/activity.html` — the ops/activity view.
+- `docs/css/` — `base.css` (Apple-native tokens: true-black dark default `#000000` (cell `#1C1C1E`), grouped-light `#F2F2F7` (cell `#FFFFFF`) via prefers-color-scheme; amber `#FFB000` dark / `#9A6800` light as the ONLY accent; the **system font stack** — `-apple-system, BlinkMacSystemFont, "SF Pro Text", …` — with tabular numerals opted in where digits must align; max-width 640px, fixed 120px time column), `layout.css` (single centered column, all breakpoints), `cards.css` (agenda rows, day groups)
+- `docs/js/` — the `Dashboard` class is split along its seams across a shared prototype (window-global, no build step): `dashboard.js` (~456 lines: lifecycle + hero + the day-grouped agenda), `live.js` (ESPN live polling, 60s), `detail.js` (expand/detail + AI-provenance modal), `followed.js` ("Dette dekker vi" disclosure), `chrome.js` (clock/date/footer/usage/install-hint). `theme.js` is the shared 3-step theme toggle (system → dark → light) used on all pages; `shared-constants.js` holds shared utilities (time windows, escaping, name matching) that mirror the server helpers; `edit.js` drives `rediger.html`.
 - Each event row answers only: **when · what · where to watch**. Must-see (favorite / importance≥4 / Norwegian) gets a small accent dot — the gentlest possible emphasis, never a card. Channel shown quietly, with an honest faint "–" when unknown.
 - The editorial agent produces a single `headline` block shown as one quiet line under the date (a "nice extra"), nothing more. AI-research events carry a small ⓘ that opens a source modal on tap.
 
@@ -183,6 +195,7 @@ stay verifiable against `base.css`; DESIGN.md is the source of intent behind the
 `coverage-gaps.json`, `coverage-audit.json` (coverage-critic), `visual-qa-log.json` (visual-qa),
 `ui-fix-log.json` (ui-fix), `self-repair-log.json` (self-repair), `improve-log.json` (improve),
 `usage-state.json` + `usage-history.jsonl` + `usage-summary.json` (quota governor: snapshot, append-only history, digest),
+`build-alert.json` (build-events health signal, written every run with `ok: true/false` — WP-94's degrade-gracefully gate keeps the previous good `events.json` on a schema/contract break instead of publishing a bad one, and records the violation here for self-repair; clears automatically on the next clean build),
 `scout-log.json`, `calibration.json` + `calibration-ledger.jsonl`, `tv-listings.json`,
 `entities.json` (stable-id index of known athletes/teams/tournaments/leagues, published by `build-entities.js`; `build-events.js` uses it to stamp `entityId` onto matched events),
 `news.json` (lens-ready news pointers — `id`/`title`/`link`/`source`/`sport`/`entityIds`/`publishedAt`, NEVER article text — built from `rss-digest.json` × the entity index by `scripts/lib/news.js` and published by `build-events.js`; dedupe-on-link, cap ~100 items / 7 days, byte-idempotent; the client lens-filters on `entityIds`/`sport` per profile),
@@ -197,10 +210,11 @@ by default) or the agents' `git add` silently skips them.
 ### Companion docs & the iOS app
 
 - **`DESIGN.md`** — the **normative design contract** for every surface: tokens,
-  type, layout laws. The iOS app + widget follow the **Apple-native baseline**
-  (semantic system colours + Dynamic Type); web (`docs/`) keeps the **Tekst-TV**
-  identity until the rebrand (the deliberate exception). Agents that touch UI read it
-  first; it is verified value-for-value against the code and is *not* freely rewritten.
+  type, layout laws. **Every surface now follows the Apple-native baseline**
+  (semantic system colours + Dynamic Type) — the iOS app + widget and, since the
+  18.07 reskin, the web (`docs/`) too (the Tekst-TV exception is closed). Agents that
+  touch UI read it first; it is verified value-for-value against the code and is *not*
+  freely rewritten.
 - **`PLAN.md`** — the commercialization/execution backlog (phases, work packages,
   gates). Long-horizon planning lives here, not in this file; consult it for what's
   queued/in-flight and update the relevant WP status row when you complete one.
@@ -223,7 +237,7 @@ matrisen per flate). Les den relevante FØR du planlegger/bygger.
 - `npm run build` — fetch data + build events + calendar
 - `npm run build:events` / `npm run validate:data` / `npm run build:calendar`
 - `npm run fetch:results`
-- `npm test` — vitest, 36 focused files (~470 tests), a few seconds
+- `npm test` — vitest, 44 focused files (648 tests), a few seconds
 - `npm run screenshot` — Playwright dashboard screenshot (`node scripts/screenshot.js out.png --width=1280 --full-page`)
 
 ## Conventions
@@ -236,12 +250,12 @@ matrisen per flate). Les den relevante FØR du planlegger/bygger.
 
 ## Testing
 
-`tests/` — 36 files / ~470 tests, all fast and network-free:
-- Pipeline: `build-events`, `build-events-schema`, `events-schema`, `validate-events`, `build-ics`, `build-entities`, `build-manifest`, `detect-coverage-gaps`, `aggregate-calibration`, `integration-pipeline` (spawn scripts against temp `SPORTSYNC_DATA_DIR`/`SPORTSYNC_CONFIG_DIR`)
+`tests/` — 44 files / 648 tests, all fast and network-free:
+- Pipeline: `build-events`, `build-events-schema`, `build-events-degrade` (WP-94 degrade-gracefully gate), `events-schema`, `validate-events`, `build-ics`, `build-entities`, `build-manifest`, `news` (news.json pointer build), `detect-coverage-gaps`, `aggregate-calibration`, `integration-pipeline` (spawn scripts against temp `SPORTSYNC_DATA_DIR`/`SPORTSYNC_CONFIG_DIR`)
 - Fetchers: `fetch-results`, `fetch-results-golden` (byte-identical output freeze), `fetch-rss`, `fetch-standings`, `f1-fetcher`, `esports`, `golf`
-- Libs: `helpers`, `event-normalizer`, `response-validator`, `llm-client` (mocked fetch), `tvkampen-scraper`, `pgatour-scraper`, `norwegian-rights`, `usage`, `readme-status`, `merge-gate`, `apply-follow-request`
+- Libs: `helpers`, `event-normalizer`, `response-validator`, `llm-client` (mocked fetch), `tvkampen-scraper`, `pgatour-scraper`, `norwegian-rights`, `usage`, `usage-gate` (freshness-aware skip logic), `escalate-research` (scout/coverage-critic dispatch), `app-version` (iOS «har jeg siste?» half), `asc-api` (App Store Connect release-lane client), `readme-status`, `merge-gate`, `apply-follow-request`
 - Client: `dashboard-cards` — loaded via `tests/helpers/load-client.js` (vm sandbox, no jsdom); `feed-vectors` (golden personalisation vectors, see `tests/fixtures/feed-vectors/DIVERGENCES.md`)
-- Coherence: `agent-prompts` (prompt contracts match client renderers; scans every `scripts/agents/*.md` for skill references), `workflows` (YAML references existing files), `interests-schema`, `tracked-schema`, `hooks` (the safety hooks)
+- Coherence: `agent-prompts` (prompt contracts match client renderers; scans every `scripts/agents/*.md` for skill references), `workflows` (YAML references existing files), `interests-schema`, `tracked-schema`, `catalog-schema` (the AI-managed coverage compass), `design-tokens` (`design/tokens.json` locks shipped CSS/Swift reality), `ios-dynamic-type-gate` (HIG gate: no isolated `.system(size:)` in `ios/Sportivista/`), `hooks` (the safety hooks)
 
 Coherence tests are the v2 replacement for v1's feedback loops: if a prompt, workflow,
 or schema drifts from the code, CI fails.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,4 @@
-# Zenji (tidl. SportSync) → personlig sportsfeed: implementeringsplan
+# Sportivista → personlig sportsfeed: implementeringsplan
 
 Arbeidsdokument for å delegere arbeid til agenter. Strategien («hvorfor») ligger i
 [kommersialiserings-dossieret](https://claude.ai/code/artifact/21c2971d-238a-48fe-b870-1c57218bd661)
@@ -55,7 +55,7 @@ mennesket, aldri av en agent.
 | WEB-1 | Web etter DESIGN.md (flatt radspråk) | 0B | WP-14.1 | ✅ merget (#256) |
 | WP-16 | FM-lekegrind (samtale→profil) | 0B | WP-10 | ✅ merget (#246, +16.1 #247 linse/ærlighet, +16.2 #248 fuzzy-resolver) — 152/152 iOS-tester (mot mock; FM kjøres ikke i CI) + DeviceDev bygget/signert/installert på fysisk iPhone (launch krever engangs manuell utvikler-trust på enheten) |
 | WP-16.4 | Sømløs assistent | 0B | WP-16,WP-14 | ✅ merget (#257) |
-| WP-17 | 💰 TestFlight-oppsett | 0B | WP-14 | 🔬 pågår 18.07 — Apple Developer-enrollment GODKJENT: gratis-teamet ble konvertert in place (samme team-ID 9LVCB72DT8); `app.sportivista.ios` + widget-id + App Group + iCloud-container registrert via provisjoneringsbygg; device-bygget signerer nå fulle entitlements, embedder widgeten og kompilerer med `-D SPORTIVISTA_CLOUDKIT` (CloudKitProfileSync aktiv) — installert på eierens iPhone. ✅ FULLFØRT 18.07 kveld: app-record (eier, app-id 6792373768), ASC API-nøkkel NHMW747CLA (App Manager — NB: mangler cloud-signing, distribusjonssignering går via Xcode-kontosesjonen), bygg 0.1.0 (1) arkivert + lastet opp (to valideringsfunn fikset: ITSAppUsesNonExemptEncryption, TARGETED_DEVICE_FAMILY=1 per target — #313), prosessert VALID, intern gruppe «Intern» (auto-alle-bygg) opprettet via API med eieren som tester. Eier: installer TestFlight-appen og aksepter invitasjonen. Eksterne testere: FORTSATT gatet bak grønn portmåling (WP-96-gate åpnet, portene måles). OPPFØLGER 19.07 — full CI/CD: universell web-testgate (ci.yml, npm-suiten gatet før INGEN PR-er utenom loopene), alltid-rapporterende iOS-gate (ios-tests.yml, macos-26 gratis på offentlig repo, skippes selv når ios/ er urørt), TestFlight-release-lane (ios-release.yml: ASC-styrt byggnummer, cloud-signering med Admin-nøkkel, auto-record av opplastingen), merge-gate venter på PR-sjekker, static-pipeline fetch-depth 0 (ærlig iosCommit). Håndhevings-lærdom 19.07: required checks på plattformnivå blokkerer også github-actions-botens DIREKTEPUSH (brakk release-lanens registrerings-commit; ville brukket pipelinens datacommits), og GitHub tillater ikke Actions-appen som bypass-aktør i rulesets på personlige repoer — så sjekk-håndhevingen bor i merge-gate (`gh pr checks --watch --fail-fast` før merge), som uansett er punktet alle automatiske merges går gjennom. Første lane-release (bygg 5) beviste arkiv+cloud-signering+opplasting E2E; kun registrerings-pushen røk (protection, nå fjernet — registrert manuelt). Versjonslærdommer: TestFlight viser aldri lavere versjonsstreng (1.0.x-linjen er låst inne av bygg 1–2); XcodeGen baker literal-versjoner uten $()-referanser |
+| WP-17 | 💰 TestFlight-oppsett | 0B | WP-14 | ✅ 18.07 — Apple Developer-enrollment GODKJENT: gratis-teamet ble konvertert in place (samme team-ID 9LVCB72DT8); `app.sportivista.ios` + widget-id + App Group + iCloud-container registrert via provisjoneringsbygg; device-bygget signerer nå fulle entitlements, embedder widgeten og kompilerer med `-D SPORTIVISTA_CLOUDKIT` (CloudKitProfileSync aktiv) — installert på eierens iPhone. ✅ FULLFØRT 18.07 kveld: app-record (eier, app-id 6792373768), ASC API-nøkkel NHMW747CLA (App Manager — NB: mangler cloud-signing, distribusjonssignering går via Xcode-kontosesjonen), bygg 0.1.0 (1) arkivert + lastet opp (to valideringsfunn fikset: ITSAppUsesNonExemptEncryption, TARGETED_DEVICE_FAMILY=1 per target — #313), prosessert VALID, intern gruppe «Intern» (auto-alle-bygg) opprettet via API med eieren som tester. Eier: installer TestFlight-appen og aksepter invitasjonen. Eksterne testere: FORTSATT gatet bak grønn portmåling (WP-96-gate åpnet, portene måles). OPPFØLGER 19.07 — full CI/CD: universell web-testgate (ci.yml, npm-suiten gatet før INGEN PR-er utenom loopene), alltid-rapporterende iOS-gate (ios-tests.yml, macos-26 gratis på offentlig repo, skippes selv når ios/ er urørt), TestFlight-release-lane (ios-release.yml: ASC-styrt byggnummer, cloud-signering med Admin-nøkkel, auto-record av opplastingen), merge-gate venter på PR-sjekker, static-pipeline fetch-depth 0 (ærlig iosCommit). Håndhevings-lærdom 19.07: required checks på plattformnivå blokkerer også github-actions-botens DIREKTEPUSH (brakk release-lanens registrerings-commit; ville brukket pipelinens datacommits), og GitHub tillater ikke Actions-appen som bypass-aktør i rulesets på personlige repoer — så sjekk-håndhevingen bor i merge-gate (`gh pr checks --watch --fail-fast` før merge), som uansett er punktet alle automatiske merges går gjennom. Første lane-release (bygg 5) beviste arkiv+cloud-signering+opplasting E2E; kun registrerings-pushen røk (protection, nå fjernet — registrert manuelt). Versjonslærdommer: TestFlight viser aldri lavere versjonsstreng (1.0.x-linjen er låst inne av bygg 1–2); XcodeGen baker literal-versjoner uten $()-referanser |
 | WP-18 | Linse-rendering (P320: event × deltakelse × linse) | 0B | WP-13,WP-16.1 | ✅ merget (#259, 14.07) — `LensRenderer` (Feed/, widget-trygg) + Agenda-integrasjon: golf rendres gjennom de norske du følger (tee time overstyrer tid/dag/sortering, status verbatim i meta, grasiøs degradering); de 5 predikatene urørt (13/13 gylne vektorer bit-like); 273/273 iOS-tester (+16), 373/373 JS urørt, begge schemes bygger, ZenjiDeviceDev installert; skjermbilder `ios/docs/design-v2/lens-{dark,light}.png` |
 | WP-19 | Profil-sync (P360: iCloud + QR-bro) | 0B | WP-16 | ✅ merget (#260) — 317/317 |
 | WP-30 | Personlig minne (P350) | 0B | WP-16.4,WP-19 | ✅ merget (#261) — 356/356 |
@@ -118,7 +118,7 @@ mennesket, aldri av en agent.
 | WP-111 | Web: deltaker-visning + ferskhetsvakt + «Om»-lesbarhet + Zenji-headere | 0I | — | 🔬 |
 | WP-112 | iOS: perf-port-robusthet + deltaker-visning i agendaraden | 0I | — | ⬜ |
 | WP-113 | Sikkerhet: preview-deploy-injeksjon + CI-skrivevakt (BESKYTTEDE STIER — eier merger) | 0I | — | ⬜ |
-| WP-114 | Dok-resynk etter 19.07-gjennomgangen | 0I | — | ⬜ |
+| WP-114 | Dok-resynk etter 19.07-gjennomgangen | 0I | — | 🔬 |
 | WP-115 | iOS: in-app nyhetsbrowser (SFSafariViewController) | 0I | WP-106 | ⬜ bølge 2 |
 | WP-116 | Dekningsbredde: katalog-utvidelse + deltaker-/«Om»-kontrakter i research/verify | 0I | WP-110 | ⬜ bølge 2 |
 | WP-117 | Design-review av alle flater (read-only rapport) | 0I | — | ⬜ |
@@ -337,7 +337,7 @@ DegView-raden omdøpt «Det du følger» (id `deg.follows` uendret). Event-detal
 følg assistent-fri. Tester: `SportivistaTests/FollowActionTests.swift` +
 UI-røyk `SportivistaUITests/FollowedListUITests.swift`.
 
-### WP-106 · Nyheter-v0-klienten — ⬜ (bølge 2)
+### WP-106 · Nyheter-v0-klienten — ✅
 Fyller `News/` med fire-seksjons-tavla per spec: brief (featured.json),
 NYTT (news.json linse-matchet på entityIds/sport), RESULTAT (recent-results
 bak spoiler-skjoldet), FREMOVER (events utover horisonten). Sync: news.json +
@@ -553,9 +553,9 @@ lock-in isolert til ett lag).
 
 ## FASE 0C · Flyttedagen: rebrand + repo-splitt (besluttet 13.07.2026)
 
-**Statusnote 13.07.2026:** Navnet er Zenji; eier kjøpte sportivista.com (tidl. zenji.app) og valgte å
+**Statusnote 13.07.2026:** Navnet er Zenji; eier kjøpte zenji.app og valgte å
 rename repoet umiddelbart (billigste tidspunkt — null brukere å brekke). Gjort:
-repo → `CHaerem/sportivista.com (tidl. zenji.app)`, alle serverte stier/brand-strenger oppdatert
+repo → `CHaerem/zenji.app`, alle serverte stier/brand-strenger oppdatert
 (manifest, sw.js, HTML, README, package.json). Konsekvens: **navnet er nå
 offentlig** → zenji.no/.tv bør kjøpes STRAKS; formell varemerkesjekk står
 fortsatt åpen; gamle PWA-installasjoner/ICS-abonnement på /SportSync/-URL-en er
@@ -600,7 +600,7 @@ er en ressurs i denne fasen.
 **Triggere (én holder):** (1) kommersiell lansering nærmer seg og prompts/skills
 utgjør reell konkurransefordel, (2) inntekt skaper kopist-insentiv, (3) B2B-/
 partnersamtaler krever IP-hygiene.
-**Design når den utføres (invertert etter renamen):** `sportivista.com (tidl. zenji.app)` BEHOLDES
+**Design når den utføres (invertert etter renamen):** `CHaerem/sportivista` BEHOLDES
 offentlig og strippes til kun site-innhold (`docs/`) — Pages/URL uavbrutt; nytt
 PRIVAT `zenji-engine` får motoren (agenter, prompts, quirks, fetchere, tester,
 workflows + secrets); deploy key scopet til site-repoet gir cross-repo-push av
@@ -1439,10 +1439,10 @@ Eierbeslutning (varemerke-søk utsatt, risiko akseptert av eier): repo omdøpt t
 merget til main, Pages-domene → `sportivista.com` (GoDaddy-DNS A/AAAA/CNAME via API),
 `zenji.app` kuttet som domene (auto-fornyelse skrus av — dør ved utløp 2027-07-13).
 iOS: `app.sportivista.ios`-id-er, `group.app.sportivista`, `sportivista://`, baseURL →
-`sportivista.com/data/`. Web: navnebyttet; Tekst-TV-utseendet består til egen web-reskin.
-Gjenstår: formelt varemerke-søk+registrering (eier), `sportivista.no`-forwarding (manuell,
-GoDaddy-UI), zenji.app renewAuto-toggle (manuell — API-PATCH bet ikke), web-reskin til
-baseline, mekanisk target-rename (Zenji.xcodeproj → Sportivista), TestFlight (WP-17).
+`sportivista.com/data/`. Web: navnebyttet; Tekst-TV-utseendet reskinnet til Apple-native baseline 18.07 (commit `1a5e89d31`).
+Utført siden: mekanisk target-rename (`Zenji.xcodeproj` → `Sportivista.xcodeproj`), web-reskin
+til baseline (18.07), TestFlight-lanen (WP-17). Gjenstår: formelt varemerke-søk+registrering (eier),
+`sportivista.no`-forwarding (manuell, GoDaddy-UI), zenji.app renewAuto-toggle (manuell — API-PATCH bet ikke).
 
 ## FASE 0F · iOS-UX: Apple-native baseline (audit 17.07.2026) — ✅ KOMPLETT 17.07.2026 (#289–#295)
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -103,10 +103,12 @@ ios/
 │   ├── DesignTokens.swift         shared baseline tokens: semantic system colours + amber + Dynamic Type font API (also used by widget + tests)
 │   ├── ThemeOverride.swift        manual system/dark/light override enum (pure)
 │   ├── Interaction.swift          shared ≥44pt tap-target helpers
+│   ├── LaunchTrace.swift          DEBUG-only launch-phase timing — the «Henter data …» cold-start measuring stick (no-op in Release)
 │   ├── Models/                    Codable models mirroring the data contract
 │   ├── Sync/                      manifest-diff sync + cache + background refresh
 │   ├── Feed/                      FeedCompiler + agenda formatting + lens renderer
 │   ├── Agenda/                    the day-grouped agenda UI + detail sheets
+│   ├── News/                      the Nyheter board: client lens + pure four-section builder + off-main model + thin view
 │   ├── Widget/                    the widget's pure timeline logic
 │   ├── Notifications/             local push reminders for must-watch events
 │   ├── Assistant/                 on-device (Foundation Models) assistant
@@ -300,6 +302,45 @@ assistant's result (a diff or an answer) presents as a native `.sheet`
 header glyphs (`P100`, the ticking clock, `»_`, the theme glyph) were removed; theme
 now lives in Deg. Screenshots: `docs/wp-83/*.png`.
 
+## News
+
+`Sportivista/News/` is the **Nyheter board** — the other half of the root segmented
+control («Uka | Nyheter», WP-104/106). It is ENDELIG: exactly four sections, no
+unread counters, no engagement mechanics (spec § Nyheter-v0, DESIGN § Nyheter).
+
+- `NewsBoard.swift` — the **pure builder**. A function of plain cached values (news,
+  featured, results, events, entities, profile, spoiler shield, now) with no I/O and
+  no clock read, so the whole board is unit-testable directly (`NewsBoardTests` /
+  `NewsLensTests`) and the view is a thin renderer over it. Four sections: **I DIN
+  VERDEN I DAG** (the editorial headline from `featured.json`, one line), **NYTT**
+  (lens-matched `news.json` pointers, newest first, capped 20), **RESULTAT** (followed
+  teams' recent football results, each stamped whether the spoiler shield must mask
+  its score), **FREMOVER** (followed events beyond the 7-day near horizon —
+  forvarsler; capped 8, via `FeedCompiler.isEventInWindow`, never a manual `time >= x`
+  filter so multi-day events survive).
+- `NewsLens.swift` — the **client-side lens** (the two-layer architecture: the server
+  publishes catalog-wide, the profile is on-device). A pointer shows when it is ABOUT
+  something followed, decided two ways: an `entityIds` ∩ followed-entities hit, or a
+  followed WHOLE-sport rule (a `sport`/`category`-type entity). It reuses the profile's
+  own rule semantics + `SportVocabulary` (the same keyword→sport / category→sports maps
+  the assistant grounds against) — it invents no new fuzzy matching. Athlete/team/
+  tournament rules stay entity-scoped (following Hovland admits golf headlines that
+  name Hovland, not every golf headline). `matchesEvent` applies the same lens to a
+  full `Event` for FREMOVER, mirroring `AgendaViewModel.ruleMatches`.
+- `NewsModel.swift` — the **living, ContentView-owned model** (WP-107). It survives
+  root-segment switches, so a switch back to Nyheter renders the last board instantly
+  (never a blank/hitch), and the heavy build (five cache reads + decodes + `EntityIndex`
+  build + `NewsBoard.build`) runs OFF the main actor — the same coalescing shape as
+  `AgendaViewModel` (one compute at a time, "siste vinner"), guarded by the shared
+  `MainThreadGuard`, and only when the board is actually stale (a profile change or a
+  completed sync — a plain tab switch is a no-op). This removed the "merkbar lag hver
+  gang man bytter til Nyheter" the owner saw on build 6.
+- `NewsView.swift` — the **thin renderer** over `news.board`: an `.insetGrouped` `List`
+  with a «Det du følger ›» link to WP-105's `FollowedListView`, a provenance ⓘ on the
+  brief, NYTT rows that tap OUT to the source (`Link`, never inlining article text —
+  DSM art. 15), and the spoiler-shielded RESULTAT reveal. No spinner ever (DESIGN
+  § Bevegelse); amber is the one accent.
+
 ## Widget
 
 `Sportivista/Widget/WidgetTimelineBuilder.swift` is a **pure function** (no
@@ -391,7 +432,9 @@ file in Application Support, **no network code**, surfaced as a discreet "DET JE
 IKKE FORSTO (N)" disclosure with a "Del rapport" `ShareLink` over an **anonymised**
 export. **Context actions** (`EventDetailSheet`): "Følg <entitet>" (a pre-filled
 add through the same grounded flow) and "Hvorfor vises denne?"
-(`FeedCompiler.whyShown`).
+(`FeedCompiler.whyShown` — its XCUITest `testEventDetailWhyShown` was fixed in
+PR #292, a **test-only** fix: the `EffectiveInterests.merge → FeedCompiler.whyShown`
+data flow was verified correct, so no app code changed).
 
 Screenshots: `docs/design-v2/assistant-{idle,thinking,diff,answer}-{dark,light}.png`,
 driven by a DEBUG-only `SPORTIVISTA_DEMO=…` launch harness (never compiled into release).
@@ -488,11 +531,13 @@ request, the Foundation Models tests drive `MockInterestAssistant`/`MockAnswerer
 only, and they reuse the frozen `SportivistaTests/Fixtures/*` snapshots as decode input
 and mock-server responses.
 
-There are **55 `*Tests.swift` files (~512 tests)**, at least one per subsystem —
-e.g. `SyncClientTests` (304 / changed-manifest / offline / corrupt-download),
-`CacheStoreTests` (App Group fallback), the `FeedCompilerUnit`/`FeedVector` pair,
-`AgendaViewModelTests`, `NotificationPlannerTests`, and the Assistant / Profile /
-Memory / Onboarding suites (see the `SportivistaTests/` listing for all). Run them with:
+There are **61 `*Tests.swift` files** (plus 8 shared doubles/fixtures — 69 `.swift`
+in all) and **573 tests**, at least one per subsystem — e.g. `SyncClientTests` (304 /
+changed-manifest / offline / corrupt-download), `CacheStoreTests` (App Group fallback),
+the `FeedCompilerUnit`/`FeedVector` pair, `AgendaViewModelTests`,
+`NotificationPlannerTests`, the `NewsBoard`/`NewsLens`/`NewsModel` trio (WP-106/107),
+and the Assistant / Profile / Memory / Onboarding suites (see the `SportivistaTests/`
+listing for all). Run them with:
 
 ```sh
 cd ios && xcodegen generate

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -78,4 +78,34 @@ describe("v2 workflows", () => {
 		// self-repair additionally gates on the events contract, as before the extraction
 		expect(wf("self-repair-agent.yml")).toContain("--validate-events");
 	});
+
+	it("the CI, iOS-test, release and Pages-deploy workflows exist and reference only files that exist", () => {
+		const files = ["ci.yml", "ios-tests.yml", "ios-release.yml", "preview-deploy.yml"];
+		const dir = fs.readdirSync(path.resolve(".github", "workflows"));
+		for (const f of files) {
+			expect(dir, f).toContain(f);
+		}
+		// every `node scripts/*.js` invoked across the four must exist on disk
+		for (const f of files) {
+			const scripts = [...wf(f).matchAll(/node (scripts\/[\w\-/]+\.js)/g)].map((m) => m[1]);
+			for (const s of scripts) {
+				expect(fs.existsSync(path.resolve(s)), `${f} → ${s}`).toBe(true);
+			}
+		}
+		// the release lane records builds via the two TestFlight scripts and kicks the pipeline
+		const release = wf("ios-release.yml");
+		for (const s of ["scripts/next-testflight-build.js", "scripts/record-testflight.js"]) {
+			expect(release, `ios-release.yml must run ${s}`).toContain(`node ${s}`);
+			expect(fs.existsSync(path.resolve(s)), s).toBe(true);
+		}
+		expect(release, "release lane kicks the static pipeline").toContain("static-pipeline.yml");
+		expect(dir, "the kicked workflow exists").toContain("static-pipeline.yml");
+		// the two PR gates run the suites branch protection requires
+		expect(wf("ci.yml"), "ci runs the web test suite").toMatch(/npm (ci|test)/);
+		expect(wf("ios-tests.yml"), "ios-tests builds the Sportivista scheme").toContain("Sportivista");
+		// preview-deploy serialises Pages deploys and is invocable by the pipeline
+		const preview = wf("preview-deploy.yml");
+		expect(preview, "preview-deploy serialises on the pages group").toContain("pages-deploy");
+		expect(preview, "preview-deploy is callable by the static pipeline").toContain("workflow_call");
+	});
 });


### PR DESCRIPTION
Docs are verifiable against the code again (the coherence promise). WP-114 row flipped ⬜→🔬 in the same PR.

## CLAUDE.md
- **Web identity: the Tekst-TV exception is CLOSED** (18.07 reskin, `1a5e89d31`; DESIGN.md § Cross-surface 290–297). Frontend + companion DESIGN.md sections now describe the Apple-native baseline that every surface follows; `base.css` tokens updated to the real values — `#000000`/`#1C1C1E` dark, `#F2F2F7`/`#FFFFFF` light, amber `#FFB000`/`#9A6800`, system font stack (all verified against `base.css`). «Hva vi følger» → «Dette dekker vi» (index.html:45). dashboard.js ~446 → ~456 (wc -l = 456).
- Test counts `36/~470` → **`44/648`** (counted: `ls tests/*.test.js` = 44, `vitest run` = 648 after rebase). The 9 previously-unlisted test files (app-version, asc-api, build-events-degrade, catalog-schema, design-tokens, escalate-research, ios-dynamic-type-gate, news, usage-gate) placed in the Testing categories.
- `build-alert.json` added to the data-file list. The four non-agent workflows documented in a new architecture subsection. usage-monitor «hourly» → «hourly 05–22 UTC» (cron `20 5-22`).

## tests/workflows.test.js
- New case covering `ci.yml` / `ios-tests.yml` / `ios-release.yml` / `preview-deploy.yml`: existence + every referenced `node scripts/*.js` exists, the release-lane TestFlight scripts + the kicked `static-pipeline.yml`, the two PR-gate suites, and preview-deploy's `pages-deploy` / `workflow_call` wiring. Follows the file's existing pattern.

## ios/README.md
- New `## News` subsystem section (NewsBoard / NewsLens / NewsModel / NewsView), written in the README's established style. `LaunchTrace.swift` + `News/` added to the directory map. Test counts → **61 `*Tests.swift` (+8 shared doubles = 69 `.swift`) / 573**. whyShown context action cross-referenced to the #292 test-only fix.

## PLAN.md metadata (FASE 0I section untouched beyond the WP-114 row)
- Title → **Sportivista**; three search-replace artifacts restored to correct prose (verified against pre-mangle git history `0ed1e4405^`): the two 13.07 statusnotes → `zenji.app`/`CHaerem/zenji.app`, the forward-looking WP-28 design → `CHaerem/sportivista`. WP-106 heading ⬜→✅ (matches its table row); WP-17 row glyph 🔬→✅; FLYTTEDAGEN rename-punkt (+web-reskin, TestFlight) moved from Gjenstår to done.

## Test result
`npx vitest run --maxWorkers=1` → **44 files / 648 tests passing**. No `docs/data/` changes; no code changes beyond `tests/workflows.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)