### PR TITLE
WP-119: portmåling — mekanisk port-report for eksterne-tester-gaten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ npm-debug.log*
 !/docs/data/entities.json
 !/docs/data/build-alert.json
 !/docs/data/news.json
+!/docs/data/port-report.json
 # Sport source files (fetched by API, consumed by build-events)
 !/docs/data/football.json
 !/docs/data/golf.json

--- a/PLAN.md
+++ b/PLAN.md
@@ -123,7 +123,7 @@ mennesket, aldri av en agent.
 | WP-116 | Dekningsbredde: katalog-utvidelse + deltaker-/«Om»-kontrakter i research/verify | 0I | WP-110 | ⬜ bølge 2 |
 | WP-117 | Design-review av alle flater (read-only rapport) | 0I | — | ✅ rapport levert 20.07 — bekreftet alle tre eier-svakheter + W1 fortids-daggruppe over «I DAG», W2 live-poll kollapser åpne rader, rediger-amber-overload, onboarding-copy «kommandolinjen», RESULTAT-seksjon feilplassert, DESIGN.md selvmotsigelse om web-klokka, stale skjermkatalog → WP-120/126–129 |
 | WP-118 | Kjernefunksjonalitet-audit (read-only rapport) | 0I | — | ✅ rapport levert 20.07 — 🔴 varsel-reconcile kun ved kald oppstart; 🔴 widget-timeline aldri invalidert ved sync; 🟡 ingen foregrunn-sync, horisont-divergens (web 14d-cap/iOS ingen/data 42d), ICS uten DTEND, 100T-entitetsdublett + intet lens-miss-signal → WP-121–125 |
-| WP-119 | Portmåling-artefakt (port-report fra verify/coverage/build-alert) | 0I | — | ⬜ bølge 2 |
+| WP-119 | Portmåling-artefakt (port-report fra verify/coverage/build-alert) | 0I | — | 🔬 PR åpen — `scripts/build-port-report.js` (kjøres fra build-events før writeManifest, ingen workflow-endring) → `docs/data/port-report.json`; fire porter (coverage/amendRate/silentStops/participantStatus) grønn/gul/rød + ærlig `basis` (manglende kilde ⇒ «ukjent», aldri stille grønn); .gitignore-whitelist + manifest auto-inkluderer; nye tester (grønn/gul/rød/ukjent + integrasjon) |
 | WP-120 | «Det du følger»: visning + håndtering (fra WP-117-funn) | 0I | WP-117 | ⬜ bølge 3 |
 | WP-121 | iOS leverings-ferskhet: varsel-reconcile + widget-reload + foregrunn-sync | 0I | WP-118 | ⬜ bølge 2 |
 | WP-122 | ~~Deltaker widget/detalj~~ → slått inn i WP-127 | 0I | — | — |

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -5,6 +5,7 @@ import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, MS_PER_DAY, makeCoverageGate, mustWatchEntity, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
 import { resolveStreaming } from "./lib/norwegian-rights.js";
 import { writeManifest } from "./build-manifest.js";
+import { writePortReport } from "./build-port-report.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
 import { buildNews } from "./lib/news.js";
 import { fileURLToPath } from "url";
@@ -711,8 +712,20 @@ const news = buildNews({ digest: rssDigest, entities });
 fs.writeFileSync(path.join(dataDir, "news.json"), JSON.stringify(news, null, 2) + "\n");
 console.log(`Published news.json (${news.items.length} item(s)).`);
 
+// WP-119: publish port-report.json — mechanical measurement of the four gates
+// that decide external-tester readiness (coverage / amend-rate / silent stops /
+// participant status). Runs here (before writeManifest, so the manifest covers
+// it) rather than as its own workflow step — .github/workflows/** is protected.
+// Reads THIS build's fresh build-alert.json + published catalog.json and the
+// PREVIOUS manifest.json (writeManifest runs next); fail-soft on any missing
+// source (the port says "unknown", never a silent green).
+const portReport = writePortReport(dataDir, configDir);
+console.log(
+	`Wrote port-report.json (coverage=${portReport.ports.coverage} amendRate=${portReport.ports.amendRate} silentStops=${portReport.ports.silentStops} participantStatus=${portReport.ports.participantStatus}).`
+);
+
 // WP-03: publish manifest.json (bytes + sha256 per published data file) —
 // last thing this script does, so it reflects everything build-events.js
-// itself just wrote (events.json, tracked.json, interests.json).
+// itself just wrote (events.json, tracked.json, interests.json, port-report.json).
 const manifest = writeManifest(dataDir);
 console.log(`Wrote manifest.json (${Object.keys(manifest.files).length} file(s)).`);

