### PR TITLE
WP-125: entitets-konsolidering (100T-alias) + lens-miss-signal i Det du følger

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,7 +129,7 @@ mennesket, aldri av en agent.
 | WP-122 | ~~Deltaker widget/detalj~~ → slått inn i WP-127 | 0I | — | — |
 | WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | 🔬 bølge 3 |
 | WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |
-| WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | ⬜ bølge 4 |
+| WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | 🔬 bølge 4 |
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | 🔬 bølge 3 — ssLiveState (web) + AgendaViewModel.liveState (iOS-speil): 'direkte'/'pågår'/null; «Direkte nå» viser TdF/sjakk/CS2 (ESPN beriker); iOS minutt-tikk (TimelineView.everyMinute); followed.js relDay bruker delt def. Widget: WP-127 eier fila (urørt) |
 | WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | 🔬 bølge 3 |
 | WP-128 | Web-agenda: fortids-dag-fiks + ekspandert-tilstand over live-poll + klokke-avstemming | 0I | WP-117 | 🔬 bølge 3 |

--- a/ios/Sportivista/Profile/FollowPresenter.swift
+++ b/ios/Sportivista/Profile/FollowPresenter.swift
@@ -135,16 +135,59 @@ struct FollowPresenter {
         return Array(matched.prefix(limit))
     }
 
+    // MARK: - Match state (the WP-125 lens-miss signal)
+
+    /// How a followed rule is currently doing against the board — the calm signal
+    /// that makes a silently-dead follow visible without any telemetry:
+    ///   • `.scheduled`  — ≥1 upcoming event → the «Neste: …» subtitle.
+    ///   • `.idle`       — a real follow that just has nothing right now (a known
+    ///                     entity, a whole-sport follow, or one still carrying
+    ///                     news): «Ikke satt opp ennå».
+    ///   • `.unresolved` — the followed NAME resolves to nothing we know AND has no
+    ///                     news either — most likely a wrong/mistyped name:
+    ///                     «Ingen treff — sjekk navnet», with nearest-name help in
+    ///                     the detail.
+    enum FollowMatchState: Equatable { case scheduled, idle, unresolved }
+
+    /// Classify a rule (see `FollowMatchState`). A whole-sport / category follow is
+    /// always a valid follow, so it is never `.unresolved`. Everything else is
+    /// `.unresolved` only when its entityId is absent from the index (an unknown
+    /// name) AND no lens-matched news carries it.
+    func matchState(for rule: InterestRule) -> FollowMatchState {
+        if !nextEvents(for: rule, limit: 1).isEmpty { return .scheduled }
+        switch group(for: rule) {
+        case .sport, .category:
+            return .idle
+        default:
+            let known = index.entity(id: rule.entityId) != nil
+            let hasNews = !newsItems(for: rule, limit: 1).isEmpty
+            return (known || hasNews) ? .idle : .unresolved
+        }
+    }
+
+    /// Nearest known names for an `.unresolved` follow — the index's OWN fuzzy
+    /// resolver (`nearestMatches`, no new matching), so a mistyped follow can be
+    /// checked against real entities. Empty for a resolved follow, or when nothing
+    /// is genuinely close (the honest answer). The rule's own id is filtered out.
+    func nameSuggestions(for rule: InterestRule, limit: Int = 3) -> [Entity] {
+        guard matchState(for: rule) == .unresolved else { return [] }
+        return index.nearestMatches(to: rule.entityName, limit: limit)
+            .filter { $0.id != rule.entityId }
+    }
+
     // MARK: - Row subtitle
 
     /// The calm per-entity subtitle: «Neste: lør 25. · Strømsgodset – Lyn · TV 2»
