### PR TITLE
WP-127: detalj & widget — Om-avsnitt iOS, deltaker-titler, RESULTAT sist, prosa-bredde

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -131,7 +131,7 @@ mennesket, aldri av en agent.
 | WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |
 | WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | ⬜ bølge 4 |
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | ⬜ bølge 3 |
-| WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | ⬜ bølge 3 |
+| WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | 🔬 bølge 3 |
 | WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | 🔬 bølge 3 |
 | WP-129 | Onboarding-copy (kapsel-modellen) + stale kommentarer + regenerert skjermkatalog | 0I | WP-117 | ⬜ bølge 4 |
 | WP-130 | Pipeline-kvalitet: refaktor-auditens quick-wins | 0I | — | 🔬 PR åpen — containsName-memo, haystack-dedup ×3, én fillesing, configDirPath (+2 env-bugfiks), 2 døde eksporter, flattenStats, golf mergeEvents |

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -145,12 +145,24 @@
 .ev-detail {
 	padding: 4px 0 16px calc(14px + 12px + var(--time-col) + 12px);
 	display: grid;
+	grid-template-columns: minmax(0, 1fr);   /* one column, fills the width so .d-prose can break out cleanly */
 	gap: 6px;
 	font-size: 13.5px;
 }
 .ev-detail .d-row { display: flex; gap: 10px; align-items: baseline; }
 .ev-detail .d-k { color: var(--fg-3); min-width: 62px; flex-shrink: 0; }
 .ev-detail .d-v { color: var(--fg-2); }
