### PR TITLE
WP-121: iOS leverings-ferskhet — varsel-reconcile + widget-reload + foregrunn-sync

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -125,7 +125,7 @@ mennesket, aldri av en agent.
 | WP-118 | Kjernefunksjonalitet-audit (read-only rapport) | 0I | — | ✅ rapport levert 20.07 — 🔴 varsel-reconcile kun ved kald oppstart; 🔴 widget-timeline aldri invalidert ved sync; 🟡 ingen foregrunn-sync, horisont-divergens (web 14d-cap/iOS ingen/data 42d), ICS uten DTEND, 100T-entitetsdublett + intet lens-miss-signal → WP-121–125 |
 | WP-119 | Portmåling-artefakt (port-report fra verify/coverage/build-alert) | 0I | — | 🔬 PR åpen — `scripts/build-port-report.js` (kjøres fra build-events før writeManifest, ingen workflow-endring) → `docs/data/port-report.json`; fire porter (coverage/amendRate/silentStops/participantStatus) grønn/gul/rød + ærlig `basis` (manglende kilde ⇒ «ukjent», aldri stille grønn); .gitignore-whitelist + manifest auto-inkluderer; nye tester (grønn/gul/rød/ukjent + integrasjon) |
 | WP-120 | «Det du følger»: visning + håndtering (fra WP-117-funn) | 0I | WP-117 | ⬜ bølge 3 |
-| WP-121 | iOS leverings-ferskhet: varsel-reconcile + widget-reload + foregrunn-sync | 0I | WP-118 | ⬜ bølge 2 |
+| WP-121 | iOS leverings-ferskhet: varsel-reconcile + widget-reload + foregrunn-sync | 0I | WP-118 | 🔬 bølge 2 — reconcile på alle sync-veier (SyncFreshness) + WidgetCenter-reload + foregrunn-gate; SyncFreshnessTests |
 | WP-122 | ~~Deltaker widget/detalj~~ → slått inn i WP-127 | 0I | — | — |
 | WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | 🔬 bølge 3 |
 | WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |

