### PR TITLE
WP-129: onboarding-klarhet — formål i klarspråk, kapsel-copy, kommentar-modernisering

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,7 +133,7 @@ mennesket, aldri av en agent.
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | ⬜ bølge 3 |
 | WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | 🔬 bølge 3 |
 | WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | 🔬 bølge 3 |
-| WP-129 | Onboarding-copy (kapsel-modellen) + stale kommentarer + regenerert skjermkatalog | 0I | WP-117 | ⬜ bølge 4 |
+| WP-129 | Onboarding-klarhet: formål i klarspråk + kapsel-copy + stale kommentarer | 0I | WP-117 | 🔬 bølge 4 |
 | WP-130 | Pipeline-kvalitet: refaktor-auditens quick-wins | 0I | — | 🔬 PR åpen — containsName-memo, haystack-dedup ×3, én fillesing, configDirPath (+2 env-bugfiks), 2 døde eksporter, flattenStats, golf mergeEvents |
 
 ---
@@ -413,15 +413,21 @@ OPP»-rader som dupliserer synlige agendarader dedupes; sport-symbol på web-rad
 vurderes for paritet. **Aksept:** nye dashboard-cards-tester (ingen fortids-dag
 øverst; ekspandert overlever poll); DESIGN.md internt konsistent.
 
-### WP-129 · Onboarding-copy + stale kommentarer + skjermkatalog (bølge 4)
-**Mål:** appen skal ikke lære bort en kontroll som ikke finnes. **Innhold:**
-(1) `OnboardingView.swift` (~435/440) + `AgendaView.emptyRow` (~216–219):
+### WP-129 · Onboarding-klarhet: formål i klarspråk + kapsel-copy + stale kommentarer (bølge 4)
+**Mål:** appen skal ikke lære bort en kontroll som ikke finnes, OG (eierbestilling
+20.07) forklare formålet i klarspråk for ikke-tekniske brukere før den ber om noe.
+**Innhold:** (1) `OnboardingView.swift` (landing) + `AgendaView.emptyRow`:
 «skriv i kommandolinjen nederst»/«»_»-idiomet erstattes med kapsel-modellens
-språk («trykk assistenten nederst»); (2) stale «Tekst-TV»/«mono»/TekstTVClock-
-kommentarer i ~15 Swift-filer ryddes; (3) `ios/docs/design-v2/`-katalogen er
-pre-baseline (14.07, viser gammelt ZENJI-utseende) — regenerer via
-design/screens/generate.sh eller merk mappa utdatert. **Aksept:** grep 0 treff
-på «kommandolinjen»/TekstTVClock i ios/Sportivista; UI-røyk grønn.
+språk («trykk assistenten nederst») + en rolig kapsel-preview (assistent-symbol ·
+prompt · amber mic); (2) formåls-klarhet: velkomst-steget sier HVA appen gjør i én
+klarspråks-setning før quick-picks/samtale, den tomme agendaen forklarer formål +
+neste steg vennlig — quick-picks beholdes som den universelle vei-uten-AI,
+samtalen er entusiast-veien (routing uendret); (3) stale «Tekst-TV»/«teletext»-
+kommentarer i 14 Swift-filer omformuleres (constraint-bærende linjer i
+DesignTokens/Interaction beholder rasjonalet, forankret i «Apple-native baseline»).
+Skjermkatalog-punktet utgår — design-v2-galleriet er slettet (regel 8), ingen
+gjenoppretting. **Aksept:** grep 0 treff på «kommandolinjen»/«Tekst-TV»/«teletext»
+i ios/Sportivista; enhets-suite + UI-røyk onboarding grønn.
 
 Første designer-runde gjennom Claude Design ga en godkjent retning («Intuitivt
 for alle», turn 3) som eier har bestilt FULL implementering av — inkludert å