+/* Long prose ("Om") gets the FULL row width instead of the narrow key/value value
+   column: cancel the title-column indent so a 700+-char summary reads across the
+   whole card, not a ~130px strip (WP-127). Short facts (Arena/Runde/Se på) keep
+   key/value. The label sits on its own line above the paragraphs. */
+.ev-detail .d-prose {
+	margin-left: calc(-38px - var(--time-col));   /* = -(14 + 12 + time-col + 12), cancels .ev-detail's indent */
+	width: calc(100% + 38px + var(--time-col));
+}
+.ev-detail .d-prose .d-k { display: block; min-width: 0; margin-bottom: 4px; }
+.ev-detail .d-prose .d-p { color: var(--fg-2); margin: 0 0 6px; line-height: 1.5; overflow-wrap: break-word; }
+.ev-detail .d-prose .d-p:last-child { margin-bottom: 0; }
 .ev-detail a { color: var(--accent); border-bottom: 1px solid transparent; }
 .ev-detail a:hover { border-bottom-color: var(--accent); }
 /* Collapsed stage race (e.g. Tour de France): past stages dimmed when expanded */

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -198,16 +198,13 @@ class Dashboard {
 	}
 
 	/** A head-to-head read off `participants` (exactly two named sides, no home/away
-	 *  pair): the escaped "Spania – Argentina" string, else null. Deliberately fires
-	 *  only for two — a golf/CS2 field of four is a tournament, not a matchup, and
-	 *  must keep its own title rather than becoming a name list. */
+	 *  pair): the escaped "Spania – Argentina" string, else null. The matchup logic
+	 *  lives in shared-constants.js (`ssParticipantMatchup`) so detail.js can reuse
+	 *  it for the share/report title; here it's escaped for HTML rendering. Fires
+	 *  only for two — a golf/CS2 field of four is a tournament, not a matchup. */
 	participantMatchup(e) {
-		if (e.homeTeam && e.awayTeam) return null;
-		const names = (Array.isArray(e.participants) ? e.participants : [])
-			.map((p) => (p && p.name) || (typeof p === 'string' ? p : ''))
-			.filter(Boolean);
-		if (names.length !== 2) return null;
-		return `${escapeHtml(ssShortName(names[0]))} – ${escapeHtml(ssShortName(names[1]))}`;
+		const m = ssParticipantMatchup(e);
+		return m ? escapeHtml(m) : null;
 	}
 
 	eventTitle(e) {

--- a/docs/js/detail.js
+++ b/docs/js/detail.js
@@ -115,9 +115,15 @@ Object.assign(window.Dashboard.prototype, {
 		} else if (e.norwegianPlayers?.length) {
 			add('Norske', escapeHtml(e.norwegianPlayers.map((p) => p.name || p).join(', ')));
 		}
-		// "Om" — the summary, structured into calm paragraphs instead of one wall.
-		// First paragraph carries the "Om" label; the rest continue under a blank key.
-		this.aboutParagraphs(e.summary).forEach((p, i) => add(i === 0 ? 'Om' : '', p));
+		// "Om" — the summary as calm paragraphs in a FULL-WIDTH prose block
+		// (.d-prose), NOT squeezed into the narrow ~130px key/value value column
+		// (WP-127). The short key-facts above (Arena/Runde/…) keep key/value; long
+		// prose earns the whole row width. aboutParagraphs already escapes each part.
+		const proseParas = this.aboutParagraphs(e.summary);
+		if (proseParas.length) {
+			const body = proseParas.map((p) => `<p class="d-p">${p}</p>`).join('');
+			rows.push(`<div class="d-prose"><span class="d-k">Om</span><div class="d-prose-body">${body}</div></div>`);
+		}
 
 		const streams = Array.isArray(e.streaming) ? e.streaming : [];
 		if (streams.length) {
@@ -190,14 +196,26 @@ Object.assign(window.Dashboard.prototype, {
 		return null;
 	},
 
+	/** The plain-text display title for share/report — the participant matchup
+	 *  ("Spania – Argentina") or the home/away pair for a head-to-head, else the
+	 *  event's own title. The text-context mirror of eventTitle (which returns
+	 *  escaped HTML for the row): uses the shared ssParticipantMatchup so the
+	 *  detail names the SAME two sides the agenda row and the iOS sheet do (WP-127). */
+	eventPlainTitle(e) {
+		if (!e) return '';
+		if (e.homeTeam && e.awayTeam) return `${ssShortName(e.homeTeam)} – ${ssShortName(e.awayTeam)}`;
+		return ssParticipantMatchup(e) || e.title || '';
+	},
+
 	/** Native share sheet for an event (when · what · where). */
 	shareEvent(e) {
 		if (!e || typeof navigator === 'undefined' || !navigator.share) return;
 		const d = new Date(e.time);
 		const day = d.toLocaleDateString('nb-NO', { weekday: 'short', day: 'numeric', month: 'short', timeZone: 'Europe/Oslo' });
 		const chan = (Array.isArray(e.streaming) && e.streaming[0] && e.streaming[0].platform) || '';
-		const text = [e.title, `${day} ${this.osloTime(d)}`, chan].filter(Boolean).join(' · ');
-		navigator.share({ title: e.title, text, url: location.href }).catch(() => {});
+		const title = this.eventPlainTitle(e);
+		const text = [title, `${day} ${this.osloTime(d)}`, chan].filter(Boolean).join(' · ');
+		navigator.share({ title, text, url: location.href }).catch(() => {});
 	},
 
 	/** Report a problem with an event → a prefilled GitHub feedback issue. */
@@ -212,7 +230,7 @@ Object.assign(window.Dashboard.prototype, {
 			`- Sport: ${e.sport}`, `- Tittel: ${e.title}`, `- Tid: ${local}`,
 			`- Kanal: ${chan}`, `- Kilde: ${e.source || 'statisk'}${e.confidence ? ` (${e.confidence})` : ''}`,
 		].join('\n');
-		const p = new URLSearchParams({ labels: 'event-feedback', title: `[feil] ${e.title}`, body });
+		const p = new URLSearchParams({ labels: 'event-feedback', title: `[feil] ${this.eventPlainTitle(e)}`, body });
 		window.open(`https://github.com/${SS_REPO}/issues/new?${p.toString()}`, '_blank', 'noopener');
 	},
 

--- a/docs/js/shared-constants.js
+++ b/docs/js/shared-constants.js
@@ -40,6 +40,21 @@ function ssShortName(name) {
 	return name.replace(/ FC$| AFC$| CF$| FK$/i, '').replace(/^FC |^AFC /i, '').trim();
 }
 
+/** The head-to-head matchup names for an event as a PLAIN "A – B" string — when
+ *  `participants` is EXACTLY two named sides and there's no home/away pair — else
+ *  null. Fires only for two: a golf/CS2 field of four is a tournament, not a
+ *  matchup, and keeps its own title. Un-escaped: HTML callers escape the result
+ *  (dashboard.js `participantMatchup`), plain-text callers (detail.js share/
+ *  report titles) use it directly. Mirrors iOS `AgendaFormat.matchupTitle`. */
+function ssParticipantMatchup(e) {
+	if (!e || (e.homeTeam && e.awayTeam)) return null;
+	const names = (Array.isArray(e.participants) ? e.participants : [])
+		.map((p) => (p && p.name) || (typeof p === 'string' ? p : ''))
+		.filter(Boolean);
+	if (names.length !== 2) return null;
+	return `${ssShortName(names[0])} – ${ssShortName(names[1])}`;
+}
+
 /** Fuzzy team name matching (normalize + substring inclusion) */
 function ssTeamMatch(a, b) {
 	const normalize = s => s.toLowerCase().replace(/ fc$| afc$| cf$| fk$/i, '').replace(/^fc |^afc /i, '').trim();
@@ -97,6 +112,7 @@ window.isEventInWindow = isEventInWindow;
 window.ssShortReason = ssShortReason;
 window.escapeHtml = escapeHtml;
 window.ssShortName = ssShortName;
+window.ssParticipantMatchup = ssParticipantMatchup;
 window.ssTeamMatch = ssTeamMatch;
 window.ssEntityName = ssEntityName;
 window.trackedTerms = trackedTerms;

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -43,13 +43,9 @@ struct EventDetailSheet: View {
                 if let venue = event.venue, !venue.isEmpty, venue != "TBD" {
                     DetailRow(label: "Arena", value: venue)
                 }
-                if let summary = event.summary, !summary.isEmpty {
-                    DetailRow(label: "Om", value: summary)
-                }
+                aboutSection
 
                 contextActionsSection
-
-                resultSection
 
                 Section {
                     if event.streaming.isEmpty {
@@ -86,6 +82,12 @@ struct EventDetailSheet: View {
                 } header: {
                     header("VARSEL")
                 }
+
+                // RESULTAT sist (WP-127) — DESIGN § Event-detalj orders the sheet
+                // Arena · Om · Hvor ser jeg det · Funnet av AI · Varsel · Resultat.
+                // The result (spoiler-masked when needed) is the LAST section, so a
+                // glance at the sheet never lands on the outcome first.
+                resultSection
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
@@ -108,6 +110,30 @@ struct EventDetailSheet: View {
             .font(.sportivista(.caption2, weight: .semibold))
             .foregroundStyle(SportivistaTokens.accent)
             .tracking(0.5)
+    }
+
+    // MARK: - "Om" (WP-127 — paragraphs, not a wall)
+
+    /// The "Om" block: the summary split into calm paragraphs (with a soft
+    /// length cap + "Mer" for extremely long texts) plus the quiet key-fact
+    /// lines — Runde / Underlag / Format — where those fields exist. Mirrors the
+    /// web detail's structure (detail.js `aboutParagraphs` + the key-fact rows);
+    /// the wall-of-text single `Text` it replaces was 600–786 chars in live data.
+    @ViewBuilder
+    private var aboutSection: some View {
+        let paragraphs = AgendaFormat.aboutParagraphs(event.summary)
+        if !paragraphs.isEmpty {
+            AboutRow(paragraphs: paragraphs)
+        }
+        if let round = event.round, !round.isEmpty {
+            DetailRow(label: "Runde", value: round)
+        }
+        if let surface = event.surface, !surface.isEmpty {
+            DetailRow(label: "Underlag", value: surface)
+        }
+        if let format = event.format, !format.isEmpty {
+            DetailRow(label: "Format", value: format)
+        }
     }
 
     // MARK: - Context actions (WP-16.4)
@@ -205,6 +231,63 @@ struct EventDetailSheet: View {
                 header("RESULTAT")
             }
         }
+    }
+}
+
+/// The "Om" summary as calm paragraphs (WP-127). `AgendaFormat.aboutParagraphs`
+/// has already split the text; this renders each as its own `Text` under a quiet
+/// "OM" label, with a soft length cap: an extremely long summary shows its
+/// leading paragraph(s) up to the cap plus a "Mer" reveal, so the sheet opens
+/// calm rather than as one wall. Dynamic-Type throughout (no fixed point sizes).
+private struct AboutRow: View {
+    let paragraphs: [String]
+    @State private var expanded = false
+
+    /// Soft cap in characters. At/under it the whole text shows; over it, the
+    /// leading paragraph(s) that reach the cap show, with a "Mer" for the rest.
+    private let softCap = 320
+
+    private var totalLength: Int { paragraphs.reduce(0) { $0 + $1.count } }
+    private var isLong: Bool { totalLength > softCap }
+
+    private var visible: [String] {
+        guard isLong, !expanded else { return paragraphs }
+        var shown: [String] = []
+        var total = 0
+        for p in paragraphs {
+            shown.append(p)
+            total += p.count
+            if total >= softCap { break }
+        }
+        return shown
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("OM")
+                .font(.sportivista(.caption2, weight: .semibold))
+                .foregroundStyle(SportivistaTokens.secondaryLabel)
+            ForEach(Array(visible.enumerated()), id: \.offset) { _, para in
+                Text(para)
+                    .font(.sportivista(.subheadline))
+                    .foregroundStyle(SportivistaTokens.label)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if isLong && !expanded && visible.count < paragraphs.count {
+                Button {
+                    expanded = true
+                } label: {
+                    Text("Mer")
+                        .font(.sportivista(.footnote, weight: .semibold))
+                        .foregroundStyle(SportivistaTokens.accent)
+                        // A comfortable tap target even though the label is small.
+                        .frame(minHeight: 44, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .listRowBackground(SportivistaTokens.cell)
     }
 }
 

--- a/ios/Sportivista/Feed/AgendaFormat.swift
+++ b/ios/Sportivista/Feed/AgendaFormat.swift
@@ -101,6 +101,60 @@ enum AgendaFormat {
         return "\(names[0]) – \(names[1])"
     }
 
+    // MARK: - "Om" — the summary, split into calm paragraphs (WP-127)
+
+    /// Split a free-text summary into calm paragraphs so the detail sheet's "Om"
+    /// section isn't one wall of text — the exact mirror of dashboard.js's
+    /// `aboutParagraphs` (WP-111). Explicit blank lines (`\n\n`) split first;
+    /// otherwise a block of more than two sentences is grouped into runs of two.
+    /// Sentence boundaries are only `.`/`!`/`?`/`…` (+ an optional closing quote)
+    /// followed by whitespace and a capital — so "kl. 21.00", "UCI 2.Pro" and
+    /// "29. juli" stay intact. Pure display; returns raw (un-escaped) strings —
+    /// SwiftUI `Text` renders them safely, no HTML escaping needed here.
+    static func aboutParagraphs(_ text: String?) -> [String] {
+        let raw = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return [] }
+        let blocks = splitByRegex(raw, "\\n\\s*\\n")
+            .map { collapseWhitespace($0) }
+            .filter { !$0.isEmpty }
+        var out: [String] = []
+        for block in blocks {
+            let sentences = splitByRegex(block, "(?<=[.!?…][»\")'\u{201D}\u{2019}]?)\\s+(?=[A-ZÆØÅ])")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            if sentences.count <= 2 { out.append(block); continue }
+            var i = 0
+            while i < sentences.count {
+                let group = sentences[i..<min(i + 2, sentences.count)]
+                out.append(group.joined(separator: " "))
+                i += 2
+            }
+        }
+        return out
+    }
+
+    /// Split `s` on every match of `pattern` (keeping the pieces between the
+    /// matches) — the Foundation equivalent of JS `String.prototype.split(regex)`.
+    private static func splitByRegex(_ s: String, _ pattern: String) -> [String] {
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return [s] }
+        let ns = s as NSString
+        var pieces: [String] = []
+        var last = 0
+        for m in re.matches(in: s, range: NSRange(location: 0, length: ns.length)) {
+            pieces.append(ns.substring(with: NSRange(location: last, length: m.range.location - last)))
+            last = m.range.location + m.range.length
+        }
+        pieces.append(ns.substring(from: last))
+        return pieces
+    }
+
+    /// Collapse any run of whitespace to a single space and trim — mirrors the
+    /// per-block JS `replace(/\s+/g, ' ').trim()`.
+    private static func collapseWhitespace(_ s: String) -> String {
+        return s.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// The quiet meta line under the title (DESIGN.md "Radens anatomi":
     /// "meta: turnering — én dempet linje ved behov"). Returns the tournament
     /// ONLY when it adds context the title doesn't already carry — i.e. it is

--- a/ios/Sportivista/Models/Event.swift
+++ b/ios/Sportivista/Models/Event.swift
@@ -75,6 +75,10 @@ struct Event: Codable, Equatable {
     var isFavorite: Bool
     /// Round/phase label, e.g. "Semifinale".
     var round: String?
+    /// Playing surface, e.g. tennis "Grus"/"Hard" — a quiet key-fact line in the
+    /// detail sheet ("Underlag") when present. Mirrors dashboard.js detail.js's
+    /// defensive `e.surface` read; absent from most events.
+    var surface: String?
     /// Computed by build-events.js — true when the event hits a
     /// tracked/must-watch entity.
     var mustWatch: Bool
@@ -110,7 +114,7 @@ struct Event: Codable, Equatable {
         case id, sport, tournament, title, time, endTime, venue, meta, norwegian, streaming,
              participants, norwegianPlayers, totalPlayers, link, status, featuredGroups,
              homeTeam, awayTeam, homeTeamEntityId, awayTeamEntityId, isFavorite, round,
-             mustWatch, format, stage, result, context, importance, summary, source,
+             surface, mustWatch, format, stage, result, context, importance, summary, source,
              confidence, evidence, researchedAt, verifiedAt, verificationStatus,
              verificationSources, norwegianRelevance, tags
     }
@@ -142,6 +146,7 @@ struct Event: Codable, Equatable {
         awayTeamEntityId = try c.decodeIfPresent(String.self, forKey: .awayTeamEntityId)
         isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
         round = try c.decodeIfPresent(String.self, forKey: .round)
+        surface = try c.decodeIfPresent(String.self, forKey: .surface)
         mustWatch = try c.decodeIfPresent(Bool.self, forKey: .mustWatch) ?? false
         format = try c.decodeIfPresent(String.self, forKey: .format)
         stage = try c.decodeIfPresent(String.self, forKey: .stage)

--- a/ios/SportivistaTests/AgendaFormatTests.swift
+++ b/ios/SportivistaTests/AgendaFormatTests.swift
@@ -120,6 +120,48 @@ final class AgendaFormatTests: XCTestCase {
         XCTAssertNil(AgendaFormat.matchupTitle(participants: [], title: "Noe"))
     }
 
+    // MARK: - aboutParagraphs (WP-127 — the "Om" wall, split calmly)
+    // Mirrors the web dashboard-cards "«Om» readability" cases so the two
+    // surfaces split identically (dashboard.js `aboutParagraphs`).
+
+    func testAboutParagraphs_multiSentence_splitsIntoParagraphs() {
+        let summary = "Første setning her. Andre setning her. Tredje setning kommer. Fjerde runder av."
+        let paras = AgendaFormat.aboutParagraphs(summary)
+        XCTAssertGreaterThan(paras.count, 1, "four sentences must not stay one wall")
+        // Grouped into runs of two.
+        XCTAssertEqual(paras.count, 2)
+        XCTAssertEqual(paras[0], "Første setning her. Andre setning her.")
+        XCTAssertEqual(paras[1], "Tredje setning kommer. Fjerde runder av.")
+    }
+
+    func testAboutParagraphs_doesNotSplitInsideAbbreviationsOrNumbers() {
+        // "kl. 21.00" and "29. juli" must NOT be read as sentence boundaries —
+        // two real sentences (≤2) collapse to one calm block.
+        let summary = "Kampen vises på NRK1 (kl. 21.00 norsk tid). Løpet går 29. juli i Aalborg."
+        let paras = AgendaFormat.aboutParagraphs(summary)
+        XCTAssertEqual(paras.count, 1)
+        XCTAssertTrue(paras[0].contains("kl. 21.00"))
+        XCTAssertTrue(paras[0].contains("29. juli"))
+    }
+
+    func testAboutParagraphs_explicitBlankLines_splitFirst() {
+        let summary = "Første avsnitt.\n\nAndre avsnitt her."
+        let paras = AgendaFormat.aboutParagraphs(summary)
+        XCTAssertEqual(paras, ["Første avsnitt.", "Andre avsnitt her."])
+    }
+
+    func testAboutParagraphs_collapsesWhitespaceWithinABlock() {
+        let summary = "Ett  avsnitt   med\n  ekstra   mellomrom."
+        let paras = AgendaFormat.aboutParagraphs(summary)
+        XCTAssertEqual(paras, ["Ett avsnitt med ekstra mellomrom."])
+    }
+
+    func testAboutParagraphs_emptyOrNil_isEmpty() {
+        XCTAssertEqual(AgendaFormat.aboutParagraphs(""), [])
+        XCTAssertEqual(AgendaFormat.aboutParagraphs("   "), [])
+        XCTAssertEqual(AgendaFormat.aboutParagraphs(nil), [])
+    }
+
     // MARK: - metaLabel (the quiet second line, "ved behov")
 
     func testMetaLabel_tournamentDistinctFromTitle_isShown() {

--- a/ios/SportivistaTests/WidgetTimelineBuilderTests.swift
+++ b/ios/SportivistaTests/WidgetTimelineBuilderTests.swift
@@ -97,6 +97,24 @@ final class WidgetTimelineBuilderTests: XCTestCase {
         XCTAssertEqual(first?.channelLabel, "Viaplay")
     }
 
+    func testBuildEntries_headToHeadParticipants_highlightTitleIsTheMatchup() {
+        // WP-112/127 — an event carrying two participants but no home/away teams
+        // (the "VM-finale" shape: generic title "VM-finalen 2026", participants
+        // Spania/Argentina) must surface in the widget highlight as the matchup,
+        // NOT the generic title — the same AgendaFormat.title the agenda row uses.
+        let now = iso("2026-07-13T08:00:00Z")
+        let event = EventBuilder.make(
+            sport: "football", title: "VM-finalen 2026", time: "2026-07-13T18:00:00Z",
+            tournament: "FIFA World Cup", participants: ["Spania", "Argentina"], importance: 5
+        )
+        let interests = Interests(followBroadly: ["football"])
+
+        let entries = WidgetTimelineBuilder.buildEntries(events: [event], interests: interests, now: now)
+
+        XCTAssertEqual(entries.first?.hasHighlight, true)
+        XCTAssertEqual(entries.first?.title, "Spania – Argentina")
+    }
+
     func testBuildEntries_noRelevantEvents_producesEmptyHighlightEntry() {
         let now = iso("2026-07-13T08:00:00Z")
         let entries = WidgetTimelineBuilder.buildEntries(events: [], interests: Interests(), now: now)

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -137,6 +137,31 @@ describe("head-to-head participants render as the row matchup", () => {
 	});
 });
 
+// WP-127: the detail's share/report title must name the SAME two sides the row
+// title does — the plain-text mirror of eventTitle, via the shared ssParticipantMatchup.
+describe("detail title (share/report) names the participants", () => {
+	it("uses the participant matchup, not the generic title", () => {
+		expect(dash.eventPlainTitle({ title: "VM-finalen 2026", participants: [{ name: "Spania" }, { name: "Argentina" }] }))
+			.toBe("Spania – Argentina");
+	});
+
+	it("uses home – away (shortened) for a team match", () => {
+		expect(dash.eventPlainTitle({ homeTeam: "Liverpool FC", awayTeam: "Arsenal FC", title: "Liverpool vs Arsenal" }))
+			.toBe("Liverpool – Arsenal");
+	});
+
+	it("falls back to the event's own title for a many-sided field (not a matchup)", () => {
+		expect(dash.eventPlainTitle({ title: "Esports World Cup 2026", participants: [{ name: "A" }, { name: "B" }, { name: "C" }, { name: "D" }] }))
+			.toBe("Esports World Cup 2026");
+	});
+
+	it("returns plain (un-escaped) text — the caller (navigator.share/issue url) is not HTML", () => {
+		// ssParticipantMatchup is the shared, un-escaped source; eventTitle escapes for the row.
+		expect(dash.eventPlainTitle({ title: "x", participants: [{ name: "A & B" }, { name: "C" }] }))
+			.toBe("A & B – C");
+	});
+});
+
 // WP-111: editorial (featured.json) is a "nice extra" that can be quota-skipped for
 // a day. A stale brief is a factual error on the hero (19.07: yesterday's "finalen
 // venter i morgen" stayed up all through finale day). Discard anything > ~20h old.
@@ -182,7 +207,20 @@ describe("«Om» readability — paragraphs, not a wall", () => {
 		expect(paras.length).toBeGreaterThan(1); // not one wall
 		const detail = dash.eventDetail({ sport: "football", title: "x", summary });
 		expect(detail).toContain('<span class="d-k">Om</span>');
-		expect((detail.match(/class="d-v"/g) || []).length).toBeGreaterThan(2); // Hvorfor + ≥2 paragraphs
+		// WP-127: the "Om" prose is a full-width .d-prose block of <p class="d-p">
+		// paragraphs, no longer squeezed into the narrow key/value value column.
+		expect(detail).toContain('class="d-prose"');
+		expect((detail.match(/<p class="d-p">/g) || []).length).toBeGreaterThan(1); // ≥2 paragraphs
+	});
+
+	it("puts long prose in a full-width .d-prose block, not the narrow d-v column", () => {
+		const summary = "Første setning her. Andre setning her. Tredje setning kommer.";
+		const detail = dash.eventDetail({ sport: "football", title: "x", summary });
+		expect(detail).toContain('<div class="d-prose">');
+		expect(detail).toContain('<div class="d-prose-body">');
+		expect(detail).toContain('<p class="d-p">');
+		// The paragraphs must NOT be emitted as key/value value cells.
+		expect(detail).not.toContain('<span class="d-v">Første setning');
 	});
 
 	it("does not split inside abbreviations/numbers like «kl. 21.00» or «29. juli»", () => {


### PR DESCRIPTION
Lukker detalj-/widget-restene av «Om»- og deltaker-funnene (WP-111/112). Tre deler, disjunkt fra WP-128 (renderAgenda/followed/chrome) og WP-126 (live).

## iOS — EventDetailSheet
- **«Om» som avsnitt:** ny `AgendaFormat.aboutParagraphs(_:)` — eksakt speil av web-ens `aboutParagraphs` (split på `\n\n`, ellers 2-setnings-grupper, forkortelses-trygg setningssplitt så «kl. 21.00»/«2.Pro»/«29. juli» ikke splittes). Wall-of-text-`Text`-en den erstatter var 600–786 tegn i live-data.
- **Nøkkelfakta-linjer** (Runde / Underlag / Format) der feltene finnes. `Event` får `surface`-felt (decode-only) for «Underlag»-pariteten med web.
- **Mykt lengdetak** (320 tegn) + «Mer»-utvidelse for ekstremt lange tekster (Dynamic Type, ≥44pt tap-mål).
- **RESULTAT sist:** seksjonen flyttet til bunnen — DESIGN § Event-detalj foreskriver Arena · Om · Hvor ser jeg det · Funnet av AI · Varsel · **Resultat**; lå tidligere for tidlig i arket.

## Deltaker-titler overalt
- `participantMatchup` flyttet fra `dashboard.js` → `shared-constants.js` (`ssParticipantMatchup`, plain-text) så `detail.js` kan gjenbruke den; `dashboard.js`-metoden delegerer + escaper for HTML (eneste endring i dashboard.js).
- `detail.js`: ny `eventPlainTitle` gir deltaker-matchup i **share/report-tittelen** («Spania – Argentina», ikke «VM-finalen 2026»).
- iOS `titleText` + widget-highlight (`WidgetTimelineBuilder.swift:98`) bruker allerede den delte `AgendaFormat.title(participants:)` fra WP-112 — ny widget-test dekker matchup i highlighten.

## Web prosa-bredde
- Lang «Om»-prosa får **full radbredde** via ny `.d-prose`-variant i `cards.css` (tittelkolonne-innrykket kanselleres); korte felt (Arena / Se på / Runde …) beholder nøkkel/verdi. Tidligere klemt inn i ~130px-kolonnen (~50 linjer på 393px).

## Verifisering
- `npx vitest run --maxWorkers=1`: **45 filer / 691 tester grønne** (post-rebase; inkl. nye `.d-prose`- + `eventPlainTitle`-tester).
- iOS unit-suite: **590 tester (1 skip), 0 failures — TEST SUCCEEDED**; ny `WidgetTimelineBuilderTests` (matchup i highlight) + 5 `AgendaFormatTests`-caser for `aboutParagraphs`.
- **4 schemes bygger** (Sportivista/WidgetExtension/UITests/DeviceDev); golden feed-vektorer bit-like (del av suiten).
- **Skjermbilder** (Playwright, 393px, expandert detalj med 795-tegns summary): «Om»-avsnittene renders i **full bredde i begge temaer** (true-black dark + grouped-light), mens Arena/Runde/Underlag/Format beholder nøkkel/verdi. Standard `npm run screenshot` av agendaen viser deltaker-matchup live («100 Thieves – Falcons», «Strømsgodset – Lyn») — ingen regresjon.

PLAN.md WP-127 ⬜→🔬 (rebase-union med WP-128s 🔬).

🤖 Generated with [Claude Code](https://claude.com/claude-code)