### PR TITLE
WP-126: live-koherens — ett delt live-begrep, TdF synlig i Direkte nå, iOS-tikk

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -130,7 +130,7 @@ mennesket, aldri av en agent.
 | WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | 🔬 bølge 3 |
 | WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |
 | WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | ⬜ bølge 4 |
-| WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | ⬜ bølge 3 |
+| WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | 🔬 bølge 3 — ssLiveState (web) + AgendaViewModel.liveState (iOS-speil): 'direkte'/'pågår'/null; «Direkte nå» viser TdF/sjakk/CS2 (ESPN beriker); iOS minutt-tikk (TimelineView.everyMinute); followed.js relDay bruker delt def. Widget: WP-127 eier fila (urørt) |
 | WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | 🔬 bølge 3 |
 | WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | 🔬 bølge 3 |
 | WP-129 | Onboarding-copy (kapsel-modellen) + stale kommentarer + regenerert skjermkatalog | 0I | WP-117 | ⬜ bølge 4 |

--- a/docs/js/followed.js
+++ b/docs/js/followed.js
@@ -79,9 +79,13 @@ Object.assign(window.Dashboard.prototype, {
 	/** Calm relative-day label in Oslo terms. */
 	relDay(e) {
 		const now = Date.now();
-		const start = new Date(e.time).getTime();
-		const end = e.endTime ? new Date(e.endTime).getTime() : start;
-		if (start <= now && end >= now) return 'pågår nå';
+		// WP-126: use the ONE shared live definition, not a raw [start,end] window.
+		// A multi-day tournament at 03:00 is 'pågår' (underway) — not 'pågår nå',
+		// which would falsely imply an active session right now; only a genuine
+		// live session (a plausible active window) reads "pågår nå".
+		const live = ssLiveState(e, now);
+		if (live === 'direkte') return 'pågår nå';
+		if (live === 'pågår') return 'pågår';
 		const days = Math.round((Date.parse(this.osloDayKey(new Date(e.time))) - Date.parse(this.osloDayKey(new Date(now)))) / SS_CONSTANTS.MS_PER_DAY);
 		if (days <= 0) return 'i dag';
 		if (days === 1) return 'i morgen';

--- a/docs/js/live.js
+++ b/docs/js/live.js
@@ -3,19 +3,59 @@
 Object.assign(window.Dashboard.prototype, {
 
 	// ── Live now (quiet line at the top) ─────────────────────────────────────
+	// WP-126: ONE shared live definition (ssLiveState). Every board event that is
+	// 'direkte' right now shows here — not just the ESPN-polled football/golf/F1.
+	// An ESPN score/leaderboard merely ENRICHES a row (score = bonus, not the
+	// entrance ticket), so a Tour stage / chess round / CS2 match finally appears
+	// in "Direkte nå" too. 'pågår' multi-day events stay OUT of the line (they
+	// carry their own agenda row).
 	renderLive() {
 		const box = document.getElementById('live-now');
 		if (!box) return;
+		const now = Date.now();
 		const items = [];
+		const shownIds = new Set();
+		// ESPN football live scores enrich their board row with the running score.
 		for (const [id, live] of Object.entries(this.liveScores)) {
 			if (live.state !== 'in') continue;
 			items.push(`<div class="live-wrap"><div class="live-item"><span class="live-dot"></span><span class="live-body"><span class="live-name">${escapeHtml(ssShortName(live.homeName))} <span class="live-score">${live.home}–${live.away}</span> ${escapeHtml(ssShortName(live.awayName))}</span></span><span class="live-meta">${escapeHtml(live.clock || '')}</span></div></div>`);
+			shownIds.add(id);
 		}
+		// Golf + F1 keep their ESPN-driven expandable leaderboard / running-order
+		// rows — that live poll is the RELIABLE signal for those two, so they are
+		// owned by this path and are NOT re-derived from the coarse daily-window
+		// heuristic below (which would risk a false 'direkte' between rounds).
 		if (this.liveLeaderboard?.state === 'in' && this.liveLeaderboard.top?.length) items.push(this.liveGolfItem(this.liveLeaderboard));
 		if (this.liveF1?.state === 'in' && this.liveF1.top?.length) items.push(this.liveF1Item(this.liveF1));
+		// WP-126: all remaining live board events — the sports the ESPN poll can't
+		// see (cycling, chess, CS2, tennis) plus any unpolled football — as calm
+		// when·what·where rows.
+		for (const e of this.directLiveEvents(now)) {
+			if (shownIds.has(e.id)) continue;              // already shown with its ESPN score
+			if (e.sport === 'golf' || e.sport === 'f1') continue; // owned by the ESPN rows above
+			if (this.liveScores[e.id]?.state === 'post') continue; // ESPN says it's finished — trust the poll
+			items.push(this.liveEventRow(e));
+		}
 		if (items.length === 0) { box.hidden = true; return; }
 		box.innerHTML = `<div class="live-label"><span class="live-dot"></span>Direkte nå</div>${items.join('')}`;
 		box.hidden = false;
+	},
+
+	/** WP-126 — every board event that is LIVE right now ('direkte' per the shared
+	 *  ssLiveState), earliest-started first. Sport- and poll-agnostic: this is the
+	 *  entrance ticket to "Direkte nå" (mirrors iOS `liveRows`). 'pågår' multi-day
+	 *  events are excluded by ssLiveState itself. */
+	directLiveEvents(now = Date.now()) {
+		return this.allEvents
+			.filter((e) => !e.isSeries && ssLiveState(e, now) === 'direkte')
+			.sort((a, b) => new Date(a.time) - new Date(b.time));
+	},
+
+	/** One calm "Direkte nå" row for a board event with no ESPN enrichment
+	 *  (cycling stage, chess round, CS2 match, an unpolled football match, …):
+	 *  when·what·where — the same quiet shape as the score rows, minus the score. */
+	liveEventRow(e) {
+		return `<div class="live-wrap"><div class="live-item"><span class="live-dot"></span><span class="live-body"><span class="live-name">${this.eventTitle(e)}</span></span><span class="live-meta">${this.whereToWatch(e)}</span></div></div>`;
 	},
 
 	/** One leaderboard row (position · name · trailing value); your player is
@@ -78,13 +118,14 @@ Object.assign(window.Dashboard.prototype, {
 		this._liveInterval = setInterval(() => this.pollLiveScores(), 60 * 1000);
 		setTimeout(() => this.pollLiveScores(), 3000);
 	},
+	// WP-126: gate the 60s poll on the SHARED live definition, not just the three
+	// ESPN sports. So a live cycling stage / chess round keeps the "Direkte nå"
+	// line re-rendering (and truthful — a finished event drops) every minute, the
+	// web counterpart of iOS's minute tick. The per-sport ESPN fetches inside
+	// pollLiveScores keep their own guards, so no needless network calls result.
 	hasLiveEvents() {
 		const now = Date.now();
-		return this.allEvents.some((e) => {
-			const start = new Date(e.time).getTime();
-			const end = e.endTime ? new Date(e.endTime).getTime() : start + 4 * SS_CONSTANTS.MS_PER_HOUR;
-			return start <= now && now <= end && ['football', 'golf', 'f1'].includes(e.sport);
-		});
+		return this.allEvents.some((e) => ssLiveState(e, now) === 'direkte');
 	},
 	async pollLiveScores() {
 		if (!this._liveVisible || !this.hasLiveEvents()) return;

--- a/docs/js/shared-constants.js
+++ b/docs/js/shared-constants.js
@@ -125,6 +125,80 @@ function ssNextEventForEntity(events, entry, now = Date.now()) {
 	return best;
 }
 
+// ── Live state (WP-126: the ONE shared "is it live right now?" definition) ────
+// Mirrored 1:1 in iOS `AgendaViewModel.liveState` (Swift). Returns:
+//   'direkte' — now sits inside a plausible ACTIVE session → the ▌ live line
+//   'pågår'   — a multi-day tournament that's underway but OUTSIDE today's
+//               plausible daily playing window (calm; it has its own agenda
+//               row and must NEVER get the live dot — the 03:00 golf bug)
+//   null      — not started yet, or finished
+//
+// This is a HEURISTIC and deliberately CONSERVATIVE: we would rather say
+// 'pågår' than a false 'direkte'. The rules, in order:
+//   1. An authoritative source `status` naming an in-progress state wins.
+//   2. Before `time`, or with no `time`, → null.
+//   3. A multi-day tournament (endTime more than ~24h after start — golf weeks,
+//      multi-day chess) can't tell us its per-day session start, so we fall back
+//      to a plausible daily window in Oslo local time [08:00, 22:00): inside →
+//      'direkte', otherwise 'pågår'; past its endTime → null. (We lack the
+//      venue-local clock — hence the conservative Oslo-clock window; a US golf
+//      afternoon read as 'pågår' late Oslo-evening is the accepted trade-off.)
+//   4. A single session: trust `endTime` when present (a plausible session
+//      length ≤ ~24h), else assume a sport-typed default duration from `time`
+//      (football ~2h15, F1 session ~2h, cycling stage ~5h30, chess round ~5h,
+//      CS2 match ~2h30, tennis ~3h30, golf-day ~10h, else ~3h). Live while
+//      now ≤ effectiveEnd, then null.
+const SS_MULTIDAY_MS = 24 * MS_PER_HOUR;
+
+/** Sport-typed default session duration in ms (WP-126) — the fallback when an
+ *  event carries no endTime. Kept identical to iOS `sportDefaultDuration`. */
+function ssSportDefaultMs(sport) {
+	switch ((sport || '').toLowerCase()) {
+		case 'football': return 135 * MS_PER_MINUTE; // ~2h15 incl. stoppage + half-time
+		case 'f1': case 'formula1': return 120 * MS_PER_MINUTE; // a race/quali/practice session
+		case 'cycling': return 330 * MS_PER_MINUTE; // a road stage (~5h30)
+		case 'chess': return 300 * MS_PER_MINUTE; // a classical round (~5h)
+		case 'cs2': case 'esports': return 150 * MS_PER_MINUTE; // a best-of match (~2h30)
+		case 'tennis': return 210 * MS_PER_MINUTE; // a best-of match (~3h30)
+		case 'golf': return 600 * MS_PER_MINUTE; // a day's play fallback (~10h; golf is normally multi-day)
+		default: return 180 * MS_PER_MINUTE; // conservative generic session (~3h)
+	}
+}
+
+/** The Oslo-local hour (0–23) at `ms` — for the multi-day daily-window check.
+ *  Uses Date's own tz formatter (not the Intl global, which the test sandbox
+ *  doesn't stub); `% 24` folds the en-GB midnight "24" quirk back to 0. */
+function ssOsloHour(ms) {
+	const s = new Date(ms).toLocaleString('en-GB', { timeZone: 'Europe/Oslo', hour: '2-digit', hour12: false });
+	return parseInt(s, 10) % 24;
+}
+
+/** The ONE shared live definition — see the block comment above. Returns
+ *  'direkte' | 'pågår' | null. `now` is a ms number or a Date (defaults to now). */
+function ssLiveState(event, now) {
+	if (!event) return null;
+	const nowMs = now instanceof Date ? now.getTime() : (now == null ? Date.now() : now);
+	// 1. authoritative in-progress status wins outright (mirror iOS substrings)
+	const status = String(event.status || '').toLowerCase();
+	if (status === 'in' || status.includes('in_progress') || status.includes('in-progress')
+		|| status.includes('live') || status.includes('halftime')) return 'direkte';
+	// 2. need a start, and it must have arrived
+	if (!event.time) return null;
+	const start = new Date(event.time).getTime();
+	if (!Number.isFinite(start) || nowMs < start) return null;
+	const rawEnd = event.endTime ? new Date(event.endTime).getTime() : null;
+	const hasEnd = rawEnd != null && Number.isFinite(rawEnd);
+	// 3. multi-day tournament → conservative daily window
+	if (hasEnd && rawEnd - start > SS_MULTIDAY_MS) {
+		if (nowMs > rawEnd) return null;
+		const h = ssOsloHour(nowMs);
+		return (h >= 8 && h < 22) ? 'direkte' : 'pågår';
+	}
+	// 4. single session
+	const effectiveEnd = (hasEnd && rawEnd > start) ? rawEnd : start + ssSportDefaultMs(event.sport);
+	return nowMs <= effectiveEnd ? 'direkte' : null;
+}
+
 /** Trim an agent reason to a one-line gist (drops the provenance prefix). */
 function ssShortReason(r, max = 130) {
 	if (!r) return '';
@@ -142,6 +216,7 @@ window.SS_CONSTANTS = Object.freeze({
 
 window.SS_REPO = SS_REPO;
 window.isEventInWindow = isEventInWindow;
+window.ssLiveState = ssLiveState;
 window.ssShortReason = ssShortReason;
 window.escapeHtml = escapeHtml;
 window.ssShortName = ssShortName;

--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -218,6 +218,22 @@ final class AgendaViewModel {
         lastSync = result.lastSync
         profileIsEmpty = result.profileIsEmpty
         cachedEntityIndex = result.index
+        liveSnapshot = (result.liveEvents, result.liveInterests)
+    }
+
+    /// WP-126 — the snapshot the live line re-derives from on the display's minute
+    /// tick (`currentLiveRows`). Set on every applied reload.
+    private var liveSnapshot: (events: [Event], interests: Interests)?
+
+    /// WP-126 — the live line re-derived against `now`, the display's minute tick
+    /// (ContentView wraps the line in `TimelineView(.everyMinute)`). Uses the SAME
+    /// pure `liveRows` the reload used, so it is bit-identical at reload time and
+    /// merely stays TRUE between reloads — a finished event drops, a just-started
+    /// one appears. Falls back to the last reload's `liveNow` before the first
+    /// snapshot exists.
+    func currentLiveRows(now: Date = Date()) -> [AgendaLiveRow] {
+        guard let snap = liveSnapshot else { return liveNow }
+        return Self.liveRows(events: snap.events, interests: snap.interests, now: now)
     }
 
     /// Everything one reload produces, computed off-main and handed to `apply`
@@ -230,6 +246,11 @@ final class AgendaViewModel {
         /// The index the compute used (the cached one, or a freshly built one) —
         /// stored back so the next reload reuses it.
         var index: EntityIndex
+        /// WP-126 — the events + interests the live line re-derives from between
+        /// reloads (the display's minute tick), so a finished event drops and a
+        /// just-started one appears without waiting for the next sync.
+        var liveEvents: [Event]
+        var liveInterests: Interests
     }
 
     /// The off-main entry: `nonisolated async` so awaiting it from the main actor
@@ -321,7 +342,8 @@ final class AgendaViewModel {
         }
         return Reload(
             sections: sections, liveNow: liveNow, lastSync: dataStore.lastSync,
-            profileIsEmpty: profile.isEmpty, index: index
+            profileIsEmpty: profile.isEmpty, index: index,
+            liveEvents: events, liveInterests: interests
         )
     }
 
@@ -611,7 +633,7 @@ final class AgendaViewModel {
         let (feedEvents, lookup) = EventBridge.bridge(events)
         let live = feedEvents.filter { fe in
             guard FeedCompiler.isRelevant(fe, interests: interests, now: now) else { return false }
-            return isLiveNow(fe, event: fe.id.flatMap { lookup[$0] }, now: now)
+            return liveState(fe, event: fe.id.flatMap { lookup[$0] }, now: now) == .direkte
         }
         .sorted { lhs, rhs in
             let lSee = FeedCompiler.isMustSee(lhs, interests: interests)
@@ -629,19 +651,69 @@ final class AgendaViewModel {
         }
     }
 
-    /// True when the event is in progress at `now` (see `liveRows`). A source
-    /// `status` that names an in-progress state wins outright; otherwise the
-    /// `[time, endTime]` window decides.
-    nonisolated static func isLiveNow(_ fe: FeedEvent, event: Event?, now: Date) -> Bool {
-        if let status = event?.status?.lowercased() {
-            if status.contains("in_progress") || status.contains("in-progress")
-                || status == "in" || status.contains("live") || status.contains("halftime") {
-                return true
-            }
+    // MARK: - WP-126: the ONE shared live definition
+
+    /// The live state of an event at `now` — mirrored 1:1 with `ssLiveState` in
+    /// docs/js/shared-constants.js (read that file's block comment for the full
+    /// heuristic + the sport-default table). `.direkte` = now inside a plausible
+    /// ACTIVE session (the ▌ LIVE line); `.pagaar` = a multi-day tournament that's
+    /// underway but outside today's plausible daily window (never the live line);
+    /// nil = not started / finished. Conservative by design — we would rather say
+    /// `.pagaar` than a false `.direkte`.
+    enum LiveState { case direkte, pagaar }
+
+    /// ~24h: an endTime further than this past the start marks a multi-day
+    /// tournament (golf week, multi-day chess), which uses the daily-window rule.
+    nonisolated static let liveMultiDay: TimeInterval = 24 * 60 * 60
+
+    nonisolated static func liveState(_ fe: FeedEvent, event: Event?, now: Date) -> LiveState? {
+        // 1. an authoritative in-progress source status wins outright (same
+        //    substrings as the JS mirror).
+        if let status = event?.status?.lowercased(),
+           status == "in" || status.contains("in_progress") || status.contains("in-progress")
+            || status.contains("live") || status.contains("halftime") {
+            return .direkte
         }
-        guard let time = fe.time else { return false }
-        let end = fe.endTime ?? time
-        return time <= now && end >= now
+        // 2. need a start, and it must have arrived.
+        guard let start = fe.time, now >= start else { return nil }
+        let rawEnd = fe.endTime
+        // 3. multi-day tournament → conservative Oslo daily window [08:00, 22:00).
+        if let end = rawEnd, end.timeIntervalSince(start) > liveMultiDay {
+            if now > end { return nil }
+            return isWithinDailyWindow(now) ? .direkte : .pagaar
+        }
+        // 4. single session: trust a plausible endTime, else the sport default.
+        let effectiveEnd: Date
+        if let end = rawEnd, end > start {
+            effectiveEnd = end
+        } else {
+            effectiveEnd = start.addingTimeInterval(sportDefaultDuration(fe.sport))
+        }
+        return now <= effectiveEnd ? .direkte : nil
+    }
+
+    /// Sport-typed default session duration (WP-126) — the fallback when an event
+    /// carries no endTime. Kept identical to JS `ssSportDefaultMs`.
+    nonisolated static func sportDefaultDuration(_ sport: String) -> TimeInterval {
+        switch sport.lowercased() {
+        case "football": return 135 * 60      // ~2h15 incl. stoppage + half-time
+        case "f1", "formula1": return 120 * 60 // a race/quali/practice session
+        case "cycling": return 330 * 60       // a road stage (~5h30)
+        case "chess": return 300 * 60         // a classical round (~5h)
+        case "cs2", "esports": return 150 * 60 // a best-of match (~2h30)
+        case "tennis": return 210 * 60        // a best-of match (~3h30)
+        case "golf": return 600 * 60          // a day's play fallback (~10h; golf is normally multi-day)
+        default: return 180 * 60              // conservative generic session (~3h)
+        }
+    }
+
+    /// Whether the Oslo-local hour sits inside the plausible daily playing window
+    /// [08:00, 22:00) — the multi-day daily-window check (mirrors JS `ssOsloHour`).
+    nonisolated static func isWithinDailyWindow(_ now: Date) -> Bool {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Europe/Oslo") ?? .current
+        let h = cal.component(.hour, from: now)
+        return h >= 8 && h < 22
     }
 
     nonisolated private static func makeItem(

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -761,34 +761,43 @@ struct ContentView: View {
 
     @ViewBuilder
     private var liveNowLine: some View {
-        if !agenda.liveNow.isEmpty {
-            VStack(alignment: .leading, spacing: 5) {
-                ForEach(agenda.liveNow) { row in
-                    HStack(spacing: 8) {
-                        Text("▌ LIVE")
-                            .font(.sportivista(.caption, weight: .semibold))
-                            .foregroundStyle(SportivistaTokens.live)
-                        Text(row.title)
-                            .font(.sportivista(.subheadline))
-                            .foregroundStyle(SportivistaTokens.label)
-                            .lineLimit(1)
-                        Text("·")
-                            .font(.sportivista(.subheadline))
-                            .foregroundStyle(SportivistaTokens.secondaryLabel.opacity(0.6))
-                        Text(row.channelLabel)
-                            .font(.sportivista(.subheadline))
-                            .foregroundStyle(SportivistaTokens.secondaryLabel)
-                            .lineLimit(1)
+        // WP-126: a light minute tick so the line stays TRUE between reloads — a
+        // finished event drops and a just-started one appears without waiting for
+        // the next sync. `TimelineView(.everyMinute)` is a data refresh, not an
+        // animation (Reduce-Motion-friendly; never per-second). `currentLiveRows`
+        // re-derives from the reload snapshot through the SAME shared live
+        // definition (`liveState`) the compile used.
+        TimelineView(.everyMinute) { context in
+            let rows = agenda.currentLiveRows(now: context.date)
+            if !rows.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(rows) { row in
+                        HStack(spacing: 8) {
+                            Text("▌ LIVE")
+                                .font(.sportivista(.caption, weight: .semibold))
+                                .foregroundStyle(SportivistaTokens.live)
+                            Text(row.title)
+                                .font(.sportivista(.subheadline))
+                                .foregroundStyle(SportivistaTokens.label)
+                                .lineLimit(1)
+                            Text("·")
+                                .font(.sportivista(.subheadline))
+                                .foregroundStyle(SportivistaTokens.secondaryLabel.opacity(0.6))
+                            Text(row.channelLabel)
+                                .font(.sportivista(.subheadline))
+                                .foregroundStyle(SportivistaTokens.secondaryLabel)
+                                .lineLimit(1)
+                        }
                     }
                 }
+                .frame(maxWidth: 640, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                Rectangle()
+                    .fill(SportivistaTokens.separator)
+                    .frame(height: 1)
             }
-            .frame(maxWidth: 640, alignment: .leading)
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-            Rectangle()
-                .fill(SportivistaTokens.separator)
-                .frame(height: 1)
         }
     }
 

--- a/ios/SportivistaTests/AgendaViewModelTests.swift
+++ b/ios/SportivistaTests/AgendaViewModelTests.swift
@@ -283,6 +283,55 @@ final class AgendaViewModelTests: XCTestCase {
         XCTAssertEqual(AgendaViewModel.liveRows(events: events, interests: interests, now: now).count, 2, "the live line shows at most two")
     }
 
+    // MARK: - WP-126: the ONE shared live definition (mirrors ssLiveState / the
+    // web dashboard-cards case matrix bit-for-bit).
+
+    /// Bridge one Event to its FeedEvent + resolved Event (as liveRows does).
+    private func bridged(_ event: Event) -> (FeedEvent, Event?) {
+        let (fes, lookup) = EventBridge.bridge([event])
+        let fe = fes[0]
+        return (fe, fe.id.flatMap { lookup[$0] })
+    }
+
+    func testLiveState_noEndTime_usesSportDefault() {
+        // football ~2h15 default when there is no endTime
+        let (fe, ev) = bridged(EventBuilder.make(sport: "football", title: "Kamp", time: "2026-07-14T12:00:00Z"))
+        XCTAssertNil(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T11:00:00Z")), "not started")
+        XCTAssertEqual(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T13:00:00Z")), .direkte, "1h in")
+        XCTAssertNil(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T15:00:00Z")), "3h in → past the ~2h15 default")
+    }
+
+    func testLiveState_tourStageMidSession_isDirekte() {
+        let (fe, ev) = bridged(EventBuilder.make(sport: "cycling", title: "Etappe 12", time: "2026-07-14T11:30:00Z", endTime: "2026-07-14T15:30:00Z"))
+        XCTAssertEqual(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T13:00:00Z")), .direkte)
+        XCTAssertNil(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T16:00:00Z")), "past its endTime")
+    }
+
+    func testLiveState_multiDayTournament_pagaarOutsideWindow_direkteInside() {
+        // Summer (CEST, UTC+2): Oslo 03:00 = 01:00Z, Oslo 14:00 = 12:00Z.
+        let (fe, ev) = bridged(EventBuilder.make(sport: "golf", title: "The Open", time: "2026-07-13T08:00:00Z", endTime: "2026-07-18T20:00:00Z"))
+        XCTAssertEqual(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-15T01:00:00Z")), .pagaar, "Oslo 03:00 → underway, not an active session")
+        XCTAssertEqual(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-15T12:00:00Z")), .direkte, "Oslo 14:00 → inside the daily window")
+    }
+
+    func testLiveState_finishedSingleSession_isNil() {
+        let (fe, ev) = bridged(EventBuilder.make(sport: "tennis", title: "Semi", time: "2026-07-14T10:00:00Z", endTime: "2026-07-14T13:00:00Z"))
+        XCTAssertNil(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T15:00:00Z")))
+    }
+
+    func testLiveState_inProgressStatus_winsOutright() {
+        // now is way past any default duration, but the source status says live.
+        let (fe, ev) = bridged(EventBuilder.make(sport: "football", title: "Kamp", time: "2026-07-14T10:00:00Z", status: "STATUS_IN_PROGRESS"))
+        XCTAssertEqual(AgendaViewModel.liveState(fe, event: ev, now: iso("2026-07-14T20:00:00Z")), .direkte)
+    }
+
+    func testLiveRows_multiDayTournament_excludedAt0300_includedAt1400() {
+        let event = EventBuilder.make(sport: "golf", title: "The Open", time: "2026-07-13T08:00:00Z", endTime: "2026-07-18T20:00:00Z", streaming: [["platform": "TV 2 Play"]])
+        let interests = Interests(followBroadly: ["golf"])
+        XCTAssertTrue(AgendaViewModel.liveRows(events: [event], interests: interests, now: iso("2026-07-15T01:00:00Z")).isEmpty, "'pågår' (Oslo 03:00) is never the ▌LIVE line")
+        XCTAssertEqual(AgendaViewModel.liveRows(events: [event], interests: interests, now: iso("2026-07-15T12:00:00Z")).count, 1, "'direkte' (Oslo 14:00) shows")
+    }
+
     // MARK: - End-to-end against the real, checked-in fixtures
 
     func testBuildSections_realFixtures_tourDeFranceCollapsesAndLynIsMustWatch() throws {

--- a/ios/SportivistaTests/EventBuilder.swift
+++ b/ios/SportivistaTests/EventBuilder.swift
@@ -38,9 +38,11 @@ enum EventBuilder {
         id: String? = nil,
         result: String? = nil,
         homeTeamEntityId: String? = nil,
-        awayTeamEntityId: String? = nil
+        awayTeamEntityId: String? = nil,
+        status: String? = nil
     ) -> Event {
         var dict: [String: Any] = ["sport": sport, "title": title, "time": time, "norwegian": norwegian, "isFavorite": isFavorite]
+        if let status { dict["status"] = status }
         if let endTime { dict["endTime"] = endTime }
         if let homeTeam { dict["homeTeam"] = homeTeam }
         if let awayTeam { dict["awayTeam"] = awayTeam }

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { createClientSandbox, loadClientScript } from "./helpers/load-client.js";
 
 let dash;
+let win;
 
 beforeAll(() => {
 	const sandbox = createClientSandbox();
@@ -13,6 +14,7 @@ beforeAll(() => {
 	loadClientScript(sandbox, "followed.js");
 	loadClientScript(sandbox, "chrome.js");
 	dash = sandbox.window.dashboard;
+	win = sandbox.window;
 });
 
 const soon = () => new Date(Date.now() + 3600000).toISOString();
@@ -706,5 +708,76 @@ describe("«Neste opp» dedupes rows already visible in the agenda (WP-128)", ()
 		dash.allEvents = [{ id: "ruud-swiss", sport: "tennis", title: "Swiss Open (Casper Ruud)", time: inDays(3) }];
 		dash._agendaShownIds = undefined;
 		expect(dash.nextUpEntries().map((r) => r.entry.name)).toEqual(["Casper Ruud"]);
+	});
+});
+
+// WP-126 — the ONE shared live definition (ssLiveState) + the "Direkte nå" line
+// showing non-ESPN sports (a Tour stage / chess round / CS2 match), not just the
+// ESPN-polled football/golf/F1.
+describe("shared live state (ssLiveState)", () => {
+	// Summer (CEST, UTC+2): Oslo 03:00 = 01:00Z, Oslo 14:00 = 12:00Z.
+	const ssLiveState = () => win.ssLiveState;
+
+	it("uses the sport default duration when there is no endTime", () => {
+		const start = "2026-07-14T12:00:00Z";
+		const e = { sport: "football", time: start }; // ~2h15 default
+		const s = new Date(start).getTime();
+		expect(win.ssLiveState(e, s + 60 * 60 * 1000)).toBe("direkte"); // 1h in
+		expect(win.ssLiveState(e, s + 3 * 60 * 60 * 1000)).toBe(null); // 3h in → past default
+		expect(win.ssLiveState(e, s - 60 * 1000)).toBe(null); // not started yet
+	});
+
+	it("a Tour de France stage mid-session is 'direkte'", () => {
+		const e = { sport: "cycling", title: "Etappe 12", time: "2026-07-14T11:30:00Z", endTime: "2026-07-14T15:30:00Z" };
+		expect(win.ssLiveState(e, new Date("2026-07-14T13:00:00Z").getTime())).toBe("direkte");
+		expect(win.ssLiveState(e, new Date("2026-07-14T16:00:00Z").getTime())).toBe(null); // finished
+	});
+
+	it("a multi-day tournament is 'pågår' outside the daily window (03:00), 'direkte' inside (14:00)", () => {
+		const e = { sport: "golf", title: "The Open", time: "2026-07-13T08:00:00Z", endTime: "2026-07-18T20:00:00Z" };
+		expect(win.ssLiveState(e, new Date("2026-07-15T01:00:00Z").getTime())).toBe("pågår"); // Oslo 03:00
+		expect(win.ssLiveState(e, new Date("2026-07-15T12:00:00Z").getTime())).toBe("direkte"); // Oslo 14:00
+	});
+
+	it("a finished single-session event is null", () => {
+		const e = { sport: "tennis", title: "Semifinale", time: "2026-07-14T10:00:00Z", endTime: "2026-07-14T13:00:00Z" };
+		expect(win.ssLiveState(e, new Date("2026-07-14T15:00:00Z").getTime())).toBe(null);
+	});
+
+	it("an authoritative in-progress status wins outright", () => {
+		const e = { sport: "football", time: "2026-07-14T10:00:00Z", status: "STATUS_IN_PROGRESS" };
+		// now is way past any default duration, but the status says live
+		expect(win.ssLiveState(e, new Date("2026-07-14T20:00:00Z").getTime())).toBe("direkte");
+	});
+});
+
+describe("the 'Direkte nå' line (live.js)", () => {
+	it("directLiveEvents surfaces a non-ESPN sport (cycling) that is live now", () => {
+		const now = new Date("2026-07-14T13:00:00Z").getTime();
+		dash.allEvents = [
+			{ id: "tdf-12", sport: "cycling", title: "Etappe 12", time: "2026-07-14T11:30:00Z", endTime: "2026-07-14T15:30:00Z", streaming: [{ platform: "TV 2 Play", url: "https://tv2.no" }] },
+			{ id: "done", sport: "tennis", title: "Ferdig", time: "2026-07-14T08:00:00Z", endTime: "2026-07-14T10:00:00Z" },
+			{ id: "later", sport: "football", title: "Senere", time: "2026-07-14T19:00:00Z" },
+		];
+		const live = dash.directLiveEvents(now);
+		expect(live.map((e) => e.id)).toEqual(["tdf-12"]); // the cycling stage, not the finished/future ones
+	});
+
+	it("renders a calm live row with the event's title + channel", () => {
+		const html = dash.liveEventRow({ id: "tdf-12", sport: "cycling", title: "Etappe 12", time: "2026-07-14T11:30:00Z", streaming: [{ platform: "TV 2 Play", url: "https://tv2.no" }] });
+		expect(html).toContain("live-item");
+		expect(html).toContain("Etappe 12");
+		expect(html).toContain("TV 2 Play");
+	});
+
+	it("hasLiveEvents is true for a live non-ESPN event (drives the 60s tick)", () => {
+		dash.allEvents = [{ id: "tdf-12", sport: "cycling", title: "Etappe 12", time: "2026-07-14T11:30:00Z", endTime: "2026-07-14T15:30:00Z" }];
+		const realNow = Date.now;
+		Date.now = () => new Date("2026-07-14T13:00:00Z").getTime();
+		try {
+			expect(dash.hasLiveEvents()).toBe(true);
+		} finally {
+			Date.now = realNow;
+		}
 	});
 });


### PR DESCRIPTION
## WP-126 · Live-koherens (eierbestilling 20.07: «bedre visning for det som pågår live, virker litt random»)

**Rotårsak (verifisert):** tre usammenhengende live-begreper —
- (a) web «Direkte nå» (`live.js renderLive`) viste KUN ESPN-pollede sports (fotballscore/golf/F1); en TdF-etappe/sjakk/CS2/friidrett vises aldri der uansett;
- (b) tidsvindu-«pågår nå» (`followed.js`) er sann kl. 03 for flerdagsevents (impliserer aktiv økt);
- (c) iOS `liveNow` beregnes kun ved reload, tikker aldri, kan vise ferdigspilt event som live.

## Løsning — ÉN delt live-definisjon

`ssLiveState(event, now)` (web, `docs/js/shared-constants.js`) ↔ `AgendaViewModel.liveState` (iOS) — speilet 1:1 med felles sport-default-tabell:

- **`'direkte'`** = nå ∈ `[time, effectiveEnd]`, der `effectiveEnd` = `endTime` når det er en plausibel økt (≤ ~24t), ellers sport-typet default fra start: fotball ~2t15, F1-økt ~2t, sykkeletappe ~5t30, sjakkrunde ~5t, CS2 ~2t30, tennis ~3t30, golf-dag ~10t, ellers ~3t. Autoritativ in-progress-`status` vinner outright.
- **`'pågår'`** = flerdagsturnering (`endTime` > ~24t etter start) UTENFOR plausibelt Oslo-dagsvindu `[08–22)` — rolig tilstand, ALDRI live-dot (fikser 03:00-buggen). Innenfor vinduet → `'direkte'`.
- **`null`** = ikke startet / ferdig.

Heuristikk, dokumentert og bevisst **konservativ**: heller `'pågår'` enn falsk `'direkte'`.

## Per flate

1. **Web «Direkte nå»** (`live.js`): viser ALLE `'direkte'` tavle-events som rolige rader (when·what·where). ESPN-score/leaderboard **beriker** raden der pollingen har data — score er bonus, ikke inngangsbillett. Golf/F1 forblir ESPN-poll-eid (det pålitelige signalet for de to; unngår falsk `'direkte'` fra det grove dagsvinduet). TdF/sjakk/CS2/tennis + upollet fotball vises nå. `hasLiveEvents` gated på delt def ⇒ 60s-tikk også for ikke-ESPN-sport.
2. **iOS** (`AgendaViewModel.liveRows` → `liveState == .direkte`): lett minutt-tikk via `TimelineView(.everyMinute)` + `currentLiveRows(now:)` (Reduce-Motion-vennlig, ikke per-sekund) så linja er sann mellom reloads. Cap på to beholdt (DESIGN §4).
3. **`followed.js relDay`**: bruker delt def — flerdags kl. 03 sier «pågår» (ikke «pågår nå»).

## Grenser (holdt)
`docs/data` urørt · News/Sync/EventDetailSheet urørt · **Widget urørt (WP-127 eier fila, merget i #339)** · predikatene/gylne vektorer bit-like (live-visning er ikke kompilering).

## Tester
- Web: `ssLiveState`-matrise (uten endTime→default, flerdags 03→pågår / 14→direkte, ferdig→null, TdF midt i økta→direkte, in-progress-status vinner) + `directLiveEvents`/`liveEventRow`/`hasLiveEvents` (ikke-ESPN-sport synlig i linja).
- iOS: `liveState`-speilingstest (samme matrise) + `liveRows`-eksklusjon av flerdags 03:00.

## Verifisering
- **699 JS-tester** grønt (`npx vitest run --maxWorkers=1`).
- **Full iOS unit-suite grønn på rebaset tre** (604 test cases, inkl. gylne `FeedVectorTests` bit-like) + **alle 4 schemes bygger** (Sportivista/Widget/UITests/DeviceDev).
- `npm run screenshot` begge temaer: rolig, ingen regresjon (natt ⇒ ingen falsk «Direkte nå»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)