--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -54,6 +54,13 @@ final class AgendaViewModel {
     /// up on the board immediately ("umiddelbar konsekvens"). Shared instance
     /// with AssistantViewModel via ContentView.
     private let profileStore: ProfileStore
+    /// WP-121 — the post-sync freshness step (widget reload + notification
+    /// reconcile). Pull-to-refresh re-synced + recompiled the board but NEVER
+    /// reconciled reminders nor nudged the widget (audit 🔴/🟡); `refresh()` now
+    /// runs it, so a moved event refreshes the push and the widget on a manual
+    /// pull too — not only at cold start. Shared with ContentView (same planner +
+    /// widget reloader instances) so every sync path behaves identically.
+    private let freshness: SyncFreshness
 
     // MARK: - WP-60 — off-main reload plumbing
 
@@ -78,10 +85,11 @@ final class AgendaViewModel {
     /// once per compute the running reload performs.
     private(set) var recompileCount = 0
 
-    init(dataStore: DataStore = DataStore(), syncClient: SyncClient = SyncClient(), profileStore: ProfileStore = ProfileStore()) {
+    init(dataStore: DataStore = DataStore(), syncClient: SyncClient = SyncClient(), profileStore: ProfileStore = ProfileStore(), freshness: SyncFreshness = SyncFreshness()) {
         self.dataStore = dataStore
         self.syncClient = syncClient
         self.profileStore = profileStore
+        self.freshness = freshness
     }
 
     /// Shows whatever is already cached immediately, then syncs and
@@ -90,11 +98,28 @@ final class AgendaViewModel {
     /// agenda instead of a placeholder row + event count.
     func refresh(now: Date = Date()) async {
         reloadFromCache(now: now)
-        _ = await syncClient.sync()
+        // WP-121: snapshot events BEFORE the sync so a moved/added/removed event
+        // can be diffed after it — pull-to-refresh must keep reminders + the
+        // widget as fresh as the cold-start path does.
+        let previousEvents = dataStore.loadEvents()
+        let result = await syncClient.sync()
         // WP-60: a sync may have rewritten entities.json — drop the cached index
         // so the post-sync reload rebuilds it from fresh data.
         invalidateEntityCache()
         reloadFromCache(now: now)
+        // WP-121: reload the widget (events/entities changed) + reconcile
+        // reminders (events changed), the SAME gates the cold-start path uses.
+        // A 304/no-op sync decides to do neither, so a pull that finds nothing
+        // new is free of both. Planning/diff semantics are unchanged.
+        await freshness.run(
+            result: result,
+            previousEvents: previousEvents,
+            newEvents: dataStore.loadEvents(),
+            interests: dataStore.loadInterests() ?? Interests(),
+            lastSync: dataStore.lastSync,
+            now: now,
+            leadTimeEnabled: NotificationLeadPreference.isLeadTimeEnabled()
+        )
         // Pull-to-refresh awaits this method — end the spinner only once the
         // recompiled board is actually applied (not merely scheduled).
         await awaitReloadsQuiescent()

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -41,6 +41,11 @@ struct ContentView: View {
     let syncClient: SyncClient
     let dataStore: DataStore
     let notificationPlanner: NotificationPlanner
+    /// WP-121 — the WidgetKit reload seam. `reloadAllTimelines()` had zero call
+    /// sites before WP-121 (audit 🔴), leaving the widget up to ~24h stale; the
+    /// sync hook now nudges it whenever events/entities change. Injectable
+    /// (defaults to the real WidgetCenter) so the seam is uniform across paths.
+    let widgetReloader: WidgetReloading
     /// WP-16.4 — the one profile store the agenda AND the assistant share.
     let profileStore: ProfileStore
     /// WP-19 — offline-first profile sync. LocalOnly by default (a no-op on the
@@ -101,6 +106,12 @@ struct ContentView: View {
     /// WP-66 — an event id the assistant's «vis <hendelse>» command resolved;
     /// handed to AgendaView to raise its detail sheet, then cleared by it.
     @State private var requestedEventID: String?
+    /// WP-121 — guards the foreground-refresh path against re-entrancy: a rapid
+    /// background→foreground toggle before the first refresh has updated
+    /// `lastSync` could otherwise fire two overlapping `refresh()` (and two
+    /// `syncClient.sync()`). Set on the main actor before the task, cleared when
+    /// it finishes; the WP-60 coalescing already collapses the agenda-reload half.
+    @State private var foregroundRefreshInFlight = false
 
     @AppStorage(ThemeOverride.storageKey) private var themeOverrideRaw = ThemeOverride.system.rawValue
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -114,12 +125,14 @@ struct ContentView: View {
         syncClient: SyncClient = SyncClient(),
         dataStore: DataStore = DataStore(),
         notificationPlanner: NotificationPlanner = NotificationPlanner(),
+        widgetReloader: WidgetReloading = WidgetCenterReloader(),
         profileStore: ProfileStore = ProfileStore(),
         profileSync: ProfileSyncCoordinator = ProfileSyncCoordinator(backend: ProfileSyncBackendFactory.make())
     ) {
         self.syncClient = syncClient
         self.dataStore = dataStore
         self.notificationPlanner = notificationPlanner
+        self.widgetReloader = widgetReloader
         self.profileStore = profileStore
         self.profileSync = profileSync
         #if DEBUG
@@ -131,7 +144,11 @@ struct ContentView: View {
         UITestSeed.seedIfRequested(profileStore: profileStore)
         #endif
         let _t0 = CFAbsoluteTimeGetCurrent()
-        self._agenda = State(initialValue: AgendaViewModel(dataStore: dataStore, syncClient: syncClient, profileStore: profileStore))
+        // WP-121: the agenda's pull-to-refresh shares THIS view's planner +
+        // widget reloader (one SyncFreshness), so every sync path — cold start,
+        // background, pull — reconciles reminders + reloads the widget the same way.
+        let freshness = SyncFreshness(notificationPlanner: notificationPlanner, widgetReloader: widgetReloader)
+        self._agenda = State(initialValue: AgendaViewModel(dataStore: dataStore, syncClient: syncClient, profileStore: profileStore, freshness: freshness))
         LaunchTrace.mark("agendaVM init", since: _t0)
         #if DEBUG
         // Screenshot harness: back the assistant with the deterministic mock
@@ -481,9 +498,31 @@ struct ContentView: View {
         }
         // WP-19 — offline-first pull → merge → push on foreground (a no-op on the
         // LocalOnly backend; the real round-trip only happens on a CloudKit build).
-        .onChange(of: scenePhase) { _, phase in
+        // Runs on EVERY becoming-active, unchanged.
+        // WP-121 — data-freshness on foreground: a genuine return FROM background
+        // to a STALE cache (≥15 min since the last data sync) runs a FULL refresh
+        // (sync + agenda reload + widget reload + notification reconcile). Before
+        // WP-121 foreground ran ONLY the profile CloudKit round (audit 🟡), so an
+        // app left open for hours showed a stale board until the next background
+        // task. Gating on `oldPhase == .background` keeps the launch inactive→active
+        // (the cold-start `.task` owns that) and a transient control-center peek
+        // (active→inactive→active) from re-syncing; the staleness gate skips a quick
+        // return (< 15 min); the in-flight flag + WP-60 coalescing keep a rapid
+        // toggle from double-syncing.
+        .onChange(of: scenePhase) { oldPhase, phase in
             guard phase == .active else { return }
             Task { await assistant.runBackgroundSync(using: profileSync) }
+            guard oldPhase == .background else { return }
+            if !foregroundRefreshInFlight,
+               ForegroundSyncGate.shouldRefresh(lastSync: dataStore.lastSync, now: Date()) {
+                foregroundRefreshInFlight = true
+                // @MainActor so the post-await flag reset stays on the main actor
+                // (refresh() is itself @MainActor; the flag is @State on this View).
+                Task { @MainActor in
+                    await refresh()
+                    foregroundRefreshInFlight = false
+                }
+            }
         }
     }
 
@@ -628,6 +667,14 @@ struct ContentView: View {
         if changedFiles.contains("entities.json") { agenda.invalidateEntityCache() }
         if !changedFiles.isDisjoint(with: agendaInputs) {
             agenda.reloadFromCache(now: Date())
+        }
+        // WP-121: the home-screen widget reads events (+ entities via the feed);
+        // nudge WidgetKit to rebuild its timeline whenever either changed, so it
+        // never sits behind the app's own board (its own reload policy only fires
+        // at the Oslo day boundary — the audit's ~24h-stale 🔴). A 304/no-op sync
+        // changes neither, so a quiet launch skips it.
+        if !changedFiles.isDisjoint(with: SyncFreshness.widgetInputs) {
+            widgetReloader.reloadAllTimelines()
         }
         #if DEBUG
         // The screenshot harness must not trip the first-launch notification

--- a/ios/Sportivista/Notifications/NotificationScheduling.swift
+++ b/ios/Sportivista/Notifications/NotificationScheduling.swift
@@ -39,13 +39,24 @@ protocol NotificationScheduling: Sendable {
 /// (one `let` reference, no locally-mutated state), the same shape the
 /// strict-concurrency checker can't verify on its own for a framework type.
 final class UNUserNotificationScheduler: NotificationScheduling, @unchecked Sendable {
-    private let center: UNUserNotificationCenter
+    /// Resolves the notification center lazily, on first actual use — merely
+    /// CONSTRUCTING this scheduler must never touch
+    /// `UNUserNotificationCenter.current()`. `.current()` throws in a hostless
+    /// process (no app bundle → `bundleProxyForCurrentProcess is nil`), so an
+    /// eager call in `init` would crash any code that builds a *default*
+    /// NotificationPlanner/SyncFreshness inside the hostless SportivistaTests bundle
+    /// — WP-121 made that reachable, since AgendaViewModel now carries a default
+    /// SyncFreshness and its unit tests construct it with no running app. The
+    /// real app always has a bundle, so lazy vs. eager resolution is behaviourally
+    /// identical there (and `.current()` returns the same singleton either way).
+    private let resolveCenter: @Sendable () -> UNUserNotificationCenter
 
-    init(center: UNUserNotificationCenter = .current()) {
-        self.center = center
+    init(center: @autoclosure @escaping @Sendable () -> UNUserNotificationCenter = .current()) {
+        self.resolveCenter = center
     }
 
     func requestAuthorizationIfNeeded() async -> Bool {
+        let center = resolveCenter()
         let settings = await center.notificationSettings()
         switch settings.authorizationStatus {
         case .authorized, .provisional, .ephemeral:
@@ -73,10 +84,10 @@ final class UNUserNotificationScheduler: NotificationScheduling, @unchecked Send
         let interval = max(request.fireDate.timeIntervalSinceNow, 1)
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
         let osRequest = UNNotificationRequest(identifier: request.id, content: content, trigger: trigger)
-        try? await center.add(osRequest)
+        try? await resolveCenter().add(osRequest)
     }
 
     func cancel(id: String) async {
-        center.removePendingNotificationRequests(withIdentifiers: [id])
+        resolveCenter().removePendingNotificationRequests(withIdentifiers: [id])
     }
 }

--- a/ios/Sportivista/Sync/BackgroundRefreshScheduler.swift
+++ b/ios/Sportivista/Sync/BackgroundRefreshScheduler.swift
@@ -56,11 +56,40 @@ enum BackgroundRefreshScheduler {
         scheduleNextRefresh(dataStore: dataStore) // line up the next one first, per Apple's guidance
 
         let syncTask = Task {
-            _ = await syncClient.sync()
+            await syncAndFreshen(syncClient: syncClient, dataStore: dataStore)
             task.setTaskCompleted(success: true)
         }
         task.expirationHandler = {
             syncTask.cancel()
         }
+    }
+
+    /// WP-121 — the background refresh's WORK, split out of `handle` so it runs
+    /// without a real BGAppRefreshTask (the wrapper above still isn't unit-tested;
+    /// this delegates to `SyncFreshness`, which IS). Before WP-121 the background
+    /// sync called `syncClient.sync()` and NOTHING else — a server-side event move
+    /// left the already-scheduled push at its old time (audit 🔴) and the widget
+    /// untouched. Now it snapshots events around the sync and, on change,
+    /// reconciles reminders + reloads the widget with the SAME quality gates the
+    /// cold-start path uses. The `SyncFreshness` seam defaults to production but is
+    /// injectable so a test can drive it with a RecordingNotificationScheduler +
+    /// a recording widget reloader.
+    static func syncAndFreshen(
+        syncClient: SyncClient,
+        dataStore: DataStore,
+        freshness: SyncFreshness = SyncFreshness(),
+        now: Date = Date()
+    ) async {
+        let previousEvents = dataStore.loadEvents()
+        let result = await syncClient.sync()
+        await freshness.run(
+            result: result,
+            previousEvents: previousEvents,
+            newEvents: dataStore.loadEvents(),
+            interests: dataStore.loadInterests() ?? Interests(),
+            lastSync: dataStore.lastSync,
+            now: now,
+            leadTimeEnabled: NotificationLeadPreference.isLeadTimeEnabled()
+        )
     }
 }

--- a/ios/Sportivista/Sync/SyncFreshness.swift
+++ b/ios/Sportivista/Sync/SyncFreshness.swift
@@ -1,0 +1,129 @@
+//
+//  SyncFreshness.swift
+//  Sportivista
+//
+//  WP-121 — the post-sync "delivery freshness" step shared by EVERY sync path
+//  (cold-start ContentView.refresh, the background BGAppRefreshTask, and
+//  pull-to-refresh): after a sync, keep the home-screen widget and the
+//  scheduled push reminders as fresh as the cache the sync just wrote.
+//
+//  Two 🔴 findings from the WP-118 kjernefunksjonalitet-audit motivated it:
+//    1. `NotificationPlanner.reconcile` had ONE call site (cold start only), so
+//       a background/pull sync that MOVED an event left its push at the old time
+//       — "feil tid i et push-varsel er det dyreste tillitsbruddet appen kan begå".
+//    2. `WidgetCenter.reloadAllTimelines()` had ZERO call sites, so the widget
+//       could sit up to ~24h behind (its own reload policy only fires at the
+//       Oslo day boundary).
+//
+//  Pure/impure split, like the rest of the codebase: `decide(from:)` is a pure
+//  function of the SyncResult (unit-tested directly), and `run(...)` performs the
+//  decided actions against injected seams (a `WidgetReloading` + a
+//  `NotificationPlanner`), so tests verify BOTH with a recording widget reloader
+//  and a RecordingNotificationScheduler — no running app, no real WidgetKit host,
+//  no OS permission prompt. The notification planning/diff semantics themselves
+//  are untouched (WP-121 non-goal): `run` just calls the existing, proven
+//  `reconcile` with the same quality gates the cold-start path uses.
+//
+
+import Foundation
+
+struct SyncFreshness: Sendable {
+    /// The files whose change means the widget must rebuild: its timeline reads
+    /// events (and, through the feed, entities). tracked/interests never reach
+    /// the widget's timeline, so a change to only those is not a widget reload.
+    static let widgetInputs: Set<String> = ["events.json", "entities.json"]
+    /// The file whose change means reminders must be reconciled: reminders are
+    /// keyed off events (their time/streaming/mustWatch), nothing else.
+    static let notificationInputs: Set<String> = ["events.json"]
+
+    var notificationPlanner: NotificationPlanner
+    var widgetReloader: WidgetReloading
+
+    init(
+        notificationPlanner: NotificationPlanner = NotificationPlanner(),
+        widgetReloader: WidgetReloading = WidgetCenterReloader()
+    ) {
+        self.notificationPlanner = notificationPlanner
+        self.widgetReloader = widgetReloader
+    }
+
+    // MARK: - Pure decision (unit-testable, no seams needed)
+
+    struct Decision: Equatable {
+        var reloadWidget: Bool
+        var reconcileNotifications: Bool
+    }
+
+    /// What a completed sync should trigger, from the files it actually wrote.
+    /// A 304 (`upToDate`) or a manifest `failure` wrote nothing → no work. This
+    /// is the SAME signal ContentView.refresh already keys off (`SyncResult`),
+    /// so the three sync paths agree on when freshness work is needed.
+    static func decide(from result: SyncResult) -> Decision {
+        let changed: Set<String>
+        switch result {
+        case .changedFiles(let files): changed = Set(files)
+        case .upToDate, .failure: changed = []
+        }
+        return Decision(
+            reloadWidget: !changed.isDisjoint(with: widgetInputs),
+            reconcileNotifications: !changed.isDisjoint(with: notificationInputs)
+        )
+    }
+
+    // MARK: - Execution (impure — the only part that touches the seams)
+
+    /// Perform the freshness actions a completed sync calls for: reload the
+    /// widget when its inputs changed, then reconcile reminders when events
+    /// changed (using the before/after snapshots the caller took around the
+    /// sync). Returns the notification operations for tests. `plain` values
+    /// (not autoclosures) keep this unambiguously `Sendable` across the
+    /// main-actor → nonisolated hop the pull/background callers make.
+    @discardableResult
+    func run(
+        result: SyncResult,
+        previousEvents: [Event],
+        newEvents: [Event],
+        interests: Interests,
+        lastSync: Date?,
+        now: Date = Date(),
+        leadTimeEnabled: Bool
+    ) async -> [NotificationOperation] {
+        let decision = Self.decide(from: result)
+        if decision.reloadWidget {
+            widgetReloader.reloadAllTimelines()
+        }
+        guard decision.reconcileNotifications else { return [] }
+        return await notificationPlanner.reconcile(
+            previousEvents: previousEvents,
+            newEvents: newEvents,
+            interests: interests,
+            now: now,
+            lastSync: lastSync,
+            leadTimeEnabled: leadTimeEnabled
+        )
+    }
+}
+
+/// WP-121 — the pure gate for foreground data-refresh. When the app becomes
+/// active (`scenePhase == .active`) the audit's third finding wants a full
+/// refresh if the cache has gone stale — but only then, so a quick app-switch
+/// doesn't hammer the network (the cold-start `.task` and the BGAppRefreshTask
+/// cover the rest). Split out as a pure function so it is testable with an
+/// injected clock (no scenePhase, no real time).
+enum ForegroundSyncGate {
+    /// How stale the cache may get before becoming active re-syncs it. Chosen
+    /// well under the research agent's 4h cadence so the board is never more
+    /// than a few minutes behind when the user actually opens the app, without
+    /// re-fetching on every glance.
+    static let staleness: TimeInterval = 15 * 60
+
+    /// Whether becoming active should trigger a full refresh: only when we have
+    /// synced before AND it was at least `staleness` ago. A never-synced cache
+    /// (`nil`) is left to the cold-start `.task` refresh — returning `false`
+    /// here avoids double-syncing at launch, where scenePhase also flips to
+    /// `.active` right as `.task` is already fetching.
+    static func shouldRefresh(lastSync: Date?, now: Date, staleness: TimeInterval = staleness) -> Bool {
+        guard let lastSync else { return false }
+        return now.timeIntervalSince(lastSync) >= staleness
+    }
+}

--- a/ios/Sportivista/Sync/WidgetReloading.swift
+++ b/ios/Sportivista/Sync/WidgetReloading.swift
@@ -1,0 +1,42 @@
+//
+//  WidgetReloading.swift
+//  Sportivista
+//
+//  WP-121: a thin seam over WidgetKit's
+//  `WidgetCenter.shared.reloadAllTimelines()` so the app can nudge the
+//  home-screen widget to rebuild the instant a sync changes the data it
+//  renders — and so tests can VERIFY that nudge without a running WidgetKit
+//  host (a recording double substitutes for the real, global WidgetCenter,
+//  the same shape RecordingNotificationScheduler uses for
+//  UNUserNotificationCenter).
+//
+//  Why this exists at all: the WP-118 audit found `reloadAllTimelines()` had
+//  ZERO call sites in the whole app — the widget's own timeline reload policy
+//  only rebuilds at the Europe/Oslo day boundary (see SportivistaWidget's
+//  TimelineReloadPolicy), so between midnights the widget could sit up to ~24h
+//  behind an event the server had moved. Every sync path (cold-start refresh,
+//  background BGAppRefreshTask, pull-to-refresh) now calls this on a data change.
+//
+//  Lives in Sportivista/Sync but is deliberately NOT in the widget target's
+//  source list (project.yml lists the widget's Sync files individually): the
+//  APP reloads the widget, the widget never reloads itself — keeping this out
+//  of the extension keeps "ingen nettverk/app-lifecycle-kode i widgeten" intact.
+//
+
+import Foundation
+import WidgetKit
+
+/// Asks WidgetKit to rebuild every timeline for this app's widgets. One method,
+/// so a test double is trivial and the production path is a single system call.
+protocol WidgetReloading: Sendable {
+    func reloadAllTimelines()
+}
+
+/// The production seam, backed by the real `WidgetCenter`. A value type with no
+/// stored state — trivially `Sendable`; `reloadAllTimelines()` is safe to call
+/// from any thread/actor (it just posts a reload request to WidgetKit).
+struct WidgetCenterReloader: WidgetReloading {
+    func reloadAllTimelines() {
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}

--- a/ios/SportivistaTests/RecordingWidgetReloader.swift
+++ b/ios/SportivistaTests/RecordingWidgetReloader.swift
@@ -1,0 +1,21 @@
+//
+//  RecordingWidgetReloader.swift
+//  SportivistaTests
+//
+//  WP-121: a recording `WidgetReloading` double — counts
+//  `reloadAllTimelines()` calls instead of touching the real, global
+//  WidgetCenter (SportivistaTests is a hostless logic bundle with no WidgetKit
+//  host; the real call needs a running app). Mirrors
+//  RecordingNotificationScheduler's `@unchecked Sendable` reasoning: test code
+//  in this suite runs single-threaded and each test gets a fresh instance.
+//
+
+import Foundation
+
+final class RecordingWidgetReloader: WidgetReloading, @unchecked Sendable {
+    private(set) var reloadCount = 0
+
+    func reloadAllTimelines() {
+        reloadCount += 1
+    }
+}

--- a/ios/SportivistaTests/SyncFreshnessTests.swift
+++ b/ios/SportivistaTests/SyncFreshnessTests.swift
@@ -1,0 +1,189 @@
+//
+//  SyncFreshnessTests.swift
+//  SportivistaTests
+//
+//  WP-121 acceptance: the post-sync "delivery freshness" step that runs on
+//  EVERY sync path (not just cold start). Three parts, each proven here:
+//    1. A NON-launch sync that MOVES a must-watch event's time reschedules the
+//       reminder to the NEW time — proven via SyncFreshness.run against a
+//       RecordingNotificationScheduler (this is exactly what the background
+//       BGAppRefreshTask + pull-to-refresh call).
+//    2. The widget is reloaded on any events/entities change — proven via a
+//       RecordingWidgetReloader injected through the same seam.
+//    3. The foreground-sync gate is a pure function of (lastSync, now) — proven
+//       with an injected clock, no scenePhase.
+//  The pure `decide(from:)` matrix pins exactly which SyncResult triggers what.
+//
+
+import XCTest
+
+final class SyncFreshnessTests: XCTestCase {
+
+    // MARK: - Fixtures (mirror NotificationPlannerTests so the bell actually rings)
+
+    private func iso(_ s: String) -> Date {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.date(from: s)!
+    }
+
+    /// Tracks football "Lyn" (teams default to notify:true) with a 30-min lead —
+    /// arms FeedCompiler.mustWatch for the Lyn event below.
+    private var interestsTrackingLyn: Interests {
+        Interests(
+            alwaysTrack: Interests.AlwaysTrack(
+                teams: [Interests.Entity(name: "Lyn", aliases: ["Lyn Oslo"], sport: "football")]
+            ),
+            notify: Interests.Notify(leadMinutes: 30)
+        )
+    }
+
+    private func lynEvent(time: Date) -> Event {
+        EventFixtureBuilder.make(
+            id: "lyn-fram", sport: "football", title: "Lyn – Fram", time: time,
+            homeTeam: "Lyn", awayTeam: "Fram"
+        )
+    }
+
+    private func makeFreshness() -> (SyncFreshness, RecordingNotificationScheduler, RecordingWidgetReloader) {
+        let scheduler = RecordingNotificationScheduler()
+        let reloader = RecordingWidgetReloader()
+        let freshness = SyncFreshness(
+            notificationPlanner: NotificationPlanner(scheduler: scheduler),
+            widgetReloader: reloader
+        )
+        return (freshness, scheduler, reloader)
+    }
+
+    // MARK: - Part 1+2: a non-launch sync that MOVES an event reschedules + reloads the widget
+
+    func testNonLaunchSync_movedEvent_reschedulesToNewTime_andReloadsWidget() async {
+        let now = iso("2026-07-13T12:00:00Z")
+        let originalKickoff = iso("2026-07-14T18:00:00Z")
+        let movedKickoff = iso("2026-07-14T19:00:00Z")
+        let (freshness, scheduler, reloader) = makeFreshness()
+
+        // This is precisely the shape the background BGAppRefreshTask + pull-to-
+        // refresh feed SyncFreshness.run: a before snapshot, an after snapshot, and
+        // the SyncResult saying events.json changed. NONE of it is the cold-start path.
+        let ops = await freshness.run(
+            result: .changedFiles(["events.json"]),
+            previousEvents: [lynEvent(time: originalKickoff)],
+            newEvents: [lynEvent(time: movedKickoff)],
+            interests: interestsTrackingLyn,
+            lastSync: now,
+            now: now,
+            leadTimeEnabled: true
+        )
+
+        // A reschedule (not a scheduleNew) — the client already had this id.
+        guard case .reschedule(let request)? = ops.first, ops.count == 1 else {
+            return XCTFail("expected exactly one .reschedule, got \(ops)")
+        }
+        // The reminder fires against the NEW kickoff, 30 min ahead — the whole
+        // point: a moved event must never leave a push at the stale time.
+        XCTAssertEqual(request.fireDate, movedKickoff.addingTimeInterval(-30 * 60))
+        XCTAssertEqual(scheduler.scheduledRequests.count, 1)
+        XCTAssertEqual(scheduler.scheduledRequests.first?.fireDate, movedKickoff.addingTimeInterval(-30 * 60))
+        // Events changed → the widget was nudged exactly once.
+        XCTAssertEqual(reloader.reloadCount, 1)
+    }
+
+    // MARK: - Part 2: entities-only change reloads the widget but reconciles nothing
+
+    func testEntitiesOnlyChange_reloadsWidget_butDoesNotReconcile() async {
+        let now = iso("2026-07-13T12:00:00Z")
+        let kickoff = iso("2026-07-14T18:00:00Z")
+        let (freshness, scheduler, reloader) = makeFreshness()
+
+        let ops = await freshness.run(
+            result: .changedFiles(["entities.json"]),
+            previousEvents: [lynEvent(time: kickoff)],
+            newEvents: [lynEvent(time: kickoff)],
+            interests: interestsTrackingLyn,
+            lastSync: now, now: now, leadTimeEnabled: true
+        )
+
+        XCTAssertTrue(ops.isEmpty, "entities-only change must not reconcile reminders")
+        XCTAssertTrue(scheduler.scheduledRequests.isEmpty)
+        XCTAssertEqual(scheduler.authorizationRequestCount, 0, "no reconcile ⇒ no permission prompt")
+        XCTAssertEqual(reloader.reloadCount, 1, "the widget still reloads on an entities change")
+    }
+
+    // MARK: - Part 2: a 304/no-op sync touches neither
+
+    func testUpToDateSync_reloadsNothing_reconcilesNothing() async {
+        let now = iso("2026-07-13T12:00:00Z")
+        let kickoff = iso("2026-07-14T18:00:00Z")
+        let (freshness, scheduler, reloader) = makeFreshness()
+
+        let ops = await freshness.run(
+            result: .upToDate,
+            previousEvents: [lynEvent(time: kickoff)],
+            newEvents: [lynEvent(time: kickoff)],
+            interests: interestsTrackingLyn,
+            lastSync: now, now: now, leadTimeEnabled: true
+        )
+
+        XCTAssertTrue(ops.isEmpty)
+        XCTAssertTrue(scheduler.scheduledRequests.isEmpty)
+        XCTAssertEqual(reloader.reloadCount, 0, "a 304 changed nothing — no widget reload")
+    }
+
+    // MARK: - Part 1: an UNCHANGED reminder is never re-touched, even when events.json is flagged changed
+
+    func testEventsChanged_butReminderUnchanged_reloadsWidgetButSchedulesNothing() async {
+        let now = iso("2026-07-13T12:00:00Z")
+        let kickoff = iso("2026-07-14T18:00:00Z")
+        let (freshness, scheduler, reloader) = makeFreshness()
+
+        // events.json changed (some OTHER event moved), but our Lyn reminder is
+        // byte-identical before/after — reconcile must produce no operation.
+        let ops = await freshness.run(
+            result: .changedFiles(["events.json"]),
+            previousEvents: [lynEvent(time: kickoff)],
+            newEvents: [lynEvent(time: kickoff)],
+            interests: interestsTrackingLyn,
+            lastSync: now, now: now, leadTimeEnabled: true
+        )
+
+        XCTAssertTrue(ops.isEmpty, "an unchanged reminder is never rescheduled")
+        XCTAssertTrue(scheduler.scheduledRequests.isEmpty)
+        XCTAssertEqual(reloader.reloadCount, 1, "events.json changed ⇒ widget still reloads")
+    }
+
+    // MARK: - The pure decision matrix
+
+    func testDecideMatrix() {
+        func decide(_ r: SyncResult) -> SyncFreshness.Decision { SyncFreshness.decide(from: r) }
+
+        XCTAssertEqual(decide(.upToDate), .init(reloadWidget: false, reconcileNotifications: false))
+        XCTAssertEqual(decide(.failure(.invalidManifest)), .init(reloadWidget: false, reconcileNotifications: false))
+        XCTAssertEqual(decide(.changedFiles([])), .init(reloadWidget: false, reconcileNotifications: false))
+        XCTAssertEqual(decide(.changedFiles(["events.json"])), .init(reloadWidget: true, reconcileNotifications: true))
+        XCTAssertEqual(decide(.changedFiles(["entities.json"])), .init(reloadWidget: true, reconcileNotifications: false))
+        XCTAssertEqual(decide(.changedFiles(["tracked.json"])), .init(reloadWidget: false, reconcileNotifications: false))
+        XCTAssertEqual(decide(.changedFiles(["interests.json"])), .init(reloadWidget: false, reconcileNotifications: false))
+        // A mixed change reloads (events present) and reconciles (events present).
+        XCTAssertEqual(decide(.changedFiles(["events.json", "tracked.json"])), .init(reloadWidget: true, reconcileNotifications: true))
+    }
+
+    // MARK: - Part 3: the foreground-sync gate (pure, clock-injected)
+
+    func testForegroundSyncGate() {
+        let now = iso("2026-07-13T12:00:00Z")
+
+        // Never synced ⇒ the cold-start .task owns the first sync, so the gate is quiet.
+        XCTAssertFalse(ForegroundSyncGate.shouldRefresh(lastSync: nil, now: now))
+        // A quick return (< 15 min) ⇒ no re-sync.
+        XCTAssertFalse(ForegroundSyncGate.shouldRefresh(lastSync: now.addingTimeInterval(-10 * 60), now: now))
+        // Exactly at the threshold ⇒ refresh.
+        XCTAssertTrue(ForegroundSyncGate.shouldRefresh(lastSync: now.addingTimeInterval(-15 * 60), now: now))
+        // Well past ⇒ refresh.
+        XCTAssertTrue(ForegroundSyncGate.shouldRefresh(lastSync: now.addingTimeInterval(-3 * 60 * 60), now: now))
+    }
+
+    func testForegroundStalenessConstant_isFifteenMinutes() {
+        XCTAssertEqual(ForegroundSyncGate.staleness, 15 * 60)
+    }
+}


### PR DESCRIPTION
Lukker de to 🔴-funnene + foregrunn-🟡 fra WP-118-kjernefunksjonalitet-auditen: **tavla og varslene skal aldri være eldre enn siste sync**. Det dyreste tillitsbruddet appen kan begå er et push med gammel/feil tid.

## Delt kjerne: `SyncFreshness` (Sync/)
Ren/uren-splitt som resten av kodebasen:
- `decide(from: SyncResult)` — ren funksjon: reload widget når `events/entities` endret, reconcile varsler når `events` endret. 304/failure ⇒ ingenting.
- `run(...)` — utfører mot injiserte sømlag (`WidgetReloading` + `NotificationPlanner`), samme kvalitetsporter som kald-oppstart. Planleggings/diff-semantikken i `NotificationPlanner` er **urørt** (ikke-mål).

## (1) Varsel-reconcile på ALLE sync-veier
Før: `NotificationPlanner.reconcile` hadde ett kallsted (kun kald oppstart).
- **Bakgrunnssync** — `BackgroundRefreshScheduler.handle` → ny `syncAndFreshen` (snapshot events før/etter, reconcile + widget-reload ved endring). Før kalte den kun `syncClient.sync()`, så et serverflyttet event beholdt gammelt push-tidspunkt.
- **Pull-to-refresh** — `AgendaViewModel.refresh` snapshotter events og kjører `SyncFreshness.run`.
- **Kald oppstart** — `ContentView.refresh` reloader nå også widgeten (reconcile var der fra før).

## (2) Widget-reload ved datasync
`WidgetCenter.reloadAllTimelines()` hadde **0 kallsteder** (widgeten opptil ~24 t bak; reload-policy kun ved døgnskiftet). Nytt `WidgetReloading`-sømlag (`WidgetCenterReloader`) kalles etter enhver sync som endret events/entities, i alle veier. Ligger i `Sync/` — bevisst utenfor widget-targetets kildeliste (appen reloader widgeten, aldri omvendt).

## (3) Foregrunn-sync
`ForegroundSyncGate.shouldRefresh(lastSync:now:)` (ren, klokke-injiserbar): ekte retur fra bakgrunn (`oldPhase == .background`) til en foreldet cache (≥15 min) → full `refresh()`. In-flight-flagg + WP-60-koalescering verner mot re-entrans; aldri-synket (nil) eies av kald-oppstart. Profil-CloudKit-runden på hver `.active` er uendret.

## Regresjonsfiks
`UNUserNotificationScheduler` resolverer nå notifikasjons-senteret **lat** (ikke i `init`): `UNUserNotificationCenter.current()` kaster i det hostløse testbundtet (`bundleProxyForCurrentProcess is nil`), og AgendaViewModels nye default-`SyncFreshness` gjorde det nåbart fra enhetstestene. Ingen kallsteder sender eget senter; oppførselen i appen er identisk.

## Ikke-mål holdt
Ingen endring i NotificationPlanner-planleggings/diff-semantikken, ingen `News/`-filer (WP-115 eier dem), ingen endring i SyncClient-protokollen.

## Tester
`SyncFreshnessTests` (+ `RecordingWidgetReloader`):
- ikke-launch-sync som flytter et events tid ⇒ `.reschedule` til NYTT tidspunkt (bevist via `RecordingNotificationScheduler`) + widget reloadet én gang;
- entities-only ⇒ widget-reload uten reconcile; 304 ⇒ ingen av delene; uendret varsel ⇒ ingen re-scheduling;
- `decide`-matrisen; foregrunn-gaten med klokke-injeksjon.

## Verifisering
- iOS-enhetssuite grønn: **591 tester, 1 skipped, 0 failures** (gylne feed-vektorer bit-like).
- Alle fire schemes bygger (Sportivista, WidgetExtension, UITests, DeviceDev).
- `npx vitest run --maxWorkers=1` grønn (45 filer, 675 tester).

PLAN.md WP-121-raden flippet ⬜→🔬.

Merk (oppfølging, ikke i denne PR-en for å unngå kollisjon med WP-115s parallelle README-endringer): `ios/README.md` § Agenda/§ Notifications sier fortsatt at pull-to-refresh IKKE reconciler — nå utdatert; hør inn i neste dok-resynk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)