--- a/scripts/build-port-report.js
+++ b/scripts/build-port-report.js
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+/**
+ * WP-119 · Portmåling-artefakt. Mechanises the four gates that decide whether
+ * Sportivista is ready for external TestFlight testers — the gates that were,
+ * until now, measured by hand ("vibes"):
+ *
+ *   1. coverage           — null tapte fulgte events
+ *   2. amendRate          — amend-rate on near-term events ≈ 0
+ *   3. silentStops        — null stille kritiske stopp
+ *   4. participantStatus  — null feilaktige deltaker-statuser
+ *
+ * Reads the pipeline's own outputs (coverage-audit.json, verify-log.json,
+ * calibration-ledger.jsonl, build-alert.json, manifest.json, catalog.json),
+ * aggregates over a rolling ~14-day window, and writes:
+ *
+ *   docs/data/port-report.json
+ *
+ * Run as the last content step of build-events.js (before writeManifest, so the
+ * manifest covers it) — NOT a new workflow step, because .github/workflows/** is
+ * a protected path. Also runnable standalone (reads SPORTSYNC_DATA_DIR).
+ *
+ * HONESTY CONTRACT: a port is only coloured (green/yellow/red) when the sources
+ * it depends on are present. When a source is missing the port reports "unknown"
+ * — NEVER a silent green — and the reason is recorded in `basis.notes`. Every
+ * read is fail-soft: a missing/empty/corrupt source degrades that port to
+ * "unknown" and never throws.
+ *
+ * NB on history depth: only the calibration ledger carries genuine per-day
+ * history (one timestamped record per source check), so `amendRate.byDay` is the
+ * real per-day dimension. coverage-audit gaps carry age (`firstSeen`); verify-log,
+ * build-alert and manifest are latest-snapshot only. The `basis` block is honest
+ * about this rather than pretending to a 14-day depth the data can't back.
+ *
+ * No LLM here — pure aggregation. Agents / the owner interpret the report.
+ */
+
+import fs from "fs";
+import path from "path";
+import { pathToFileURL } from "url";
+import { rootDataPath, readJsonIfExists, iso, MS_PER_HOUR, MS_PER_DAY } from "./lib/helpers.js";
+
+export const PORT_REPORT_NAME = "port-report.json";
+export const WINDOW_DAYS = 14;
+
+// ── Thresholds (constants so tests can target them) ─────────────────────────
+// Port 1 · coverage: a low gap that has recurred this many times is the audit's
+// own escalation trigger (coverage-critic bumps low→medium at >=3); an open gap
+// older than this many days is stale enough to matter.
+const GAP_ESCALATE_RECURRENCES = 3;
+const GAP_STALE_DAYS = 14;
+// Port 2 · amend-rate: near 0 is the goal. Verify amends a couple per ~10 near-term
+// checks in healthy operation (~0.2), so that is the green ceiling.
+const AMEND_GREEN = 0.2;
+const AMEND_YELLOW = 0.4;
+// Port 3 · silent stops: the static pipeline runs hourly 05–21 UTC, so the
+// longest legitimate quiet gap is the ~8h overnight window. A daytime build miss
+// shows as >12h; more than a full day-cycle (>26h) is a real stop. A fetcher file
+// that hasn't refreshed in >26h is a stale hole even while the pipeline runs.
+const STALE_YELLOW_HOURS = 12;
+const STALE_RED_HOURS = 26;
+const STALE_FILE_HOURS = 26;
+// Port 4 · participant status: verify runs daily, so a verify-log older than this
+// means the freshness guarantee is lagging and statuses may be rotting.
+const VERIFY_STALE_HOURS = 48;
+
+const COLORS = { green: 0, yellow: 1, red: 2 };
+function worst(a, b) {
+	return COLORS[a] >= COLORS[b] ? a : b;
+}
+function round2(n) {
+	return Math.round(n * 100) / 100;
+}
+function ageHours(ts, now) {
+	const t = Date.parse(ts);
+	if (!Number.isFinite(t)) return null;
+	return round2((now - t) / MS_PER_HOUR);
+}
+function dayKey(ts) {
+	const t = Date.parse(ts);
+	if (!Number.isFinite(t)) return null;
+	return new Date(t).toISOString().slice(0, 10);
+}
+
+// ── Port 4 heuristics · verify-log notes about participant statuses ─────────
+// A verify note touches participant status when it names a participant-status
+// concept. Among those, an "unresolved" note (verify could not confirm / sources
+// conflict) is the real failure; a plain correction is the WP-95 freshness
+// mechanism WORKING (reality moved — a cut, a withdrawal — and verify updated it),
+// so corrections are reported but do NOT redden the port.
+const PARTICIPANT_STRONG = /wp-95|deltakelsessjekk|deltaker-?status|participation[- ]?status/i;
+const PARTICIPANT_TOKEN = /norwegianplayers|\bdeltaker|deltakelse|startliste|\bcut\b|cutten|røk cutten|misset? cut|slått ut|trukket seg|trakk seg|trekning|withdrew|withdrawn|did not start|\bdns\b/i;
+const PARTICIPANT_UNRESOLVED = /kunne ikke (bekreft|verifis)|ikke bekreftet|uklar|konflikt|motstrid|uenig|unresolved|unable to (confirm|verify)|mismatch|feil status/i;
+
+function isParticipantNote(note) {
+	return PARTICIPANT_STRONG.test(note) || PARTICIPANT_TOKEN.test(note);
+}
+
+// ── Port 1 · coverage ───────────────────────────────────────────────────────
+function catalogTerms(catalog) {
+	const terms = new Set();
+	for (const s of catalog?.tier1 || []) if (s) terms.add(String(s).toLowerCase());
+	const buckets = catalog?.tier2 || {};
+	for (const bucket of Object.values(buckets)) {
+		if (!Array.isArray(bucket)) continue;
+		for (const e of bucket) {
+			if (e?.name) terms.add(String(e.name).toLowerCase());
+			for (const a of e?.aliases || []) if (a) terms.add(String(a).toLowerCase());
+			if (e?.sport) terms.add(String(e.sport).toLowerCase());
+		}
+	}
+	return terms;
+}
+
+function escapeRegExp(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function gapMatchesCatalog(gap, terms) {
+	if (!terms || !terms.size) return null; // catalog unavailable ⇒ can't cross-check
+	const hay = `${gap?.interest || ""} ${gap?.whatsMissing || ""}`.toLowerCase();
+	for (const t of terms) {
+		if (t.length < 2) continue; // skip single-char terms (substring noise); "f1", "g2" etc. kept
+		// Word-boundary match, not naive substring — "ao" (Australian Open alias)
+		// must not match inside "kanoår"; "f1" must match "f1 hele sesongen".
+		if (new RegExp(`\\b${escapeRegExp(t)}\\b`, "i").test(hay)) return true;
+	}
+	return false;
+}
+
+function assessCoverage(auditRaw, catalog, now) {
+	if (!auditRaw || !Array.isArray(auditRaw.gaps)) {
+		return { status: "unknown", detail: null, available: false };
+	}
+	const terms = catalogTerms(catalog);
+	const bySeverity = { high: 0, medium: 0, low: 0 };
+	let oldestAgeDays = null;
+	let escalatable = 0;
+	let catalogMatched = 0;
+	const gaps = [];
+	for (const g of auditRaw.gaps) {
+		const sev = ["high", "medium", "low"].includes(g?.severity) ? g.severity : "low";
+		bySeverity[sev]++;
+		const seen = Date.parse(g?.firstSeen);
+		const ageD = Number.isFinite(seen) ? round2((now - seen) / MS_PER_DAY) : null;
+		if (ageD != null && (oldestAgeDays == null || ageD > oldestAgeDays)) oldestAgeDays = ageD;
+		const recurrences = Number.isFinite(g?.recurrences) ? g.recurrences : 0;
+		const aged = ageD != null && ageD >= GAP_STALE_DAYS;
+		if (recurrences >= GAP_ESCALATE_RECURRENCES || aged) escalatable++;
+		const matched = gapMatchesCatalog(g, terms);
+		if (matched === true) catalogMatched++;
+		gaps.push({
+			interest: g?.interest || null,
+			severity: sev,
+			ageDays: ageD,
+			recurrences,
+			catalogMatched: matched,
+		});
+	}
+	let status = "green";
+	if (bySeverity.high > 0) status = "red";
+	else if (bySeverity.medium > 0 || escalatable > 0) status = "yellow";
+	return {
+		status,
+		available: true,
+		detail: {
+			openGaps: auditRaw.gaps.length,
+			bySeverity,
+			oldestGapAgeDays: oldestAgeDays,
+			escalatable,
+			catalogMatched: terms.size ? catalogMatched : null,
+			auditedAt: auditRaw.auditedAt || null,
+			gaps,
+		},
+	};
+}
+
+// ── Port 2 · amend-rate on near-term events ─────────────────────────────────
+function assessAmendRate(verifyLog, ledgerLines, now) {
+	const haveVerify = verifyLog && typeof verifyLog === "object";
+	const haveLedger = Array.isArray(ledgerLines) && ledgerLines.length > 0;
+	if (!haveVerify && !haveLedger) {
+		return { status: "unknown", detail: null, available: false };
+	}
+
+	// Per-day trend from the ledger (the only genuinely per-day source). A
+	// boardWasProvisional firm-up is the source correcting an estimate — NOT a
+	// board error (WP-93) — so it is tracked as a `correction`, not an amendment.
+	const cutoff = now - WINDOW_DAYS * MS_PER_DAY;
+	const byDayMap = new Map();
+	let windowChecks = 0;
+	let windowAmendments = 0;
+	let windowCorrections = 0;
+	if (haveLedger) {
+		for (const line of ledgerLines) {
+			let rec;
+			try {
+				rec = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (!rec || typeof rec.agreed !== "boolean") continue;
+			const t = Date.parse(rec.checkedAt);
+			if (!Number.isFinite(t) || t < cutoff) continue;
+			const key = dayKey(rec.checkedAt);
+			if (!key) continue;
+			const corrected = rec.agreed === false && rec.boardWasProvisional === true;
+			const amended = rec.agreed === false && !corrected;
+			if (!byDayMap.has(key)) byDayMap.set(key, { date: key, checks: 0, amendments: 0, corrections: 0 });
+			const d = byDayMap.get(key);
+			d.checks++;
+			windowChecks++;
+			if (amended) {
+				d.amendments++;
+				windowAmendments++;
+			}
+			if (corrected) {
+				d.corrections++;
+				windowCorrections++;
+			}
+		}
+	}
+	const byDay = [...byDayMap.values()]
+		.sort((a, b) => a.date.localeCompare(b.date))
+		.map((d) => ({ ...d, rate: d.checks ? round2(d.amendments / d.checks) : null }));
+	const windowRate = windowChecks ? round2(windowAmendments / windowChecks) : null;
+
+	// Near-term rate: verify.md scopes its run to events in the next ~7 days, so
+	// verify-log's amended/checked IS the near-term amend rate the port cares about
+	// (the ledger doesn't record an event's lead time, so <72h can't be filtered
+	// from it — see basis.notes). Prefer it; fall back to the ledger window rate.
+	let nearTermRate = null;
+	let nearTermChecked = null;
+	let nearTermAmended = null;
+	if (haveVerify && Number.isFinite(verifyLog.checked) && verifyLog.checked > 0) {
+		nearTermChecked = verifyLog.checked;
+		nearTermAmended = Number.isFinite(verifyLog.amended) ? verifyLog.amended : 0;
+		nearTermRate = round2(nearTermAmended / nearTermChecked);
+	}
+
+	const rate = nearTermRate != null ? nearTermRate : windowRate;
+	let status;
+	if (rate == null) status = "unknown"; // sources present but no usable numbers yet
+	else if (rate <= AMEND_GREEN) status = "green";
+	else if (rate <= AMEND_YELLOW) status = "yellow";
+	else status = "red";
+
+	return {
+		status,
+		available: true,
+		detail: {
+			nearTermRate,
+			nearTermChecked,
+			nearTermAmended,
+			verifyRunAt: haveVerify ? verifyLog.runAt || null : null,
+			windowRate,
+			windowChecks,
+			windowAmendments,
+			windowCorrections,
+			byDay,
+		},
+	};
+}
+
+// ── Port 3 · silent stops ────────────────────────────────────────────────────
+function assessSilentStops(buildAlert, manifest, now) {
+	const haveAlert = buildAlert && typeof buildAlert === "object";
+	const haveManifest = manifest && typeof manifest === "object";
+	if (!haveAlert && !haveManifest) {
+		return { status: "unknown", detail: null, available: false };
+	}
+	let status = "green";
+	const detail = {
+		buildOk: null,
+		buildCheckedAt: null,
+		buildAgeHours: null,
+		manifestGeneratedAt: null,
+		manifestAgeHours: null,
+		staleFiles: [],
+	};
+
+	if (haveAlert) {
+		detail.buildOk = buildAlert.ok === true ? true : buildAlert.ok === false ? false : null;
+		detail.buildCheckedAt = buildAlert.checkedAt || null;
+		detail.buildAgeHours = ageHours(buildAlert.checkedAt, now);
+		if (detail.buildOk === false) status = worst(status, "red"); // a recorded degrade-gate trip
+		if (detail.buildAgeHours != null) {
+			if (detail.buildAgeHours > STALE_RED_HOURS) status = worst(status, "red");
+			else if (detail.buildAgeHours > STALE_YELLOW_HOURS) status = worst(status, "yellow");
+		}
+	}
+
+	if (haveManifest) {
+		detail.manifestGeneratedAt = manifest.generatedAt || null;
+		detail.manifestAgeHours = ageHours(manifest.generatedAt, now);
+		if (detail.manifestAgeHours != null) {
+			if (detail.manifestAgeHours > STALE_RED_HOURS) status = worst(status, "red");
+			else if (detail.manifestAgeHours > STALE_YELLOW_HOURS) status = worst(status, "yellow");
+		}
+		const files = manifest.files && typeof manifest.files === "object" ? manifest.files : {};
+		for (const [name, entry] of Object.entries(files)) {
+			const stamp = entry && entry.sourceLastUpdated;
+			if (!stamp) continue; // only fetcher files carry a freshness stamp
+			const age = ageHours(stamp, now);
+			if (age != null && age > STALE_FILE_HOURS) {
+				detail.staleFiles.push({ file: name, sourceLastUpdated: stamp, ageHours: age });
+			}
+		}
+		if (detail.staleFiles.length) status = worst(status, "yellow");
+	}
+
+	return { status, available: true, detail };
+}
+
+// ── Port 4 · participant status ──────────────────────────────────────────────
+function assessParticipantStatus(verifyLog, now) {
+	if (!verifyLog || typeof verifyLog !== "object") {
+		return { status: "unknown", detail: null, available: false };
+	}
+	const notes = Array.isArray(verifyLog.notes) ? verifyLog.notes.map(String) : [];
+	let corrections = 0;
+	let unresolved = 0;
+	const signals = [];
+	for (const note of notes) {
+		if (!isParticipantNote(note)) continue;
+		const isUnresolved = PARTICIPANT_UNRESOLVED.test(note);
+		if (isUnresolved) unresolved++;
+		else corrections++;
+		signals.push(note.length > 160 ? note.slice(0, 157) + "…" : note);
+	}
+	const verifyAge = ageHours(verifyLog.runAt, now);
+	let status = "green";
+	if (unresolved > 0) status = "red"; // a status verify could not confirm is the real failure
+	else if (verifyAge == null || verifyAge > VERIFY_STALE_HOURS) status = "yellow"; // freshness lagging
+	return {
+		status,
+		available: true,
+		detail: { checkedAt: verifyLog.runAt || null, verifyAgeHours: verifyAge, corrections, unresolved, signals },
+	};
+}
+
+/**
+ * Pure aggregator. Takes already-parsed inputs (null / [] for missing sources)
+ * and never throws. Returns the full port-report object.
+ */
+export function buildPortReport(inputs = {}, now = Date.now()) {
+	const { coverageAudit = null, verifyLog = null, ledgerLines = [], buildAlert = null, manifest = null, catalog = null } = inputs;
+
+	const coverage = assessCoverage(coverageAudit, catalog, now);
+	const amendRate = assessAmendRate(verifyLog, ledgerLines, now);
+	const silentStops = assessSilentStops(buildAlert, manifest, now);
+	const participantStatus = assessParticipantStatus(verifyLog, now);
+
+	const basis = {
+		coverageAudit: coverage.available,
+		verifyLog: verifyLog != null,
+		calibrationLedger: Array.isArray(ledgerLines) && ledgerLines.length > 0,
+		buildAlert: buildAlert != null,
+		manifest: manifest != null,
+		catalog: catalog != null,
+		notes: [],
+	};
+	if (!basis.coverageAudit) basis.notes.push("coverage-audit.json unavailable — coverage-porten er «ukjent», ikke grønn.");
+	if (!basis.verifyLog) basis.notes.push("verify-log.json unavailable — amend-rate + deltaker-status mangler sin primærkilde.");
+	if (!basis.calibrationLedger) basis.notes.push("calibration-ledger.jsonl unavailable/empty — ingen per-dag amend-trend.");
+	if (!basis.buildAlert && !basis.manifest) basis.notes.push("build-alert.json + manifest.json unavailable — stille-stopp-porten er «ukjent».");
+	if (!basis.catalog) basis.notes.push("catalog.json unavailable — coverage-gaps krysssjekkes ikke mot katalogen (severity/alder brukes fortsatt).");
+	// Honest scope caveat: the ledger doesn't record an event's lead time, so the
+	// <72h near-term filter is applied via verify-log's next-7-day scope, not the ledger.
+	if (basis.calibrationLedger) basis.notes.push("amendRate.byDay dekker ALLE verify-kildesjekker (ledgeren registrerer ikke event-ledetid, så <72t-filteret kommer fra verify-log sitt neste-7-dager-omfang).");
+
+	return {
+		generatedAt: iso(now),
+		windowDays: WINDOW_DAYS,
+		ports: {
+			coverage: coverage.status,
+			amendRate: amendRate.status,
+			silentStops: silentStops.status,
+			participantStatus: participantStatus.status,
+		},
+		basis,
+		coverage: coverage.detail,
+		amendRate: amendRate.detail,
+		silentStops: silentStops.detail,
+		participantStatus: participantStatus.detail,
+	};
+}
+
+/** Read the pipeline's outputs from disk, build the report, write it. Fail-soft. */
+export function writePortReport(dataDir = rootDataPath(), configDir = defaultConfigDir(), now = Date.now()) {
+	const ledgerPath = path.join(dataDir, "calibration-ledger.jsonl");
+	let ledgerLines = [];
+	try {
+		if (fs.existsSync(ledgerPath)) {
+			ledgerLines = fs.readFileSync(ledgerPath, "utf-8").split("\n").filter(Boolean);
+		}
+	} catch {
+		ledgerLines = [];
+	}
+	// catalog: prefer the copy already published to dataDir this build, fall back
+	// to the source config (standalone runs before a publish).
+	const catalog = readJsonIfExists(path.join(dataDir, "catalog.json")) || readJsonIfExists(path.join(configDir, "catalog.json"));
+
+	const report = buildPortReport(
+		{
+			coverageAudit: readJsonIfExists(path.join(dataDir, "coverage-audit.json")),
+			verifyLog: readJsonIfExists(path.join(dataDir, "verify-log.json")),
+			ledgerLines,
+			buildAlert: readJsonIfExists(path.join(dataDir, "build-alert.json")),
+			manifest: readJsonIfExists(path.join(dataDir, "manifest.json")),
+			catalog,
+		},
+		now
+	);
+	fs.writeFileSync(path.join(dataDir, PORT_REPORT_NAME), JSON.stringify(report, null, 2));
+	return report;
+}
+
+function defaultConfigDir() {
+	return process.env.SPORTSYNC_CONFIG_DIR || path.resolve(process.cwd(), "scripts", "config");
+}
+
+function main() {
+	const report = writePortReport();
+	const p = report.ports;
+	console.log(
+		`Port-report: coverage=${p.coverage} amendRate=${p.amendRate} silentStops=${p.silentStops} participantStatus=${p.participantStatus} (window ${report.windowDays}d)`
+	);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+	main();
+}

--- a/tests/build-manifest.test.js
+++ b/tests/build-manifest.test.js
@@ -256,13 +256,16 @@ describe("build-events.js integration (WP-03)", () => {
 		execFileSync("node", ["scripts/build-events.js"], { env }); // re-reads its own events.json output, rebuilds
 		const second = JSON.parse(fs.readFileSync(path.join(dataDir, MANIFEST_NAME), "utf-8"));
 
-		// build-alert.json (WP-94) carries its own per-run `checkedAt` timestamp —
-		// like manifest.generatedAt, it legitimately differs run-to-run even when
-		// nothing else changed, so its entry is excluded the same way.
+		// build-alert.json (WP-94) carries its own per-run `checkedAt` timestamp,
+		// and port-report.json (WP-119) its own `generatedAt` + time-relative age
+		// measurements — like manifest.generatedAt, both legitimately differ
+		// run-to-run even when nothing else changed, so their entries are excluded
+		// the same way.
 		const stripVolatile = (m) => {
 			const { generatedAt, ...rest } = m;
 			const files = { ...rest.files };
 			delete files["build-alert.json"];
+			delete files["port-report.json"];
 			return { ...rest, files };
 		};
 		expect(stripVolatile(first)).toEqual(stripVolatile(second));

--- a/tests/build-port-report.test.js
+++ b/tests/build-port-report.test.js
@@ -1,0 +1,263 @@
+// WP-119: build-port-report.js — mechanical measurement of the four external-
+// tester gates (coverage / amend-rate / silent stops / participant status).
+// Pure-function fixtures prove green/yellow/red per port + missing-source ⇒
+// "unknown" (never a silent green); integration proves the standalone CLI and
+// that build-events wires it in before the manifest (which auto-covers it).
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { buildPortReport, PORT_REPORT_NAME } from "../scripts/build-port-report.js";
+
+const NOW = Date.parse("2026-07-20T12:00:00Z");
+const daysAgo = (d) => new Date(NOW - d * 86400000).toISOString();
+const hoursAgo = (h) => new Date(NOW - h * 3600000).toISOString();
+
+function tmpDir(prefix) {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("buildPortReport — topline + honesty contract", () => {
+	it("all sources missing ⇒ every port is 'unknown', never a silent green", () => {
+		const r = buildPortReport({}, NOW);
+		expect(r.ports).toEqual({
+			coverage: "unknown",
+			amendRate: "unknown",
+			silentStops: "unknown",
+			participantStatus: "unknown",
+		});
+		expect(r.windowDays).toBe(14);
+		expect(r.generatedAt).toBe(new Date(NOW).toISOString());
+		expect(r.basis).toMatchObject({
+			coverageAudit: false,
+			verifyLog: false,
+			calibrationLedger: false,
+			buildAlert: false,
+			manifest: false,
+			catalog: false,
+		});
+		expect(r.basis.notes.length).toBeGreaterThan(0);
+	});
+
+	it("never throws on empty / malformed inputs", () => {
+		expect(() => buildPortReport({ coverageAudit: {}, verifyLog: {}, ledgerLines: ["not json", ""], buildAlert: {}, manifest: {} }, NOW)).not.toThrow();
+	});
+});
+
+describe("port 1 · coverage", () => {
+	const lowGap = { severity: "low", firstSeen: daysAgo(2), recurrences: 1, interest: "F1 hele sesongen", whatsMissing: "kvalifisering mangler" };
+
+	it("green: only a fresh low gap", () => {
+		const r = buildPortReport({ coverageAudit: { gaps: [lowGap] } }, NOW);
+		expect(r.ports.coverage).toBe("green");
+		expect(r.coverage.openGaps).toBe(1);
+		expect(r.coverage.bySeverity).toEqual({ high: 0, medium: 0, low: 1 });
+	});
+
+	it("yellow: a medium-severity gap", () => {
+		const r = buildPortReport({ coverageAudit: { gaps: [{ severity: "medium", firstSeen: daysAgo(1), recurrences: 1 }] } }, NOW);
+		expect(r.ports.coverage).toBe("yellow");
+	});
+
+	it("yellow: a low gap that recurred past the escalation threshold", () => {
+		const r = buildPortReport({ coverageAudit: { gaps: [{ severity: "low", firstSeen: daysAgo(3), recurrences: 3 }] } }, NOW);
+		expect(r.ports.coverage).toBe("yellow");
+		expect(r.coverage.escalatable).toBe(1);
+	});
+
+	it("red: any high-severity gap", () => {
+		const r = buildPortReport({ coverageAudit: { gaps: [{ severity: "high", firstSeen: daysAgo(1), recurrences: 1 }, lowGap] } }, NOW);
+		expect(r.ports.coverage).toBe("red");
+	});
+
+	it("unknown: no coverage-audit", () => {
+		expect(buildPortReport({ verifyLog: {} }, NOW).ports.coverage).toBe("unknown");
+	});
+
+	it("cross-checks a gap against the catalog when present", () => {
+		const catalog = { tier1: ["f1"], tier2: {} };
+		const r = buildPortReport({ coverageAudit: { gaps: [lowGap] }, catalog }, NOW);
+		expect(r.coverage.gaps[0].catalogMatched).toBe(true);
+		expect(r.coverage.catalogMatched).toBe(1);
+		// catalog absent ⇒ per-gap match is null, not a false claim
+		const r2 = buildPortReport({ coverageAudit: { gaps: [lowGap] } }, NOW);
+		expect(r2.coverage.gaps[0].catalogMatched).toBeNull();
+		expect(r2.coverage.catalogMatched).toBeNull();
+	});
+});
+
+describe("port 2 · amend-rate", () => {
+	it("green: near-term verify amend rate ≤ 0.2", () => {
+		const r = buildPortReport({ verifyLog: { runAt: hoursAgo(5), checked: 10, amended: 1 } }, NOW);
+		expect(r.ports.amendRate).toBe("green");
+		expect(r.amendRate.nearTermRate).toBe(0.1);
+	});
+
+	it("yellow: near-term amend rate in (0.2, 0.4]", () => {
+		const r = buildPortReport({ verifyLog: { runAt: hoursAgo(5), checked: 10, amended: 3 } }, NOW);
+		expect(r.ports.amendRate).toBe("yellow");
+	});
+
+	it("red: near-term amend rate > 0.4", () => {
+		const r = buildPortReport({ verifyLog: { runAt: hoursAgo(5), checked: 10, amended: 6 } }, NOW);
+		expect(r.ports.amendRate).toBe("red");
+	});
+
+	it("unknown: neither verify-log nor ledger", () => {
+		expect(buildPortReport({ coverageAudit: { gaps: [] } }, NOW).ports.amendRate).toBe("unknown");
+	});
+
+	it("per-day trend from the ledger; provisional firm-ups are corrections, not amendments; old records fall outside the window", () => {
+		const lines = [
+			JSON.stringify({ checkedAt: daysAgo(2), sport: "golf", source: "pgatour.com", agreed: false }),
+			JSON.stringify({ checkedAt: daysAgo(2), sport: "golf", source: "pgatour.com", agreed: true }),
+			JSON.stringify({ checkedAt: daysAgo(1), sport: "cycling", source: "cyclingstage.com", agreed: false, boardWasProvisional: true }),
+			JSON.stringify({ checkedAt: daysAgo(1), sport: "cycling", source: "cyclingstage.com", agreed: true }),
+			JSON.stringify({ checkedAt: daysAgo(20), sport: "f1", source: "formula1.com", agreed: false }), // outside 14d window
+		];
+		const r = buildPortReport({ ledgerLines: lines }, NOW);
+		expect(r.amendRate.windowChecks).toBe(4);
+		expect(r.amendRate.windowAmendments).toBe(1);
+		expect(r.amendRate.windowCorrections).toBe(1);
+		expect(r.amendRate.windowRate).toBe(0.25);
+		expect(r.amendRate.byDay).toHaveLength(2);
+		const dayB = r.amendRate.byDay.find((d) => d.date === daysAgo(1).slice(0, 10));
+		expect(dayB).toMatchObject({ checks: 2, amendments: 0, corrections: 1, rate: 0 });
+		// no verify-log ⇒ port falls back to the ledger window rate (0.25 ⇒ yellow)
+		expect(r.ports.amendRate).toBe("yellow");
+	});
+
+	it("verify-log near-term rate wins over the ledger window rate", () => {
+		const lines = [JSON.stringify({ checkedAt: daysAgo(1), source: "x.com", agreed: false })]; // window rate 1.0
+		const r = buildPortReport({ verifyLog: { runAt: hoursAgo(5), checked: 10, amended: 1 }, ledgerLines: lines }, NOW);
+		expect(r.amendRate.windowRate).toBe(1);
+		expect(r.amendRate.nearTermRate).toBe(0.1);
+		expect(r.ports.amendRate).toBe("green");
+	});
+});
+
+describe("port 3 · silent stops", () => {
+	it("green: fresh ok build + fresh manifest + no stale files", () => {
+		const r = buildPortReport({ buildAlert: { ok: true, checkedAt: hoursAgo(1) }, manifest: { generatedAt: hoursAgo(1), files: {} } }, NOW);
+		expect(r.ports.silentStops).toBe("green");
+		expect(r.silentStops.buildOk).toBe(true);
+	});
+
+	it("red: build-alert reports a degrade", () => {
+		const r = buildPortReport({ buildAlert: { ok: false, checkedAt: hoursAgo(1) } }, NOW);
+		expect(r.ports.silentStops).toBe("red");
+	});
+
+	it("red: build hasn't run in over a day", () => {
+		const r = buildPortReport({ buildAlert: { ok: true, checkedAt: hoursAgo(30) } }, NOW);
+		expect(r.ports.silentStops).toBe("red");
+	});
+
+	it("yellow: a daytime build was missed (12–26h)", () => {
+		const r = buildPortReport({ buildAlert: { ok: true, checkedAt: hoursAgo(15) } }, NOW);
+		expect(r.ports.silentStops).toBe("yellow");
+	});
+
+	it("yellow: a fetcher file stopped refreshing (stale sourceLastUpdated hole)", () => {
+		const manifest = {
+			generatedAt: hoursAgo(1),
+			files: {
+				"football.json": { bytes: 10, sha256: "x", sourceLastUpdated: hoursAgo(30) },
+				"golf.json": { bytes: 10, sha256: "y", sourceLastUpdated: hoursAgo(1) },
+				"events.json": { bytes: 10, sha256: "z" }, // no stamp ⇒ ignored
+			},
+		};
+		const r = buildPortReport({ buildAlert: { ok: true, checkedAt: hoursAgo(1) }, manifest }, NOW);
+		expect(r.ports.silentStops).toBe("yellow");
+		expect(r.silentStops.staleFiles.map((f) => f.file)).toEqual(["football.json"]);
+	});
+
+	it("unknown: neither build-alert nor manifest", () => {
+		expect(buildPortReport({ verifyLog: {} }, NOW).ports.silentStops).toBe("unknown");
+	});
+});
+
+describe("port 4 · participant status", () => {
+	it("green: verify recent + a correction (freshness working), no unresolved status", () => {
+		const verifyLog = { runAt: hoursAgo(6), notes: ["Tennis Gstaad: Casper Ruud slått ut i kvartfinalen. Amendet norwegianPlayers-status til \"slått ut\" (WP-95 deltakelsessjekk)."] };
+		const r = buildPortReport({ verifyLog }, NOW);
+		expect(r.ports.participantStatus).toBe("green");
+		expect(r.participantStatus.corrections).toBe(1);
+		expect(r.participantStatus.unresolved).toBe(0);
+		expect(r.participantStatus.signals).toHaveLength(1);
+	});
+
+	it("red: a participant status verify could not confirm", () => {
+		const verifyLog = { runAt: hoursAgo(6), notes: ["Deltakelsessjekk: kunne ikke bekrefte om Hovland klarte cutten — kilder i konflikt."] };
+		expect(buildPortReport({ verifyLog }, NOW).ports.participantStatus).toBe("red");
+	});
+
+	it("yellow: verify-log is stale (freshness guarantee lagging)", () => {
+		const verifyLog = { runAt: hoursAgo(60), notes: [] };
+		expect(buildPortReport({ verifyLog }, NOW).ports.participantStatus).toBe("yellow");
+	});
+
+	it("green ignores non-participant notes (e.g. streaming amendments)", () => {
+		const verifyLog = { runAt: hoursAgo(6), notes: ["Amendet streaming-kanal til HBO Max for Corales.", "Ingen events fjernet."] };
+		const r = buildPortReport({ verifyLog }, NOW);
+		expect(r.ports.participantStatus).toBe("green");
+		expect(r.participantStatus.corrections).toBe(0);
+	});
+
+	it("unknown: no verify-log", () => {
+		expect(buildPortReport({ coverageAudit: { gaps: [] } }, NOW).ports.participantStatus).toBe("unknown");
+	});
+});
+
+describe("integration · standalone CLI against a temp data dir", () => {
+	it("reads the pipeline outputs and writes a coloured port-report.json", () => {
+		const dataDir = tmpDir("ss-port-cli-");
+		fs.writeFileSync(path.join(dataDir, "coverage-audit.json"), JSON.stringify({ auditedAt: hoursAgo(6), gaps: [{ severity: "high", firstSeen: daysAgo(2), recurrences: 1, interest: "Tour de France" }] }));
+		fs.writeFileSync(path.join(dataDir, "verify-log.json"), JSON.stringify({ runAt: hoursAgo(6), checked: 10, amended: 1, notes: [] }));
+		fs.writeFileSync(path.join(dataDir, "calibration-ledger.jsonl"), [
+			JSON.stringify({ checkedAt: hoursAgo(20), source: "pgatour.com", agreed: true }),
+			JSON.stringify({ checkedAt: hoursAgo(20), source: "pgatour.com", agreed: false }),
+		].join("\n") + "\n");
+		fs.writeFileSync(path.join(dataDir, "build-alert.json"), JSON.stringify({ ok: true, checkedAt: hoursAgo(1) }));
+		fs.writeFileSync(path.join(dataDir, "manifest.json"), JSON.stringify({ generatedAt: hoursAgo(1), files: {} }));
+		fs.writeFileSync(path.join(dataDir, "catalog.json"), JSON.stringify({ tier1: ["cycling"], tier2: { tournaments: [{ name: "Tour de France", aliases: ["TdF"], sport: "cycling" }] } }));
+
+		execFileSync("node", ["scripts/build-port-report.js"], { env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir } });
+
+		const report = JSON.parse(fs.readFileSync(path.join(dataDir, PORT_REPORT_NAME), "utf-8"));
+		expect(report.ports.coverage).toBe("red"); // the high gap
+		expect(report.ports.amendRate).toBe("green"); // verify near-term 0.1
+		expect(report.ports.silentStops).toBe("green");
+		expect(report.basis).toMatchObject({ coverageAudit: true, verifyLog: true, calibrationLedger: true, buildAlert: true, manifest: true, catalog: true });
+		expect(report.coverage.gaps[0].catalogMatched).toBe(true);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+});
+
+describe("integration · build-events wires it in and the manifest covers it", () => {
+	it("build-events writes port-report.json and manifest.json includes it", () => {
+		const dataDir = tmpDir("ss-port-be-");
+		const configDir = tmpDir("ss-port-be-cfg-");
+		const env = { ...process.env, SPORTSYNC_DATA_DIR: dataDir, SPORTSYNC_CONFIG_DIR: configDir };
+		const future = (d) => new Date(Date.now() + d * 86400000).toISOString();
+		fs.writeFileSync(path.join(dataDir, "football.json"), JSON.stringify({ tournaments: [{ name: "Premier League", events: [{ title: "Liverpool vs Arsenal", time: future(1), homeTeam: "Liverpool", awayTeam: "Arsenal" }] }] }));
+		fs.writeFileSync(path.join(configDir, "tracked.json"), JSON.stringify({ version: 1, leagues: [], athletes: [], tournaments: [], notes: [] }));
+
+		execFileSync("node", ["scripts/build-events.js"], { env });
+
+		const reportPath = path.join(dataDir, PORT_REPORT_NAME);
+		expect(fs.existsSync(reportPath)).toBe(true);
+		const report = JSON.parse(fs.readFileSync(reportPath, "utf-8"));
+		expect(Object.keys(report.ports).sort()).toEqual(["amendRate", "coverage", "participantStatus", "silentStops"]);
+		// build-events wrote a fresh build-alert this run ⇒ silent-stop port is assessable
+		expect(report.ports.silentStops).toBe("green");
+
+		const manifest = JSON.parse(fs.readFileSync(path.join(dataDir, "manifest.json"), "utf-8"));
+		expect(manifest.files).toHaveProperty(PORT_REPORT_NAME);
+
+		fs.rmSync(dataDir, { recursive: true, force: true });
+		fs.rmSync(configDir, { recursive: true, force: true });
+	});
+});


### PR DESCRIPTION
## WP-119 · Portmåling-artefakt (FASE 0I, bølge 2)

Gjør målingen av de fire portene som gater eksterne TestFlight-testere **mekanisk** — før dette ble de vurdert for hånd («magefølelse»).

### Hva
Ny `scripts/build-port-report.js` aggregerer pipelinens egne outputs over et rullerende **14-dagers vindu** → `docs/data/port-report.json`:

| Port | Kilde | Grønn / gul / rød |
|---|---|---|
| **coverage** | `coverage-audit.json` gaps (severity + alder) × `catalog.json` | high⇒rød · medium/eskalerbar⇒gul · ellers grønn |
| **amendRate** | `verify-log.json` (nær-term neste-7d) + `calibration-ledger.jsonl` (per-dag trend) | ≤0,2 grønn · ≤0,4 gul · >0,4 rød |
| **silentStops** | `build-alert.json` ok/ferskhet + `manifest.json` generatedAt + stale fetcher-filer (`sourceLastUpdated`-huller) | degrade/>26t⇒rød · 12–26t/stale-fil⇒gul |
| **participantStatus** | `verify-log.json`-notater om deltaker-statusfeil (WP-95) | uløst status⇒rød · verify stale⇒gul · ellers grønn |

**Ærlig `basis`-blokk:** hver port sier `unknown` (aldri stille grønn) når kilden mangler, og `notes` forklarer hvorfor + at ledgeren ikke registrerer event-ledetid (derfor kommer <72t-nær-term-filteret fra verify sitt neste-7d-omfang, ikke ledgeren). WP-93-semantikk bevart: `boardWasProvisional`-firm-ups telles som `corrections`, ikke `amendments`.

### Hvordan (ingen workflow-endring)
Kalles fra `build-events.js` som siste content-steg **før `writeManifest`**, så manifestet auto-inkluderer `port-report.json` (konvensjonen dekker alle `docs/data/*.json`). `.github/workflows/**` er beskyttet sti — derfor ikke et nytt pipeline-steg. Whitelistet i `.gitignore`. Fail-soft mot manglende/tomme/korrupte kilder — kaster aldri.

### Test
- `tests/build-port-report.test.js` (27 tester): grønn/gul/rød per port + manglende-kilde ⇒ `unknown` + provisional-eksklusjon + per-dag-vindu + standalone-CLI- og `build-events`-integrasjon mot temp `SPORTSYNC_DATA_DIR`.
- `build-manifest` idempotens-testen ekskluderer nå `port-report.json` (per-run `generatedAt` + tidsrelative aldre — samme grunn som `build-alert.json`).
- **675 tester grønne** (`npx vitest run --maxWorkers=1`); `build-events` + `validate-events` mot /tmp-sandbox rent (45 events, 0 feil); port-report på ekte data = alle fire porter **grønne**.

PLAN.md WP-119-raden flippet ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)