### PR TITLE
WP-128: web-agenda — fortids-dag-fiks, ekspandert over poll, klokke fjernet (paritet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,13 +178,15 @@ widget and, since the 18.07 reskin (commit `1a5e89d31`), the web (`docs/`) too. 
 old Tekst-TV exception is CLOSED** (DESIGN.md § Cross-surface, lines 290–297): the
 teletext-rooted identity (a monospace type stack, near-black `#0A0A0C` page, warm
 paper) is retired. Web keeps its own layout details (one column max 640px, the
-day-grouped agenda, the ticking amber clock in the header) but its colours and type
-are now the baseline. The web values below must stay verifiable against `base.css`;
+day-grouped agenda) but its colours and type are now the baseline. (WP-128: the
+ticking amber header clock was removed for iOS parity; the header keeps the theme
+glyph ◐ as a deliberate exception since web has no "Deg" screen — see DESIGN.md
+§ Cross-surface.) The web values below must stay verifiable against `base.css`;
 DESIGN.md is the source of intent behind them.
 
 - `docs/index.html` — shell: header (wordmark · date · theme toggle), one quiet editorial headline line, live-now line (conditional), the agenda, "Dette dekker vi" disclosure, footer. `docs/rediger.html` — the follow-request page (see below); `docs/activity.html` — the ops/activity view.
 - `docs/css/` — `base.css` (Apple-native tokens: true-black dark default `#000000` (cell `#1C1C1E`), grouped-light `#F2F2F7` (cell `#FFFFFF`) via prefers-color-scheme; amber `#FFB000` dark / `#9A6800` light as the ONLY accent; the **system font stack** — `-apple-system, BlinkMacSystemFont, "SF Pro Text", …` — with tabular numerals opted in where digits must align; max-width 640px, fixed 120px time column), `layout.css` (single centered column, all breakpoints), `cards.css` (agenda rows, day groups)
-- `docs/js/` — the `Dashboard` class is split along its seams across a shared prototype (window-global, no build step): `dashboard.js` (~456 lines: lifecycle + hero + the day-grouped agenda), `live.js` (ESPN live polling, 60s), `detail.js` (expand/detail + AI-provenance modal), `followed.js` ("Dette dekker vi" disclosure), `chrome.js` (clock/date/footer/usage/install-hint). `theme.js` is the shared 3-step theme toggle (system → dark → light) used on all pages; `shared-constants.js` holds shared utilities (time windows, escaping, name matching) that mirror the server helpers; `edit.js` drives `rediger.html`.
+- `docs/js/` — the `Dashboard` class is split along its seams across a shared prototype (window-global, no build step): `dashboard.js` (~456 lines: lifecycle + hero + the day-grouped agenda), `live.js` (ESPN live polling, 60s), `detail.js` (expand/detail + AI-provenance modal), `followed.js` ("Dette dekker vi" disclosure), `chrome.js` (date/footer/usage/install-hint). `theme.js` is the shared 3-step theme toggle (system → dark → light) used on all pages; `shared-constants.js` holds shared utilities (time windows, escaping, name matching) that mirror the server helpers; `edit.js` drives `rediger.html`.
 - Each event row answers only: **when · what · where to watch**. Must-see (favorite / importance≥4 / Norwegian) gets a small accent dot — the gentlest possible emphasis, never a card. Channel shown quietly, with an honest faint "–" when unknown.
 - The editorial agent produces a single `headline` block shown as one quiet line under the date (a "nice extra"), nothing more. AI-research events carry a small ⓘ that opens a source modal on tap.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -292,9 +292,19 @@ skal likevel bestå denne før merge; håndhev det som kan håndheves i CI:
   (true-black `#000000`-side i mørk, `#F2F2F7` grouped-light) og amber som eneste
   aksent. Verdiene er tokenisert i `base.css` og skal stå verifiserbart mot
   denne tabellen. Web beholder sine egne layout-detaljer (én kolonne maks 640px,
-  dag-gruppert agenda, den tikkende amber-klokka i toppen), men fargene og
-  typografien er baseline. Det historiske Tekst-TV-uttrykket (mono type-stack,
-  near-black `#0A0A0C`, varmt-papir) er dermed avviklet.
+  dag-gruppert agenda), men fargene og typografien er baseline. Det historiske
+  Tekst-TV-uttrykket (mono type-stack, near-black `#0A0A0C`, varmt-papir) er
+  dermed avviklet.
+- **Klokke-paritet (WP-128):** den sekundtikkende amber-klokka i web-headeren er
+  **FJERNET** — datoen består, tid bor i raden (samsvar med § Bevegelse og iOS).
+- **Tema-glyf-unntak (WP-128):** web beholder tema-toggle-glyfen ◐ i headeren
+  (system → mørk → lys) som et *bevisst* unntak fra § Tema. iOS flyttet temavalget
+  til Deg › Utseende, men web har ingen Deg-skjerm, så header-glyfen er den eneste
+  plassen det kan bo.
+- **Sport-symbol-unntak (WP-128):** § Radens anatomis per-sport SF-symbol gjelder
+  KUN native flater. Web har ingen SF Symbols, og emoji/logo i kromet er forbudt
+  (§ Forbudsliste), så web signaliserer sport gjennom innholdet (tittel + meta),
+  ikke en per-rad-glyf. Et eget web-ikonsett innføres ikke bare for dette.
 - **Stemme:** norsk, lavmælt, presis. «Kanal ukjent», ikke «Ingen streaming!».
   Aldri utropstegn i kromet. Feil forklarer hva og hvorfor.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -132,7 +132,7 @@ mennesket, aldri av en agent.
 | WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | ⬜ bølge 4 |
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | ⬜ bølge 3 |
 | WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | ⬜ bølge 3 |
-| WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | ⬜ bølge 3 |
+| WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | 🔬 bølge 3 |
 | WP-129 | Onboarding-copy (kapsel-modellen) + stale kommentarer + regenerert skjermkatalog | 0I | WP-117 | ⬜ bølge 4 |
 
 ---

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -1,7 +1,7 @@
 /* Sportivista — the agenda. One quiet list, grouped by day. The flat row language of
-   DESIGN.md: hairlines, one amber dot for must-see, a ticking clock the only
-   motion. No cards, no washes, no left-stripes, no chips, no chevrons, no emoji
-   in the chrome. Each row answers only: when · what · where to watch. */
+   DESIGN.md: hairlines, one amber dot for must-see. No cards, no washes, no
+   left-stripes, no chips, no chevrons, no emoji in the chrome. Each row answers
+   only: when · what · where to watch. */
 
 /* ── Live now: a quiet line at the very top, only when something is on ─────── */
 .live-now { margin: 18px 0 4px; }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -11,8 +11,8 @@
 	.wrap { padding: 0 16px; }
 }
 
-/* Masthead — Sportivista + date, a ticking amber
-   clock. Two quiet rows, one hairline under. */
+/* Masthead — Sportivista + date. Two quiet rows, one hairline under.
+   (WP-128: the ticking amber clock is gone — parity with iOS; time lives in the row.) */
 .masthead {
 	position: sticky;
 	top: 0;
@@ -51,9 +51,11 @@
 	letter-spacing: 0.04em;
 }
 .mast-index { color: var(--fg-3); }
