### PR TITLE
WP-123: ICS — DTEND fra endTime, flerdagsevents som blokker

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -127,7 +127,7 @@ mennesket, aldri av en agent.
 | WP-120 | «Det du følger»: visning + håndtering (fra WP-117-funn) | 0I | WP-117 | ⬜ bølge 3 |
 | WP-121 | iOS leverings-ferskhet: varsel-reconcile + widget-reload + foregrunn-sync | 0I | WP-118 | ⬜ bølge 2 |
 | WP-122 | ~~Deltaker widget/detalj~~ → slått inn i WP-127 | 0I | — | — |
-| WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | ⬜ bølge 3 |
+| WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | 🔬 bølge 3 |
 | WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |
 | WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | ⬜ bølge 4 |
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | ⬜ bølge 3 |

--- a/scripts/build-ics.js
+++ b/scripts/build-ics.js
@@ -70,6 +70,21 @@ function vevent(ev, withAlarm) {
 	lines.push(`UID:${uid}`);
 	lines.push(`DTSTAMP:${nowStamp}`);
 	lines.push(`DTSTART:${dtStart}`);
+	// DTEND from endTime so multi-day events (golf, stage races, EM/NM friidrett,
+	// CS2 group stages) render as calendar BLOCKS, not single points (WP-123).
+	// We emit DATE-TIME (UTC) values, for which RFC 5545's "non-inclusive end" is
+	// the exact end INSTANT: the event occupies the half-open interval
+	// [DTSTART, DTEND). endTime already IS that instant (e.g. golf's final-round
+	// 20:00Z), so it maps to DTEND UNCHANGED — no +adjustment. (The +1 nudge is
+	// only needed for VALUE=DATE all-day events, which we never emit.) Guarded to
+	// a valid instant strictly after start so a malformed or non-positive-duration
+	// endTime never yields an invalid DTEND; endTime-less events are byte-unchanged.
+	if (ev.endTime) {
+		const startMs = Date.parse(ev.time);
+		const endMs = Date.parse(ev.endTime);
+		if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs)
+			lines.push(`DTEND:${formatDateTime(ev.endTime)}`);
+	}
 	if (ev.venue) lines.push(`LOCATION:${esc(ev.venue)}`);
 	const parts = [];
 	if (ev.tournament) parts.push(ev.tournament);