-    /// (day · what · where), or an honest «Ikke satt opp ennå» when nothing is
-    /// scheduled — replacing the old, identical-on-every-row «varsler på».
+    /// (day · what · where) when scheduled; an honest «Ikke satt opp ennå» when a
+    /// real follow is quiet; or «Ingen treff — sjekk navnet» when the name resolves
+    /// to nothing (the WP-125 lens-miss signal). No technical words ever.
     func rowSubtitle(for rule: InterestRule) -> String {
-        guard let next = nextEvents(for: rule, limit: 1).first else { return "Ikke satt opp ennå" }
-        var parts = ["Neste: \(shortDayLabel(dayKey: next.dayKey))", next.title]
-        if next.channelLabel != "–" { parts.append(next.channelLabel) }
-        return parts.joined(separator: " · ")
+        if let next = nextEvents(for: rule, limit: 1).first {
+            var parts = ["Neste: \(shortDayLabel(dayKey: next.dayKey))", next.title]
+            if next.channelLabel != "–" { parts.append(next.channelLabel) }
+            return parts.joined(separator: " · ")
+        }
+        return matchState(for: rule) == .unresolved ? "Ingen treff — sjekk navnet" : "Ikke satt opp ennå"
     }
 
     // MARK: - Helpers

--- a/ios/Sportivista/Profile/FollowedListView.swift
+++ b/ios/Sportivista/Profile/FollowedListView.swift
@@ -233,9 +233,34 @@ struct FollowDetailView: View {
 
     private var upcoming: [FeedQueryEvent] { snapshot?.presenter.nextEvents(for: rule, limit: 3) ?? [] }
     private var news: [NewsItem] { snapshot?.presenter.newsItems(for: rule, limit: 3) ?? [] }
+    /// WP-125: this follow's name resolves to nothing we know — likely mistyped.
+    private var isUnresolved: Bool { snapshot?.presenter.matchState(for: rule) == .unresolved }
+    /// Nearest real names for an unresolved follow (reuses the index fuzzy).
+    private var nameSuggestions: [Entity] { snapshot?.presenter.nameSuggestions(for: rule) ?? [] }
 
     var body: some View {
         List {
+            if isUnresolved {
+                Section {
+                    Text("Vi finner ingen kamper eller nyheter for «\(rule.entityName)». Navnet stemmer kanskje ikke helt.")
+                        .font(.sportivista(.subheadline))
+                        .foregroundStyle(SportivistaTokens.label)
+                        .fixedSize(horizontal: false, vertical: true)
+                    ForEach(nameSuggestions, id: \.id) { suggestion in
+                        suggestionRow(suggestion)
+                    }
+                } header: {
+                    groupHeader("SJEKK NAVNET")
+                } footer: {
+                    Text(nameSuggestions.isEmpty
+                        ? "Prøv å legge til på nytt med et litt annet navn."
+                        : "Kanskje du mente ett av disse? Legg det til på nytt om navnet er feil.")
+                        .font(.sportivista(.footnote))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                }
+                .listRowBackground(SportivistaTokens.cell)
+            }
+
             if !upcoming.isEmpty {
                 Section {
                     ForEach(upcoming, id: \.id) { event in
@@ -430,6 +455,31 @@ struct FollowDetailView: View {
     }
 
     // MARK: - Detail rows / helpers
+
+    // MARK: - SJEKK NAVNET row (WP-125 lens-miss suggestion)
+
+    /// One calm, informational nearest-name suggestion — the name + its sport.
+    /// Deliberately not a button: the honest read is "check the name"; correcting
+    /// it is done through the normal Legg til-søk, so nothing is changed by tap.
+    private func suggestionRow(_ entity: Entity) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: SportSymbol.name(for: entity.sport))
+                .font(.sportivista(.body))
+                .foregroundStyle(SportivistaTokens.tertiaryLabel)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entity.name)
+                    .font(.sportivista(.body))
+                    .foregroundStyle(SportivistaTokens.label)
+                Text(SportVocabulary.display(for: entity.sport))
+                    .font(.sportivista(.footnote))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("followed.suggestion.\(entity.id)")
+    }
 
     private func detailInfoRow(_ label: String, _ value: String) -> some View {
         HStack {

--- a/ios/SportivistaTests/Fixtures/entities.json
+++ b/ios/SportivistaTests/Fixtures/entities.json
@@ -343,14 +343,9 @@
   {
     "id": "100-thieves",
     "name": "100 Thieves",
-    "aliases": [],
-    "sport": "esports",
-    "type": "team"
-  },
-  {
-    "id": "100t",
-    "name": "100T",
-    "aliases": [],
+    "aliases": [
+      "100T"
+    ],
     "sport": "esports",
     "type": "team"
   },

--- a/ios/SportivistaTests/Fixtures/manifest.json
+++ b/ios/SportivistaTests/Fixtures/manifest.json
@@ -25,8 +25,8 @@
       "sourceLastUpdated": "2026-07-13T16:25:00.760Z"
     },
     "entities.json": {
-      "bytes": 8673,
-      "sha256": "aea3157f660fac1b5baa9254c48ec5ed3c9d073764fe64dcb31bfd659fe7153d"
+      "bytes": 8582,
+      "sha256": "7184ef03f0b0d755097e3fc46d0cc17ceb0657b57b2c668d13ccc8ae47a09d9c"
     },
     "esports.json": {
       "bytes": 120,

--- a/ios/SportivistaTests/FollowPresenterTests.swift
+++ b/ios/SportivistaTests/FollowPresenterTests.swift
@@ -120,6 +120,42 @@ final class FollowPresenterTests: XCTestCase {
         )
     }
 
+    // MARK: - Lens-miss signal (WP-125)
+
+    func test_matchState_scheduledWhenEventsExist() {
+        XCTAssertEqual(presenter().matchState(for: rule("fk-lyn-oslo", "Lyn", "football")), .scheduled)
+    }
+
+    func test_matchState_knownEntityNothingScheduled_isIdle() {
+        // Casper Ruud IS a known entity, just with nothing on the board right now.
+        let p = presenter()
+        XCTAssertEqual(p.matchState(for: rule("casper-ruud", "Casper Ruud", "tennis")), .idle)
+        XCTAssertTrue(p.nameSuggestions(for: rule("casper-ruud", "Casper Ruud", "tennis")).isEmpty)
+    }
+
+    func test_matchState_wholeSportRuleNeverUnresolved() {
+        // A whole-sport follow with nothing scheduled is idle, never «sjekk navnet».
+        XCTAssertEqual(presenter().matchState(for: rule("sport-golf", "Golf", "golf")), .idle)
+    }
+
+    func test_matchState_unknownNameWithNews_staysIdle() {
+        // An entity absent from the index but WITH matching news is a real follow,
+        // just quiet on the agenda — «Ikke satt opp ennå», not «sjekk navnet».
+        let news = [NewsItem(id: "n", title: "Nytt", link: "https://x/n", source: "nrk", sport: "esports", entityIds: ["mystery-x"])]
+        let p = presenter(news: news)
+        XCTAssertEqual(p.matchState(for: rule("mystery-x", "Mystery", "esports")), .idle)
+    }
+
+    func test_matchState_unknownName_isUnresolvedWithNearestNameSuggestion() {
+        // A mistyped follow: the id resolves to nothing, no events, no news.
+        let p = presenter()
+        let typo = rule("caspar-ruud-typo", "Caspar Ruud", "tennis")
+        XCTAssertEqual(p.matchState(for: typo), .unresolved)
+        XCTAssertEqual(p.rowSubtitle(for: typo), "Ingen treff — sjekk navnet")
+        // The suggestion reuses the index fuzzy (no new matching) → real Casper Ruud.
+        XCTAssertEqual(p.nameSuggestions(for: typo).map(\.name), ["Casper Ruud"])
+    }
+
     // MARK: - News (SISTE NYTT)
 
     func test_newsItems_matchByEntityIdAndSport() {

--- a/scripts/build-entities.js
+++ b/scripts/build-entities.js
@@ -38,12 +38,18 @@
  * On merge, only aliases are unioned — the first-registered entity keeps its
  * id/name/type/sport.
  *
- * Known, accepted limitation: dedup only fires when some (name|alias) pair
- * literally overlaps at a word boundary. Purely alternate spellings with no
- * shared token (e.g. "Norway" vs. "Norge", or "100 Thieves" vs. "100T") are
- * NOT folded together and end up as separate entities. Fine for this WP —
- * matching against event text still works either way, just under two ids
- * instead of one; true synonym-resolution is future work, not required here.
+ * WP-125: dedup ALSO fires when one term is a nickname / initial-form of
+ * another — the "100 Thieves" ⇄ "100T" class. sports-config lists both spellings
+ * of the same team so its focus-team filter matches either; left un-folded they
+ * became two entities (`100-thieves` + `100t`), so a fan following one never
+ * matched events/news stamped with the other (a real lens-miss). `isNicknameForm`
+ * (below) closes it: "100T" now folds in as an ALIAS of "100 Thieves", one id.
+ *
+ * Known, accepted limitation: dedup still needs a token overlap OR an
+ * initial-form match. Purely alternate spellings with no shared token AND no
+ * abbreviation relationship (e.g. "Norway" vs. "Norge") are NOT folded and end
+ * up as separate entities. Fine for this WP — matching against event text still
+ * works either way, just under two ids; true synonym-resolution is future work.
  *
  * NOTE ON TYPE ACCURACY: tracked.json files a few entries under its "leagues"
  * bucket that are really clubs (e.g. "fc-barcelona"), because tracked.json
@@ -232,12 +238,44 @@ function terms(e) {
 	return [e?.name, ...(e?.aliases || [])].filter(Boolean);
 }
 
-/** Do two term sets share a word-boundary match in either direction? */
+/**
+ * WP-125: the initial / nickname compaction of a MULTI-word name — each word
+ * reduced to its leading run (the whole token when it starts with a digit, so
+ * "100" stays "100"; else just its first letter). "100 thieves" → "100t";
+ * "tour de france" → "tdf". Returns null for a single-word name (nothing to
+ * abbreviate). Operates on already-normalizeText'd input.
+ */
+function initialForm(multiNorm) {
+	const words = multiNorm.split(/\s+/).filter(Boolean);
+	if (words.length < 2) return null;
+	return words.map((w) => (/^\d/.test(w) ? w : Array.from(w)[0])).join("");
+}
+
+/**
+ * WP-125: is one of these two terms a nickname / initial-form of the other —
+ * the "100 Thieves" ⇄ "100T" class? True only when a MULTI-word name compacts
+ * (initialForm) EXACTLY to the other, SINGLE-token name. Deliberately asymmetric
+ * in shape (multi ⇄ single) so two distinct multi-word teams are never compared
+ * this way ("Real Madrid" vs. "Real Mallorca" both survive) and a coincidental
+ * single word can't swallow an unrelated multi-word club ("brooklyn fc" → "bf" ≠
+ * "lyn"). Same-sport + same-type is already enforced by the caller (upsert).
+ */
+function isNicknameForm(a, b) {
+	const na = normalizeText(a).trim();
+	const nb = normalizeText(b).trim();
+	if (!na || !nb) return false;
+	if (!/\s/.test(nb) && initialForm(na) === nb) return true;
+	if (!/\s/.test(na) && initialForm(nb) === na) return true;
+	return false;
+}
+
+/** Do two term sets share a word-boundary or nickname/initial-form match? */
 function termsOverlap(aTerms, bTerms) {
 	for (const a of aTerms) {
 		for (const b of bTerms) {
 			if (normalizeText(a).trim() === normalizeText(b).trim()) return true;
 			if (containsName(a, b) || containsName(b, a)) return true;
+			if (isNicknameForm(a, b)) return true;
 		}
 	}
 	return false;

--- a/tests/build-entities.test.js
+++ b/tests/build-entities.test.js
@@ -124,6 +124,78 @@ describe("buildEntityIndex", () => {
 		expect(team.aliases).toContain("Lyn"); // Lyn merged into the TEAM entity, not the league
 	});
 
+	// WP-125: nickname / initial-form consolidation (the 100T lens-miss class).
+	it("consolidates a nickname/initial-form team duplicate into ONE entity (100T ⇒ alias of 100 Thieves)", () => {
+		// The real source: sports-config lists BOTH spellings so the esports
+		// focus-team filter matches either; un-folded they became `100-thieves` +
+		// `100t`, so following one never matched events/news stamped with the other.
+		const fakeSportsConfig = {
+			esports: { sport: "esports", norwegian: { teams: ["100 Thieves", "100T"] } },
+		};
+		const entities = buildEntityIndex(tmpDir("ss-entities-nickname-"), fakeSportsConfig);
+		const esTeams = entities.filter((e) => e.sport === "esports" && e.type === "team");
+		expect(esTeams).toHaveLength(1); // one team, not two
+		expect(esTeams[0].id).toBe("100-thieves"); // the full name wins the id (registered first)
+		expect(esTeams[0].name).toBe("100 Thieves");
+		expect(esTeams[0].aliases).toContain("100T"); // the nickname folds in as an alias
+	});
+
+	it("does NOT over-merge two distinct multi-word teams (Real Madrid vs. Real Mallorca stay separate)", () => {
+		// Safety boundary: the initial-form rule compares a MULTI-word name against a
+		// SINGLE-token nickname only — two multi-word clubs are never abbreviated
+		// onto each other, so a shared leading word cannot collapse them.
+		const fakeSportsConfig = {
+			football: { sport: "football", norwegian: { teams: ["Real Madrid", "Real Mallorca"] } },
+		};
+		const entities = buildEntityIndex(tmpDir("ss-entities-no-overmerge-"), fakeSportsConfig);
+		const teams = entities.filter((e) => e.sport === "football" && e.type === "team");
+		expect(teams).toHaveLength(2);
+		expect(teams.map((e) => e.name).sort()).toEqual(["Real Madrid", "Real Mallorca"]);
+	});
+
+	it("guards the built index against same-type nickname/initial-form duplicates (normalized comparison)", () => {
+		// Independent (normalized) mirror of the relation the generator now folds,
+		// so this is a genuine regression guard, not a tautology: within any
+		// sport+type, no entity NAME may be the initial/nickname form of another's.
+		const normalize = (s) => (s || "").normalize("NFD").replace(/\p{M}/gu, "").toLowerCase().trim();
+		const initialForm = (name) => {
+			const words = normalize(name).split(/\s+/).filter(Boolean);
+			if (words.length < 2) return null;
+			return words.map((w) => (/^\d/.test(w) ? w : Array.from(w)[0])).join("");
+		};
+		const isNickname = (a, b) => {
+			const na = normalize(a), nb = normalize(b);
+			if (!na || !nb) return false;
+			return (!/\s/.test(nb) && initialForm(na) === nb) || (!/\s/.test(na) && initialForm(nb) === na);
+		};
+		// Run over the REAL default config (docs/data/entities.json's source), so a
+		// production regression — e.g. a new 100T-style pair the generator fails to
+		// fold — trips this. The generator guarantees the invariant by construction.
+		const entities = buildEntityIndex();
+		const byGroup = new Map();
+		for (const e of entities) {
+			const key = `${normalize(e.sport)}|${e.type}`;
+			if (!byGroup.has(key)) byGroup.set(key, []);
+			byGroup.get(key).push(e);
+		}
+		const dupes = [];
+		for (const group of byGroup.values()) {
+			for (let i = 0; i < group.length; i++) {
+				for (let j = i + 1; j < group.length; j++) {
+					if (isNickname(group[i].name, group[j].name)) {
+						dupes.push(`${group[i].name} ⇄ ${group[j].name} (${group[i].sport}/${group[i].type})`);
+					}
+				}
+			}
+		}
+		expect(dupes).toEqual([]);
+		// Non-vacuous: the real esports team really is consolidated under one id.
+		const hundred = entities.filter((e) => e.id === "100-thieves");
+		expect(hundred).toHaveLength(1);
+		expect(hundred[0].aliases).toContain("100T");
+		expect(entities.find((e) => e.id === "100t")).toBeUndefined();
+	});
+
 	it("generates a stable, readable kebab-case slug for a free-text name with no existing id", () => {
 		const fakeSportsConfig = { cycling: { sport: "cycling", norwegian: { players: ["Søren Wærenskjold"] } } };
 		const entities = buildEntityIndex(tmpDir("ss-entities-slug-"), fakeSportsConfig);


### PR DESCRIPTION
## Mål
Lukk **100T-klassen** (to lag-entiteter `100-thieves` + `100t` uten alias-kobling → linse-miss) og gjør **stille-døde følginger synlige**.

## Del 1 — SERVER: entitets-konsolidering (`scripts/build-entities.js`)
**Kilden til dubletten** (fikset generatoren, ikke symptomet): `scripts/config/sports-config.js` sin esports-config lister `teams: ["100 Thieves", "100T"]` — fetcheren trenger begge strengene til fokuslag-filteret. `build-entities.js` upsertet hver for seg, og `termsOverlap` fant ingen ordgrense-overlapp mellom «100T» og «100 Thieves» → to entiteter.

**Fiks:** ny `isNicknameForm` — en MULTI-ords-navn ⇄ ENKELT-token initialform (sifre beholdes: «100» → «100»; bokstavord → forbokstav: «Thieves» → «t»). «100 thieves» ⇒ «100t» == «100t» → folder «100T» inn som **alias** på `100-thieves`, én entitet. Formen er bevisst asymmetrisk (multi ⇄ enkelt), så to fler-ords-lag aldri slås sammen (Real Madrid / Real Mallorca består) og «brooklyn fc» → «bf» ≠ «lyn».

**Nye tester** (`tests/build-entities.test.js`): konsolidering (100T → alias) · ingen over-merging av distinkte fler-ords-lag · normalisert **invariant-guard** over hele indeksen (ingen same-sport+type der ett navn er kallenavn/initialform av et annet).

## Del 2 — iOS: lens-miss-signal (`FollowPresenter` + `FollowedListView`)
En fulgt regel med 0 events differensieres nå via `FollowMatchState`:
- **kjent entitet / hel-sport / har-nyheter** → «Ikke satt opp ennå» (uendret)
- **ukjent navn** (ikke i indeksen OG 0 nyheter) → rolig **«Ingen treff — sjekk navnet»**, med nærmeste navneforslag i detaljen (**gjenbruker `EntityIndex.nearestMatches`**, ingen ny fuzzy)

Klarspråk — «linse»/«indeks» forekommer aldri i UI. Fem nye `FollowPresenter`-tester.

## Fixture-re-frys (konsistent)
- iOS `entities.json`-fixturen: `100t`-entiteten fjernet, «100T» lagt til som alias på `100-thieves`.
- iOS `manifest.json`-fixturens `entities.json`-oppføring (bytes 8673→8582 + ny sha256) oppdatert deretter — SyncClient verifiserer nedlastet body mot manifest-sha, så fixturen må være selv-konsistent.
- **Feed-vektorene** matcher via `interests` (ikke `entities.json`) → uendret; golden-vektorene består **bit-likt**. WP-92/96-reglene i DIVERGENCES.md følges.
- `docs/data/` **ikke** rørt.

## Verifisering
- `npx vitest run --maxWorkers=1` → **719 grønn** (build-entities + feed-vectors + manifest inkl.)
- `build-entities → build-events → validate-events` rent mot **/tmp-sandbox** (ikke docs/data)
- iOS unit-suite (`Sportivista`) → **619 grønn, 0 feil** (1 opt-in FM-eval skippet); golden feed-vektorer bit-like
- Alle **4 schemes** bygger (Sportivista/Widget/DeviceDev/UITests)
- 100T-eventet treffer 100 Thieves-følging i vektor 14 (uendret, `cs2-100t` → relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)