+/* A quiet amber masthead label (tabular). No longer a clock on index.html (WP-128);
+   still used by activity.html for its «aktivitet» page label. */
 .masthead-clock {
 	font-size: 13px;
-	color: var(--accent);          /* the ticking clock — the only continuous motion */
+	color: var(--accent);
 	font-variant-numeric: tabular-nums;
 	letter-spacing: 0.04em;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,6 @@
 			</div>
 			<div class="mast-row mast-row-sub">
 				<p class="mast-date"><span id="hero-date"></span></p>
-				<span class="masthead-clock" id="masthead-clock" aria-hidden="true"></span>
 			</div>
 		</div>
 	</header>

--- a/docs/js/chrome.js
+++ b/docs/js/chrome.js
@@ -1,5 +1,5 @@
-// Sportivista — shell chrome: the ticking clock, the date stamp, the footer (freshness
-// + staleness), the quiet AI-budget line, and the iOS install hint.
+// Sportivista — shell chrome: the date stamp, the footer (freshness + staleness),
+// the quiet AI-budget line, and the iOS install hint.
 // Extends window.Dashboard.prototype (see js/dashboard.js). Loads AFTER dashboard.js.
 Object.assign(window.Dashboard.prototype, {
 
@@ -24,18 +24,6 @@ Object.assign(window.Dashboard.prototype, {
 	renderDate() {
 		const el = document.getElementById('hero-date');
 		if (el) el.textContent = new Date().toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/Oslo' });
-	},
-
-	/** Teletext-style ticking clock in the header. */
-	startClock() {
-		const el = document.getElementById('masthead-clock');
-		if (!el) return;
-		const tick = () => {
-			el.textContent = new Date().toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'Europe/Oslo' });
-		};
-		tick();
-		clearInterval(this._clockInterval);
-		this._clockInterval = setInterval(tick, 1000);
 	},
 
 	renderFooter() {

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -10,7 +10,7 @@
 //   js/live.js     — live-now line + ESPN live polling
 //   js/detail.js   — progressive-disclosure event detail (tap to expand)
 //   js/followed.js — "Dine neste" + "Hva vi følger" index
-//   js/chrome.js   — shell chrome (clock, date, footer, AI-budget, install hint)
+//   js/chrome.js   — shell chrome (date, footer, AI-budget, install hint)
 // Depends on: shared-constants.js.
 
 class Dashboard {
@@ -24,12 +24,15 @@ class Dashboard {
 		this.liveF1 = null;
 		this._liveInterval = null;
 		this._liveVisible = !document.hidden;
+		// Agenda rows the reader has expanded, by event id — remembered so the 60s
+		// live-poll re-render (which rebuilds the agenda's innerHTML) re-opens them
+		// instead of collapsing what's being read (WP-128; mirrors live.js' _liveOpen).
+		this._agendaOpen = new Set();
 	}
 
 	async init() {
 		// Theme is owned by js/theme.js (shared across pages).
 		this.renderDate();
-		this.startClock();
 		await this.loadData();
 		this.render();
 		this._lastRefresh = Date.now();
@@ -96,8 +99,11 @@ class Dashboard {
 	render() {
 		this.renderTodayLine();
 		this.renderLive();
-		this.renderNextUp();
+		// Agenda before "Neste opp": renderAgenda records which event ids are visible
+		// in the window (this._agendaShownIds) so renderNextUp can dedupe a glance row
+		// that already has its own agenda row (WP-128).
 		this.renderAgenda();
+		this.renderNextUp();
 		this.renderFollowed();
 		this.renderFooter();
 		this.renderUsage();
@@ -255,9 +261,12 @@ class Dashboard {
 	}
 
 	// ── The agenda: one list, grouped by day ─────────────────────────────────
-	renderAgenda() {
-		const el = document.getElementById('agenda');
-		if (!el) return;
+	/** The pure grouping behind the agenda: the windowed, series-collapsed events
+	 *  bucketed into day sections. Testable without a DOM. Also records
+	 *  `this._agendaShownIds` (what's visible in the window) so "Neste opp" can
+	 *  dedupe, and rebuilds `this._eventById` for tap-to-expand lookups.
+	 *  Returns { groups: [{ key, name, isToday, events }], hasMore, empty }. */
+	agendaDayGroups() {
 		const now = Date.now();
 		const start = now - 3 * SS_CONSTANTS.MS_PER_HOUR;
 		const maxHorizon = now + 14 * SS_CONSTANTS.MS_PER_DAY;
@@ -275,31 +284,48 @@ class Dashboard {
 
 		this._eventById = new Map(this.allEvents.map((e) => [e.id, e]));
 		for (const it of items) if (it.isSeries) this._eventById.set(it.id, it);
+		// The ids currently on the board (post-collapse) — "Neste opp" dedupes against these.
+		this._agendaShownIds = new Set(shown.map((e) => e.id));
 
-		if (shown.length === 0) {
-			el.innerHTML = `<p class="empty">Ingen kommende arrangementer akkurat nå.</p>`;
-			return;
-		}
+		if (shown.length === 0) return { groups: [], hasMore: false, empty: true };
 
 		const todayKey = this.osloDayKey(new Date());
 		const tomorrowKey = this.osloDayKey(new Date(now + SS_CONSTANTS.MS_PER_DAY));
 		const groups = new Map();
 		for (const e of shown) {
-			// Multi-day events that started earlier but are still running belong under "I dag",
-			// not their (past) start day.
+			// Anything still in the display window whose start day is already past —
+			// a still-running OR just-finished multi-day event (kept briefly with its
+			// FERDIG status/result), or a late-night event from yesterday still inside
+			// the 3h tail — lives under "I dag". A past-day heading must NEVER render
+			// above "I dag" (DESIGN § Agendaen, lov 1: "Aldri passerte dager"; WP-128).
 			let key = this.osloDayKey(new Date(e.time));
-			if (key < todayKey && e.endTime && new Date(e.endTime).getTime() >= now) key = todayKey;
+			if (key < todayKey) key = todayKey;
 			if (!groups.has(key)) groups.set(key, []);
 			groups.get(key).push(e);
 		}
 
-		let html = '';
+		const out = [];
 		for (const [key, evs] of groups) {
 			let name;
 			if (key === todayKey) name = 'I dag';
 			else if (key === tomorrowKey) name = 'I morgen';
 			else name = new Date(evs[0].time).toLocaleDateString('nb-NO', { weekday: 'long', day: 'numeric', month: 'long', timeZone: 'Europe/Oslo' });
-			html += `<section class="day${key === todayKey ? ' is-today' : ''}"><div class="day-name">${escapeHtml(name)}</div>${evs.map((e) => this.eventRow(e)).join('')}</section>`;
+			out.push({ key, name, isToday: key === todayKey, events: evs });
+		}
+		return { groups: out, hasMore, empty: false };
+	}
+
+	renderAgenda() {
+		const el = document.getElementById('agenda');
+		if (!el) return;
+		const { groups, hasMore, empty } = this.agendaDayGroups();
+		if (empty) {
+			el.innerHTML = `<p class="empty">Ingen kommende arrangementer akkurat nå.</p>`;
+			return;
+		}
+		let html = '';
+		for (const g of groups) {
+			html += `<section class="day${g.isToday ? ' is-today' : ''}"><div class="day-name">${escapeHtml(g.name)}</div>${g.events.map((e) => this.eventRow(e)).join('')}</section>`;
 		}
 		if (hasMore) html += `<button type="button" class="agenda-more">Vis resten av de neste to ukene</button>`;
 		el.innerHTML = html;
@@ -308,6 +334,11 @@ class Dashboard {
 		if (!this._revealed) { el.classList.add('reveal'); this._revealed = true; }
 		else { el.classList.remove('reveal'); }
 	}
+
+	/** Is this row currently expanded? Read by eventRow/seriesRow so a re-render
+	 *  bakes the open state back into the HTML — the reader's open row survives the
+	 *  60s live-poll rebuild (WP-128). */
+	isRowOpen(id) { return !!(this._agendaOpen && this._agendaOpen.has(id)); }
 
 	/** Fold same-tournament stage races (cycling "Etappe N", etc.) into one series item. */
 	collapseSeries(events, now) {
@@ -407,15 +438,16 @@ class Dashboard {
 		else if (done) trailing = `<span class="ev-done">Ferdig${done.score ? `<span class="ev-done-score">${escapeHtml(done.score)}</span>` : ''}</span>`;
 		else trailing = this.whereToWatch(e);
 		const expandable = this.hasDetail(e);
+		const open = expandable && this.isRowOpen(e.id);
 		const attrs = expandable
-			? ` role="button" tabindex="0" aria-expanded="false" data-event-id="${escapeHtml(e.id)}"`
+			? ` role="button" tabindex="0" aria-expanded="${open}" data-event-id="${escapeHtml(e.id)}"`
 			: '';
 		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${status ? ' cancelled' : ''}${done ? ' done' : ''}${expandable ? ' expandable' : ''}"${attrs}>
 			${this.dotCell(this.isMustSee(e))}
 			<span class="ev-time">${escapeHtml(this.timeLabel(e))}</span>
 			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${this.eventMeta(e, trailing)}</span>
 			${this.infoCell(e)}
-		</div><div class="ev-detail" hidden></div></div>`;
+		</div><div class="ev-detail"${open ? '' : ' hidden'}>${open ? this.eventDetail(e) : ''}</div></div>`;
 	}
 
 	/** A stage race collapsed to one line: next stage + count, tap to expand. */
@@ -424,12 +456,13 @@ class Dashboard {
 		const m = String(s.nextStage.title || '').match(/(etappe|stage)\s*\d+/i);
 		const nextLabel = m ? m[0] : ssShortName(s.nextStage.title || '');
 		const meta = `neste: ${escapeHtml(nextLabel)}<span class="ev-sep"> · </span>${s.stages.length} etapper<span class="ev-sep"> · </span>${this.whereToWatch(s.nextStage)}`;
-		return `<div class="ev-wrap"><div class="ev expandable series" role="button" tabindex="0" aria-expanded="false" data-event-id="${escapeHtml(s.id)}">
+		const open = this.isRowOpen(s.id);
+		return `<div class="ev-wrap"><div class="ev expandable series" role="button" tabindex="0" aria-expanded="${open}" data-event-id="${escapeHtml(s.id)}">
 			${this.dotCell(false)}
 			<span class="ev-time">${escapeHtml(this.osloTime(date))}</span>
 			<span class="ev-main"><span class="ev-title">${escapeHtml(s.tournament)}</span><span class="ev-meta">${meta}</span></span>
 			<span></span>
-		</div><div class="ev-detail" hidden></div></div>`;
+		</div><div class="ev-detail"${open ? '' : ' hidden'}>${open ? this.eventDetail(s) : ''}</div></div>`;
 	}
 
 	/** Expanded series: every stage as a quiet line (past ones dimmed). */
@@ -469,6 +502,11 @@ class Dashboard {
 			if (!open && !detail.innerHTML) detail.innerHTML = this.eventDetail(e);
 			row.setAttribute('aria-expanded', String(!open));
 			detail.hidden = open;
+			// Remember open rows so the 60s live-poll re-render (renderAgenda's
+			// innerHTML rebuild) re-opens whatever the reader has expanded — eventRow
+			// reads this set and bakes the open state back into the HTML (WP-128).
+			this._agendaOpen = this._agendaOpen || new Set();
+			if (open) this._agendaOpen.delete(id); else this._agendaOpen.add(id);
 		};
 		agenda.addEventListener('click', (evt) => {
 			const link = evt.target.closest('a');

--- a/docs/js/followed.js
+++ b/docs/js/followed.js
@@ -14,9 +14,15 @@ Object.assign(window.Dashboard.prototype, {
 		// WP-96: sourced from the catalog (what we cover), not a personal profile.
 		const at = this.covers && this.covers.alwaysTrack;
 		if (!at) return [];
+		// WP-128: don't repeat an entity's next event in the glance when that same
+		// event already has its own visible agenda row in the window (renderAgenda
+		// records the shown ids). Absent the set (e.g. before first agenda render),
+		// no dedupe — the glance still shows everything.
+		const shown = this._agendaShownIds;
 		return [...(at.athletes || []), ...(at.teams || [])]
 			.map((entry) => ({ entry, next: this.nextEventForEntity(entry) }))
 			.filter((x) => x.next)
+			.filter((x) => !(shown && shown.has(x.next.id)))
 			.sort((a, b) => new Date(a.next.time) - new Date(b.next.time));
 	},
 

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -566,3 +566,107 @@ describe("loadData: stable id from the server, index fallback for old payloads",
 		expect(html).toContain("1–0"); // eventRow reads this.liveScores[e.id] and rendered the live score
 	});
 });
+
+// WP-128: a just-finished multi-day event (endTime just past, start day in the past)
+// stayed in the display window but kept its PAST start-day heading, which then sat
+// ABOVE «I dag» (19.–20.07 the finished Corales/«Torsdag 16. juli» tronet øverst) —
+// a break of DESIGN § Agendaen lov 1 ("Aldri passerte dager"). It must live under
+// «I dag» instead; a past-day heading must never render. Tested on the pure grouping.
+describe("agenda day grouping: no past-day heading above «I dag» (WP-128)", () => {
+	const hoursAgo = (h) => new Date(Date.now() - h * 3600000).toISOString();
+	const daysAgo = (d) => new Date(Date.now() - d * 86400000).toISOString();
+	const inHours = (h) => new Date(Date.now() + h * 3600000).toISOString();
+
+	it("buckets a just-finished multi-day event (past start day) under «I dag», never its past start day", () => {
+		dash._fullHorizon = false;
+		dash.allEvents = [
+			// Started 4 days ago, ended ~1h ago — still inside the 3h recently-finished
+			// tail (so it's shown), but its start day is in the past.
+			{ id: "corales", sport: "golf", title: "Corales Championship", time: daysAgo(4), endTime: hoursAgo(1) },
+			{ id: "today1", sport: "football", title: "A vs B", homeTeam: "A", awayTeam: "B", time: inHours(2) },
+		];
+		const { groups } = dash.agendaDayGroups();
+		const todayKey = dash.osloDayKey(new Date());
+		// No heading may sit on a past day, and «I dag» is first (nothing above it).
+		expect(groups.every((g) => g.key >= todayKey)).toBe(true);
+		expect(groups[0].name).toBe("I dag");
+		// The finished multi-day event lives under «I dag».
+		const today = groups.find((g) => g.isToday);
+		expect(today.events.some((e) => e.id === "corales")).toBe(true);
+	});
+
+	it("keeps «I dag» the first heading even when the only event is a past-start one", () => {
+		dash._fullHorizon = false;
+		dash.allEvents = [
+			{ id: "solo", sport: "golf", title: "Some Championship", time: daysAgo(3), endTime: hoursAgo(2) },
+		];
+		const { groups } = dash.agendaDayGroups();
+		expect(groups).toHaveLength(1);
+		expect(groups[0].name).toBe("I dag");
+		expect(groups[0].isToday).toBe(true);
+	});
+});
+
+// WP-128: the live poller re-renders the whole agenda (innerHTML rebuild) every 60s,
+// which used to collapse whatever row the reader had expanded. eventRow now reads the
+// remembered-open set (this._agendaOpen) and bakes the open state back into the HTML,
+// so a re-render re-opens it. Tested on the pure eventRow string.
+describe("expanded agenda rows survive a live-poll re-render (WP-128)", () => {
+	const soon = () => new Date(Date.now() + 3600000).toISOString();
+	// Golf + venue → genuinely expandable (hasDetail true), with «Royal Portrush» in the detail.
+	const ev = { id: "exp1", sport: "golf", title: "The Open", time: soon(), venue: "Royal Portrush" };
+
+	it("renders aria-expanded=false with an empty, hidden detail when not remembered open", () => {
+		dash._agendaOpen = new Set();
+		const html = dash.eventRow(ev);
+		expect(html).toContain('aria-expanded="false"');
+		expect(html).toContain('class="ev-detail" hidden></div>'); // detail is empty + hidden
+		expect(html).not.toContain("Royal Portrush");
+	});
+
+	it("bakes the open state back into the row when the id is remembered (survives the rebuild)", () => {
+		dash._agendaOpen = new Set(["exp1"]);
+		const html = dash.eventRow(ev);
+		expect(html).toContain('aria-expanded="true"');
+		expect(html).not.toContain('class="ev-detail" hidden'); // detail shown, not hidden
+		expect(html).toContain("Royal Portrush");                // detail content present after the rebuild
+	});
+
+	it("isRowOpen reflects the remembered-open set", () => {
+		dash._agendaOpen = new Set(["exp1"]);
+		expect(dash.isRowOpen("exp1")).toBe(true);
+		expect(dash.isRowOpen("nope")).toBe(false);
+	});
+});
+
+// WP-128: «Neste opp» must not repeat an entity's next event when that same event
+// already has its own visible agenda row in the window (renderAgenda records the
+// shown ids). Without the set (before the first agenda render) it shows everything.
+describe("«Neste opp» dedupes rows already visible in the agenda (WP-128)", () => {
+	const inDays = (n) => new Date(Date.now() + n * 86400000).toISOString();
+
+	it("drops a glance entry whose next event already has an agenda row in the window", () => {
+		dash.covers = { alwaysTrack: {
+			athletes: [{ name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis" }],
+			teams: [{ name: "Lyn", sport: "football" }],
+		} };
+		dash.allEvents = [
+			{ id: "ruud-swiss", sport: "tennis", title: "Swiss Open (Casper Ruud)", time: inDays(3) },
+			{ id: "lyn-match", sport: "football", title: "Strømsgodset – Lyn", homeTeam: "Strømsgodset", awayTeam: "Lyn", time: inDays(5) },
+		];
+		// Ruud's next event is already a visible agenda row; Lyn's is not.
+		dash._agendaShownIds = new Set(["ruud-swiss"]);
+		const rows = dash.nextUpEntries();
+		expect(rows.map((r) => r.entry.name)).toEqual(["Lyn"]);
+	});
+
+	it("shows everything when no agenda has rendered yet (no shown-id set)", () => {
+		dash.covers = { alwaysTrack: {
+			athletes: [{ name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis" }],
+			teams: [],
+		} };
+		dash.allEvents = [{ id: "ruud-swiss", sport: "tennis", title: "Swiss Open (Casper Ruud)", time: inDays(3) }];
+		dash._agendaShownIds = undefined;
+		expect(dash.nextUpEntries().map((r) => r.entry.name)).toEqual(["Casper Ruud"]);
+	});
+});


### PR DESCRIPTION
Implementerer **WP-128 · Web-agenda** (bølge 3): de to høy/middels-funnene fra WP-117-auditene + DESIGN-avstemming. Grensen respektert: kun `renderAgenda`/dag-gruppering/`chrome.js`/`followed.js` + docs. `docs/data/`, `live.js` og `detail.js` er ikke rørt.

## (1) Fortids-dag-fiks (høyest)
`renderAgenda` er splittet i en ren, DOM-fri `agendaDayGroups()` + selve DOM-skrivingen. Grupperingsregelen endret fra «bare still-running flerdagsevents flyttes til I DAG» til **«alt som fortsatt er i visningsvinduet men har startdag i fortiden lever under I DAG»**. Dermed lager en ferdigspilt flerdagsevent (`endTime < nå`, men innenfor 3t-halen så den fortsatt vises) aldri en fortids-dagoverskrift ØVER «I dag» (DESIGN § Agendaen lov 1: «Aldri passerte dager»). FERDIG-status/resultatverdien beholdes.

Bekreftet på live-data (20.07): «Corales Puntacana Championship» (startet 16.07, FERDIG) og «EFG Swiss Open Gstaad» (startet 17.07) ligger nå under **I DAG** — ikke under en «TORSDAG 16. JULI»-overskrift øverst som før.

## (2) Ekspandert tilstand over live-poll
Live-pollingen re-renderer agendaen hvert 60. s (innerHTML-rebuild) og lukket raden brukeren leste. `eventRow`/`seriesRow` leser nå `this._agendaOpen` (event-id-er brukeren har åpnet, oppdatert i `bindAgendaExpand`-toggle) og **baker den åpne tilstanden inn i HTML-en** (`aria-expanded` + forhåndsfylt detalj), så re-render gjenåpner raden. Samme mønster som `live.js`' `_liveOpen`.

## (3) Klokke-avstemming (eierbeslutning: fjern)
Den sekundtikkende amber-klokka i web-headeren er **fjernet** for paritet med iOS (DESIGN § Bevegelse kalte den alt «skall, ikke visjon»). Datoen består.
- `DESIGN.md § Cross-surface` rettet (motsa § Bevegelse): klokke-linja fjernet; **tema-glyf-unntaket ◐** dokumentert (web har ingen Deg-skjerm, så header-glyfen er eneste plass for tema-toggle); **sport-symbol-web-unntaket** dokumentert (se (4b)).
- `CLAUDE.md`-frontendlinjene oppdatert.
- Død klokke-kode ryddet: `chrome.js startClock`, `#masthead-clock`-span i `index.html`, CSS-kommentarer i `layout.css`/`cards.css`. **`.masthead-clock`-klassen beholdt** — `activity.html` gjenbruker den som «aktivitet»-etikett (utenfor denne pakkens eierskap).

## (4) Småplukk
- **(a) «Neste opp»-dedupe:** `followed.js nextUpEntries` filtrerer nå bort en glimt-rad hvis entitetens neste event allerede har en synlig agendarad i vinduet (`this._agendaShownIds`, satt av `renderAgenda`; `render()` omordnet så agendaen kjører før «Neste opp»). Bekreftet på live-data: «100 Thieves» (spiller onsdag, synlig agendarad) er deduplisert bort fra «Neste opp», mens fjern-fremtidige entiteter (om 9–23 dager) blir stående.
- **(b) Sport-symbol på web:** **droppet** — ville krevd et nytt ikonsystem (SF Symbols finnes ikke på web; emoji/logo forbudt i kromet, § Forbudsliste). Web-unntaket dokumentert i `DESIGN.md § Cross-surface` i stedet.

## Tester
Nye tester i `tests/dashboard-cards.test.js`:
- Fortids-dag: `agendaDayGroups()` grupperer en ferdigspilt flerdagsevent under «I dag»; ingen overskrift på passert dag; «I dag» først.
- Ekspandert overlever re-render: `eventRow` baker åpen tilstand (aria-expanded + detalj) når id-en er husket; lukket = tom/hidden detalj; `isRowOpen`.
- «Neste opp»-dedupe mot `_agendaShownIds`.

`npx vitest run --maxWorkers=1`: **grønn — 45 filer / 682 tester** (dashboard-cards: 65, +7 nye).

## Skjermbilder (ikke committet)
`npm run screenshot` @ 393px full-page, begge temaer:
- **Mørk (true-black):** header viser kun «SPORTIVISTA:» + «MANDAG 20. JULI» + tema-glyf ◐ — ingen klokke. «I DAG» øverst med Corales (FERDIG) + Swiss Open som flerdags-vindusrader.
- **Lys (grouped-light #F2F2F7):** identisk struktur, korrekte semantiske flater, amber kun som aksent (ordmerke-kolon, seksjonsoverskrifter, must-see-prikk).
Begge rolige, ingen trunkering/overflow, ingen fortids-dag.

PLAN.md: WP-128 ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