--- a/tests/build-ics.test.js
+++ b/tests/build-ics.test.js
@@ -5,22 +5,70 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+// Mirror build-ics.js formatDateTime: UTC datetime stamp YYYYMMDDTHHMMSSZ.
+function stamp(iso) {
+	const d = new Date(iso);
+	const pad = (n) => String(n).padStart(2, "0");
+	return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+}
+
+function buildIcs(events) {
+	const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ss-ics-"));
+	fs.writeFileSync(path.join(dataDir, "events.json"), JSON.stringify(events));
+	execFileSync("node", ["scripts/build-ics.js"], {
+		env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir },
+	});
+	const ics = fs.readFileSync(path.join(dataDir, "events.ics"), "utf-8");
+	fs.rmSync(dataDir, { recursive: true, force: true });
+	return ics;
+}
+
 describe("build-ics", () => {
 	it("emits valid VEVENT lines for events", () => {
-		const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ss-ics-"));
 		const future = new Date(Date.now() + 86400000).toISOString();
-		fs.writeFileSync(
-			path.join(dataDir, "events.json"),
-			JSON.stringify([{ sport: "golf", tournament: "PGA", title: "The Open", time: future, venue: "St Andrews" }])
-		);
-		execFileSync("node", ["scripts/build-ics.js"], {
-			env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir },
-		});
-		const ics = fs.readFileSync(path.join(dataDir, "events.ics"), "utf-8");
+		const ics = buildIcs([{ sport: "golf", tournament: "PGA", title: "The Open", time: future, venue: "St Andrews" }]);
 		expect(ics).toContain("BEGIN:VCALENDAR");
 		expect(ics).toContain("BEGIN:VEVENT");
 		expect(ics).toContain("END:VEVENT");
 		expect(ics).toMatch(/SUMMARY:.*The Open/);
-		fs.rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it("emits DTEND from endTime as a datetime block (WP-123)", () => {
+		const start = new Date(Date.now() + 86400000);
+		const end = new Date(start.getTime() + 5 * 3600000); // +5h stage-length block
+		const ics = buildIcs([
+			{ sport: "cycling", tournament: "Tour de France", title: "Etappe 3 (fjell)", time: start.toISOString(), endTime: end.toISOString() },
+		]);
+		expect(ics).toContain(`DTSTART:${stamp(start.toISOString())}`);
+		expect(ics).toContain(`DTEND:${stamp(end.toISOString())}`);
+		// DTEND follows DTSTART directly, before any LOCATION/SUMMARY.
+		expect(ics.indexOf("DTSTART:")).toBeLessThan(ics.indexOf("DTEND:"));
+	});
+
+	it("omits DTEND for events without endTime (output byte-unchanged)", () => {
+		const future = new Date(Date.now() + 86400000).toISOString();
+		const ics = buildIcs([{ sport: "football", tournament: "PL", title: "Arsenal v Spurs", time: future }]);
+		expect(ics).toContain("DTSTART:");
+		expect(ics).not.toContain("DTEND");
+	});
+
+	it("renders a multi-day event as a block spanning start→end days", () => {
+		// Golf: 4-day tournament — start and end fall on different UTC dates.
+		const ics = buildIcs([
+			{ sport: "golf", tournament: "PGA Tour", title: "Corales Puntacana Championship", time: "2026-07-16T04:00:00.000Z", endTime: "2026-07-19T20:00:00.000Z" },
+		]);
+		expect(ics).toContain("DTSTART:20260716T040000Z");
+		expect(ics).toContain("DTEND:20260719T200000Z");
+		// The block genuinely spans multiple days: end date != start date.
+		expect(ics).toMatch(/DTSTART:20260716T\d{6}Z[\s\S]*DTEND:20260719T\d{6}Z/);
+	});
+
+	it("skips a DTEND that would be at or before DTSTART (no invalid block)", () => {
+		const start = new Date(Date.now() + 86400000);
+		const ics = buildIcs([
+			{ sport: "chess", tournament: "Norway Chess", title: "Runde 1", time: start.toISOString(), endTime: start.toISOString() },
+		]);
+		expect(ics).toContain("DTSTART:");
+		expect(ics).not.toContain("DTEND");
 	});
 });


### PR DESCRIPTION
## WP-123 · ICS: DTEND fra endTime (FASE 0I, bølge 3)

**Problem:** `scripts/build-ics.js` skrev `DTSTART` men aldri `DTEND`/`DURATION`, så flerdagsevents (golf, etapperitt, EM/NM friidrett, CS2-gruppespill — 30 events med `endTime` i dagens data, flere mustWatch) ble enkeltpunkt i abonnert kalender i stedet for blokker.

**Fiks:** `vevent()` emitter nå `DTEND` fra `ev.endTime` når satt.

### DTEND-eksklusivitet — valget, dokumentert i koden
Vi skriver **DATE-TIME (UTC)**-verdier. RFC 5545 sin «non-inclusive end» for en datetime er det eksakte slutt-**instantet**: eventet opptar det halvåpne intervallet `[DTSTART, DTEND)`. `endTime` ER allerede det instantet (f.eks. golfs siste-runde 20:00Z), så det mappes til `DTEND` **uendret** — ingen `+`-justering. (`+1`-nudgen trengs kun for `VALUE=DATE` heldags-events, som vi aldri skriver.)

Guardet til et gyldig instant strengt etter start, så en feilformet eller ikke-positiv-varighet `endTime` aldri gir en ugyldig `DTEND`.

**Uendret:** events uten `endTime` gir byte-identisk output; VALARM-logikken er urørt.

### Tester (`tests/build-ics.test.js`, +4)
- DTEND fra endTime som datetime-blokk (rekkefølge DTSTART→DTEND)
- ingen DTEND uten endTime (output uendret)
- flerdagsevent (golf) → blokk som spenner start→sluttdag
- skip av DTEND ≤ DTSTART (ingen ugyldig blokk)

### Verifisering
- `npx vitest run --maxWorkers=1` grønn: 44 filer / 652 tester
- Røyktest `node scripts/build-ics.js` mot sandbox (`SPORTSYNC_DATA_DIR` i /tmp): golf-blokk 07-16→07-19, etappe-blokk 10:10→15:10, endTime-løst fotball uten DTEND
- `docs/data/` urørt i commiten

PLAN.md: WP-123 ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)