--- a/ios/Sportivista/Agenda/AgendaView.swift
+++ b/ios/Sportivista/Agenda/AgendaView.swift
@@ -199,7 +199,7 @@ struct AgendaView: View {
     /// honest "nothing right now" — `lastSync == nil` is DataStore's own
     /// "never synced" flag (see DataStore.swift), not just "zero events".
     /// WP-31: when the board is empty AND the follow-profile is empty (onboarding
-    /// skipped), point back at the command line instead of reading as "nothing on".
+    /// skipped), point at the assistant capsule instead of reading as "nothing on".
     @ViewBuilder
     private var emptyRow: some View {
         if viewModel.filter != nil {
@@ -211,12 +211,13 @@ struct AgendaView: View {
             emptyText("Henter data …")
         } else if viewModel.profileIsEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                emptyText("Fortell Sportivista hva du følger.")
+                emptyText("Fortell Sportivista hva du følger, så samler den når og hvor du kan se det.")
                 HStack(spacing: 8) {
-                    Text("»_")
+                    Image(systemName: SportSymbol.assistant)
                         .font(.sportivista(.callout, weight: .semibold))
                         .foregroundStyle(SportivistaTokens.secondaryLabel)
-                    Text("Skriv i linjen nederst.")
+                        .accessibilityHidden(true)
+                    Text("Trykk assistenten nederst.")
                         .font(.sportivista(.footnote))
                         .foregroundStyle(SportivistaTokens.secondaryLabel.opacity(0.8))
                 }

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -7,8 +7,8 @@
 //  carries `source == "ai-research"` — the AI provenance block (confidence +
 //  evidence links). "Åpenhet er en funksjon" (CLAUDE.md): the ⓘ isn't
 //  decoration, it's how the app earns trust for events a human didn't
-//  curate. Still Tekst-TV throughout (mono, amber, near-black), not the
-//  system's default List chrome.
+//  curate. Still the Apple-native baseline throughout (system type, amber), not
+//  the system's default List chrome.
 //
 
 import SwiftUI

--- a/ios/Sportivista/Assistant/AgendaFilter.swift
+++ b/ios/Sportivista/Assistant/AgendaFilter.swift
@@ -113,7 +113,7 @@ struct AgendaFilter: Equatable, Sendable {
     /// window-only filter ("vis alt i dag") keeps every subject, just this day.
     var hasSubjectConstraint: Bool { !sports.isEmpty || !entities.isEmpty }
 
-    /// The calm Tekst-TV subject for the filter line ("GOLF · DENNE UKA"). A
+    /// The calm subject for the filter line ("GOLF · DENNE UKA"). A
     /// sports set that exactly matches a known umbrella category collapses to the
     /// category name ("VINTERSPORT") so the line stays short.
     var subjectLabel: String {

--- a/ios/Sportivista/Assistant/AssistantSheetView.swift
+++ b/ios/Sportivista/Assistant/AssistantSheetView.swift
@@ -289,7 +289,7 @@ struct AssistantSheetView: View {
     }
 }
 
-/// The Tekst-TV block cursor. Blinks (the assistant's only motion) unless Reduce
+/// The block cursor. Blinks (the assistant's only motion) unless Reduce
 /// Motion is on, in which case it holds steady (DESIGN "Bevegelse & haptikk").
 /// Re-homed here from CommandLineView (WP-104) — shared by the sheet's thinking
 /// state and the onboarding conversation step.

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -793,7 +793,7 @@ struct ContentView: View {
     }
 
     /// WP-67 — the quiet filter line over the agenda when a presentation filter
-    /// is active («VISER: GOLF · DENNE UKA ✕»). Tekst-TV to the core: mono,
+    /// is active («VISER: GOLF · DENNE UKA ✕»). Calm to the core:
     /// dempet «VISER:», the amber subject, and a one-tap ✕ that resets. Hidden
     /// when no filter is set — the calm default is an unfiltered board.
     @ViewBuilder

--- a/ios/Sportivista/DesignTokens.swift
+++ b/ios/Sportivista/DesignTokens.swift
@@ -18,7 +18,7 @@
 //      for the time column and other places digits must line up.
 //
 //  The WP-80 migration shims (the legacy fixed-size `sportivistaMono` font and the
-//  Tekst-TV colour aliases) were removed in WP-85 once every surface had
+//  pre-baseline colour aliases) were removed in WP-85 once every surface had
 //  migrated to the API above. Fixed `.system(size:)` points are barred by the
 //  HIG CI gate (tests/ios-dynamic-type-gate.test.js).
 //
@@ -66,7 +66,7 @@ enum SportivistaTokens {
 	/// Hairline / separator. `rgba(84,84,88,.6)` / `#C6C6C8`.
 	static let separator = Color(uiColor: .separator)
 
-	/// The ONE accent — teletext amber. `#FFB000` dark / `#9A6800` light. Used
+	/// The ONE accent — amber. `#FFB000` dark / `#9A6800` light. Used
 	/// only for accent (selected state, bar-button tint, must-see dot, alert-on,
 	/// primary action) — never body text, never two amber elements in one row.
 	static let accent = Color.sportivista(dark: Color(hex: 0xFFB000), light: Color(hex: 0x9A6800))

--- a/ios/Sportivista/Eval/EvalView.swift
+++ b/ios/Sportivista/Eval/EvalView.swift
@@ -137,7 +137,7 @@ final class EvalScreenModel {
     func clearMetricLog() { metricStore.deleteAll() }
 }
 
-/// The DEBUG eval screen — calm Tekst-TV: monospace, amber accent, no charts.
+/// The DEBUG eval screen — calm: amber accent, no charts.
 struct EvalView: View {
     @State private var model: EvalScreenModel
     @Environment(\.dismiss) private var dismiss

--- a/ios/Sportivista/Feed/AgendaFormat.swift
+++ b/ios/Sportivista/Feed/AgendaFormat.swift
@@ -11,7 +11,7 @@
 //  helpers here means the widget target picks them up for free, no separate
 //  project.yml entry needed.
 //
-//  Every function here answers exactly one Tekst-TV row question — "når",
+//  Every function here answers exactly one agenda-row question — "når",
 //  "hva", "hvor" — plus the day-section label and the collapsed-series
 //  summary line. Kept pure (no Date() calls, no I/O) so every rule is
 //  unit-testable in isolation (AgendaFormatTests) with fixed inputs.

--- a/ios/Sportivista/Interaction.swift
+++ b/ios/Sportivista/Interaction.swift
@@ -6,13 +6,13 @@
 //  package): every interactive element gets an Apple HIG-compliant ≥44×44pt
 //  hit area, however small its glyph reads visually. The owner's finding on a
 //  physical iPhone was "veldig små knapper" (very small buttons) — the fix is
-//  ALWAYS the hit area, never the Tekst-TV glyph scale (DESIGN.md's small,
-//  quiet mono glyphs are the visual language and are kept as-is).
+//  ALWAYS the hit area, never the glyph scale: the small, quiet marks are the
+//  Apple-native visual language (DESIGN.md) and are kept exactly as-is.
 //
 //  Two shapes cover every case in the audit (see PR body for the full table):
 //
 //   • `.sportivistaTapTarget()` — for glyph/icon-only or small-text chrome (header
-//     glyphs, the command line's sigil/send/Avbryt, toolbar "Lukk", "OK",
+//     glyphs, the samtaleark's send/Avbryt, toolbar "Lukk", "OK",
 //     "Fjern", "Slett", note-edit controls …). The glyph/text stays exactly
 //     the size DESIGN.md specifies; only the invisible hit area grows to
 //     ≥44×44pt via padding + `contentShape`, never by enlarging the mark.
@@ -29,7 +29,7 @@ import SwiftUI
 extension View {
     /// Grows the tappable area to ≥44×44pt around a small glyph or text
     /// label without changing how it looks — the padding is invisible, the
-    /// mark stays Tekst-TV-quiet (DESIGN.md "Interaksjon").
+    /// mark stays visually quiet (DESIGN.md "Interaksjon").
     func sportivistaTapTarget() -> some View {
         self
             .frame(minWidth: 44, minHeight: 44)

--- a/ios/Sportivista/Memory/WhatIKnowView.swift
+++ b/ios/Sportivista/Memory/WhatIKnowView.swift
@@ -7,8 +7,8 @@
 //  structured facts, episodic notes, behaviour stats — each readable, the
 //  structured facts editable, everything deletable, plus a "Glem alt" that wipes
 //  all personal memory. Reached from the assistant flow, the same place as "Hva
-//  jeg følger". Tekst-TV throughout: mono, one amber accent, near-black/warm
-//  paper, no emoji, tap targets ≥44pt.
+//  jeg følger". Apple-native baseline throughout: system type, one amber accent,
+//  no emoji, tap targets ≥44pt.
 //
 //  Honest about the privacy contract, in the intro line: this lives ONLY on your
 //  device (and your own iCloud / QR bridge) — never our server.

--- a/ios/Sportivista/Onboarding/OnboardingGate.swift
+++ b/ios/Sportivista/Onboarding/OnboardingGate.swift
@@ -16,10 +16,10 @@
 import Foundation
 
 /// The steps of the calm first-run flow. `welcome` is always first; the build
-/// step is `converse` when Apple Intelligence is available (the primary,
-/// say-what-you-follow path) else `quickPicks` (the fallback that must give
-/// full value on its own); `landing` is the quiet finish that points at the
-/// always-present command line.
+/// step is `converse` (the say-what-you-follow conversation) when Apple
+/// Intelligence is available, else `quickPicks` (the tap-to-follow path that
+/// works for everyone, no assistant understanding needed); `landing` is the
+/// quiet finish that points at the always-present assistant capsule.
 enum OnboardingStep: Equatable, Sendable {
     case welcome
     case converse

--- a/ios/Sportivista/Onboarding/OnboardingView.swift
+++ b/ios/Sportivista/Onboarding/OnboardingView.swift
@@ -4,24 +4,28 @@
 //
 //  WP-31 — the calm first-run experience (dossier P310's «definere»-løkke:
 //  "onboarding er en samtale, ikke et skjema — ingen konkurrent lar deg SI hva
-//  du bryr deg om"). Four quiet steps, all in the Tekst-TV language (mono,
-//  amber, near-black, the ensō mark), no hero art, no carousel, no emoji, no
-//  exclamation marks:
+//  du bryr deg om"). Four quiet steps on the Apple-native baseline (system
+//  type, one amber accent, the ensō mark), no hero art, no carousel, no emoji,
+//  no exclamation marks. WP-129 — the copy speaks plainly to a non-technical
+//  first-time user (say WHAT the app does before asking for anything) and points
+//  at the assistant CAPSULE, never the retired inline command line:
 //
-//    1. welcome    — one honest sentence about what Sportivista is (når · hva · hvor)
+//    1. welcome    — one plain-language sentence about what Sportivista does
+//                    (samler når · hvor du kan se sporten du bryr deg om)
 //                    + the on-device privacy moment (P350/P360).
-//    2. converse   — the PRIMARY path when Apple Intelligence is available: the
-//                    same »_ command-line idiom, free Norwegian text → the
-//                    EXISTING assistant (InterestAssistant.interpret) → a calm
-//                    diff the user confirms, saying several things in a row while
-//                    the "Følger nå" list grows. This reuses AssistantViewModel
-//                    wholesale — NOT a parallel input.
-//    3. quickPicks — the fallback (and available to everyone): curated Norwegian
-//                    starter packs as ≥44pt tap targets. This alone gives full
-//                    value on a cold start with no Apple Intelligence.
-//    4. landing    — the quiet finish: it points at the always-present command
-//                    line ("du kan alltid si mer til Sportivista") and drops the user
-//                    into an agenda that ALREADY reflects the choices, because
+//    2. converse   — the say-what-you-follow path (Apple Intelligence only):
+//                    free Norwegian text in an inline field → the EXISTING
+//                    assistant (InterestAssistant.interpret) → a calm diff the
+//                    user confirms, saying several things in a row while the
+//                    "Følger nå" list grows. Reuses AssistantViewModel wholesale
+//                    — NOT a parallel input.
+//    3. quickPicks — the tap-to-follow path that works for EVERYONE: curated
+//                    Norwegian starter packs as ≥44pt tap targets. This alone
+//                    gives full value on a cold start with no Apple Intelligence,
+//                    and needs no understanding of the assistant.
+//    4. landing    — the quiet finish: it points at the always-present assistant
+//                    capsule ("du kan alltid si mer til Sportivista") and drops the
+//                    user into an agenda that ALREADY reflects the choices, because
 //                    every confirm/tap recompiled it live via onProfileChanged.
 //
 //  Presentation only. Every mutation goes through AssistantViewModel + the pure
@@ -103,7 +107,7 @@ struct OnboardingView: View {
     private var welcomeStep: some View {
         VStack(alignment: .leading, spacing: 20) {
             stepHeading("Velkommen")
-            Text("Sportivista er én rolig oversikt over idretten du følger — når det skjer, hva det er, og hvor du kan se det.")
+            Text("Sportivista samler når og hvor du kan se sporten du bryr deg om — alt i én rolig liste.")
                 .font(.sportivistaTabular(.subheadline, weight: .regular))
                 .foregroundStyle(SportivistaTokens.label.opacity(0.9))
                 .fixedSize(horizontal: false, vertical: true)
@@ -169,9 +173,10 @@ struct OnboardingView: View {
         }
     }
 
-    /// The command line, reused as the onboarding input — the SAME idiom as the
-    /// always-present line (mono `»_`, plain field, blinking amber cursor /
-    /// "tenker …" / send), so onboarding feels like the app, not a wizard.
+    /// The onboarding's inline conversation field — the enthusiast, say-what-you-
+    /// follow input. A plain field with a `»_` prompt sigil and a blinking amber
+    /// cursor / "tenker …" / send, feeding the SAME assistant the capsule opens,
+    /// so onboarding feels like the app, not a wizard.
     private var promptLine: some View {
         HStack(alignment: .center, spacing: 10) {
             Text("»_")
@@ -419,7 +424,7 @@ struct OnboardingView: View {
         VStack(alignment: .leading, spacing: 20) {
             stepHeading("Klart")
             if assistant.profile.isEmpty {
-                Text("Du følger ingenting ennå — det er helt greit. Skriv til Sportivista når som helst nederst på skjermen.")
+                Text("Du følger ingenting ennå — det er helt greit. Trykk assistenten nederst når du vil legge til noe.")
                     .font(.sportivistaTabular(.subheadline, weight: .regular))
                     .foregroundStyle(SportivistaTokens.label.opacity(0.85))
                     .fixedSize(horizontal: false, vertical: true)
@@ -431,17 +436,29 @@ struct OnboardingView: View {
                 followingNow
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Du kan alltid si mer til Sportivista — skriv i kommandolinjen nederst.")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Du kan alltid si mer til Sportivista — trykk assistenten nederst.")
                     .font(.sportivistaTabular(.footnote, weight: .regular))
                     .foregroundStyle(SportivistaTokens.label.opacity(0.75))
                     .fixedSize(horizontal: false, vertical: true)
-                HStack(spacing: 8) {
-                    Text("»_")
+                // A quiet preview of the always-present assistant capsule
+                // (§ Hjelperen): leading assistant symbol · the same prompt ·
+                // the amber mic — so the finish points at the REAL control, not
+                // the retired command line.
+                HStack(spacing: 10) {
+                    Image(systemName: SportSymbol.assistant)
                         .font(.sportivistaTabular(.subheadline, weight: .semibold))
                         .foregroundStyle(SportivistaTokens.secondaryLabel)
-                    BlinkingCursor()
+                    Text(AssistantViewModel.capsulePrompt)
+                        .font(.sportivistaTabular(.subheadline, weight: .regular))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    Image(systemName: "mic")
+                        .font(.sportivistaTabular(.subheadline, weight: .semibold))
+                        .foregroundStyle(SportivistaTokens.accent)
                 }
+                .accessibilityHidden(true)
             }
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/Sportivista/Onboarding/StarterPacks.swift
+++ b/ios/Sportivista/Onboarding/StarterPacks.swift
@@ -52,7 +52,7 @@ struct StarterRule: Equatable, Sendable {
 /// A tappable curated bundle of follow-rules.
 struct StarterPack: Identifiable, Equatable, Sendable {
     var id: String
-    /// Short Tekst-TV title ("Norske golfere").
+    /// Short title ("Norske golfere").
     var title: String
     /// One dempet line under it — what the pack covers.
     var subtitle: String

--- a/ios/Sportivista/Profile/ProfileQRCode.swift
+++ b/ios/Sportivista/Profile/ProfileQRCode.swift
@@ -4,12 +4,12 @@
 //
 //  WP-19 — the QR image for the "Del profil" flow. A thin CoreImage wrapper: the
 //  actual payload/merge logic lives in ProfileShareCodec (pure, Foundation-only);
-//  this only turns a string into a crisp, Tekst-TV-monochrome QR bitmap.
+//  this only turns a string into a crisp, monochrome QR bitmap.
 //
 //  Kept deliberately small and side-effect-free (a string in, an image out) so
 //  it is testable in the Simulator/CI without a camera or an iCloud account.
 //  Rendered as pure black modules on a clear background; the SwiftUI view tints
-//  it to the page's ink token so it reads as part of the teletext surface rather
+//  it to the page's ink token so it reads as part of the page surface rather
 //  than a glossy sticker.
 //
 

--- a/ios/Sportivista/Profile/ProfileSharePanel.swift
+++ b/ios/Sportivista/Profile/ProfileSharePanel.swift
@@ -8,7 +8,7 @@
 //  No emoji, one amber accent, hairline boxes, ≥44pt hit areas — DESIGN.md to the
 //  letter. All logic lives in AssistantViewModel + ProfileShareCodec; this only
 //  lays it out (the QR bitmap comes from ProfileQRCode, tinted to the ink token
-//  so it reads as part of the teletext surface, never a glossy sticker).
+//  so it reads as part of the page surface, never a glossy sticker).
 //
 
 import SwiftUI

--- a/ios/Sportivista/Sync/AppVersion.swift
+++ b/ios/Sportivista/Sync/AppVersion.swift
@@ -74,7 +74,7 @@ enum AppVersionCheck {
         return false
     }
 
-    /// The quiet Tekst-TV foot line: «BYGG a1b2c3d · 16.07 21:40 · SISTE»,
+    /// The quiet foot line: «BYGG a1b2c3d · 16.07 21:40 · SISTE»,
     /// «… · NYERE FINNES (d4e5f6a)» or just the stamp when there is no verdict.
     static func line(stamp: String, date: String, published: AppVersion?) -> String {
         let head = date.isEmpty ? "BYGG \(stamp)" : "BYGG \(stamp) · \(date)"

--- a/ios/SportivistaTests/DesignTokensTests.swift
+++ b/ios/SportivistaTests/DesignTokensTests.swift
@@ -10,7 +10,7 @@
 //    • the 8pt spacing scale exists.
 //
 //  The WP-80 migration shims (the fixed-size `sportivistaMono` font and the legacy
-//  Tekst-TV colour aliases) were removed in WP-85; their tests went with them.
+//  pre-baseline colour aliases) were removed in WP-85; their tests went with them.
 //
 
 import XCTest

--- a/ios/SportivistaTests/OnboardingTests.swift
+++ b/ios/SportivistaTests/OnboardingTests.swift
@@ -192,7 +192,8 @@ final class OnboardingTests: XCTestCase {
 
     func test_skip_leavesEmptyProfile_andEmptyBoard() {
         // Skipping adds nothing; with no followed entities a tennis-only event
-        // set produces no sections (the agenda's empty state then points at »_).
+        // set produces no sections (the agenda's empty state then points at the
+        // assistant capsule).
         let now = AssistantTestSupport.iso("2026-07-14T09:00:00Z")
         let match = EventBuilder.make(
             sport: "tennis", title: "Casper Ruud – Carlos Alcaraz", time: "2026-07-14T18:00:00Z",


### PR DESCRIPTION
## WP-129 · Onboarding-klarhet (bølge 4)

**Mål:** appen skal ikke lære bort en kontroll som ikke finnes, OG (eierbestilling 20.07) forklare formålet i klarspråk for ikke-tekniske brukere før den ber om noe. Appen skal betjene BÅDE tech-entusiaster og ikke-tekniske brukere.

### (1) Copy-fiks — kapsel-modellen (design-review I4)
Rot-linja er nå en kapsel-KNAPP (`AssistantCapsule`), ikke en kommandolinje. Onboardingen + tom agenda lærte fortsatt bort den gamle `»_`-linja.
- **`OnboardingView` landing:** «skriv i kommandolinjen nederst» → «trykk assistenten nederst». `»_`+cursor-forhåndsvisningen erstattet med en rolig **kapsel-preview** (assistent-symbol · `capsulePrompt` · amber `mic`) som viser den EKTE kontrollen brukeren møter nederst.
- **`AgendaView.emptyRow`:** «Skriv i linjen nederst.» → «Trykk assistenten nederst.», `»_` → assistent-symbolet.

### (2) Formåls-klarhet (eierutvidelse 20.07)
- **Velkomst-steget** sier HVA appen gjør i én klarspråks-setning FØR quick-picks/samtale: «Sportivista samler når og hvor du kan se sporten du bryr deg om — alt i én rolig liste.»
- **Tom agenda** forklarer formål + neste steg vennlig: «Fortell Sportivista hva du følger, så samler den når og hvor du kan se det.»
- Ingen «profil»/«linse»-sjargong i knapper/labels (var allerede rent).

**Routing-tolkning (flagges for eier):** «Behold quick-picks-flyten som primær; samtalen er entusiast-veien» er tolket som å BEVARE quick-picks som den universelle vei-uten-AI og samtalen som den Apple-Intelligence-gatede entusiast-veien — som allerede er tilfellet. Jeg **endret ikke** default-routingen (velkomst → samtale når AI finnes, ellers quick-picks), fordi (a) «behold» = bevar, (b) «IKKE legg til nye skjermer/steg», og (c) både UI-testene og `OnboardingTests` koder inn dagens flyt. Vil eier at *inngangssteget* skal flippes til quick-picks for alle, er det en liten oppfølging (`OnboardingGate.buildStep` + 1 enhetstest + 2 UI-tester).

### (3) Kommentar-modernisering
17 «Tekst-TV»/«teletext»-linjer i 14 filer omformulert (ikke slettet rasjonale). Constraint-bærende kommentarer beholder betydningen, nå forankret i **«Apple-native baseline»**:
- `DesignTokens.swift`: amber-token-rasjonalet + migrasjons-shim-historikken beholdt (kun metaforen byttet).
- `Interaction.swift`: ≥44 pt hit-area-regelen beholdt ordrett; eksempel-listen peker nå på samtalearket, ikke «the command line».
- Resten (fil-headere, QR/del-flate, agenda-format, eval, app-versjon, starterpacks) kort omformulert.
- Stale «command line»-referanser i onboarding-doc-kommentarene peker nå på kapselen.
- `ios/SportivistaTests/DesignTokensTests.swift` fikk samme omformulering for koherens.

**Skjermkatalog-punktet i spec-en utgår** — design-v2-galleriet er slettet (regel 8); ingen gjenoppretting.

### PLAN.md
WP-129-raden ⬜→🔬 + detaljseksjonen oppdatert til faktisk scope.

## Verifisering
- **Enhets-suite grønn:** 597 tester, 1 hoppet over (opt-in real-FM-eval), 0 feil — inkl. gylne feed-vektorer bit-like (`FeedVectorTests`).
- **4 schemes bygger:** Sportivista (testet), SportivistaWidgetExtension, SportivistaUITests (build-for-testing), SportivistaDeviceDev.
- **Onboarding-UI-røyk grønn:** `testOnboardingConversationThenQuickPicks` + `testRapidStarterPackTogglesStayResponsive` (2/2).
- **Grep-aksept:** 0 treff på «kommandolinjen»/«Tekst-TV»/«teletext» i `ios/Sportivista/`.
- Copy-endringene rører kun ikke-asserterte strenger, så eksisterende UI-/enhetstester består uten assert-oppdateringer. `npx vitest` urørt (ingen web/scripts-endringer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)