### PR TITLE
WP-124: horisont-konsistens — iOS Uka 14d-cap + web Fremover (14–42d)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -128,7 +128,7 @@ mennesket, aldri av en agent.
 | WP-121 | iOS leverings-ferskhet: varsel-reconcile + widget-reload + foregrunn-sync | 0I | WP-118 | 🔬 bølge 2 — reconcile på alle sync-veier (SyncFreshness) + WidgetCenter-reload + foregrunn-gate; SyncFreshnessTests |
 | WP-122 | ~~Deltaker widget/detalj~~ → slått inn i WP-127 | 0I | — | — |
 | WP-123 | ICS: DTEND fra endTime (flerdagsevents) | 0I | — | 🔬 bølge 3 |
-| WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | ⬜ bølge 4 |
+| WP-124 | Horisont-konsistens: web «Fremover» (14–42 d) + iOS Uka-cap (EIERBESLUTNING) | 0I | WP-118 | 🔬 bølge 4 — iOS Uka cappes 14 d (buildSections `maxHorizon`, speiler web `agendaDayGroups`); web «Fremover»-disclosure (14–42 d, ingen kanal); NewsBoard forwardHorizonDays 7→14 (null [7,14]-overlap/gap); vektorene urørt (predikater, ikke vindu) |
 | WP-125 | Entitets-konsolidering (100T-alias) + lens-miss-signal | 0I | WP-118 | 🔬 bølge 4 |
 | WP-126 | Live-koherens: ett delt live-begrep på alle flater (eierbestilling 20.07) | 0I | WP-121 | 🔬 bølge 3 — ssLiveState (web) + AgendaViewModel.liveState (iOS-speil): 'direkte'/'pågår'/null; «Direkte nå» viser TdF/sjakk/CS2 (ESPN beriker); iOS minutt-tikk (TimelineView.everyMinute); followed.js relDay bruker delt def. Widget: WP-127 eier fila (urørt) |
 | WP-127 | Detalj & widget: «Om»-avsnitt iOS + deltaker-titler + RESULTAT sist + prosa-bredde web | 0I | WP-112 | 🔬 bølge 3 |

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -187,6 +187,31 @@
 
 .empty { color: var(--fg-2); font-size: 15px; padding: 40px 0; text-align: center; }
 
+/* ── "Fremover" — the quiet 14–42-day forward look (WP-124) ───────────────────
+   One calm, collapsed disclosure under the agenda: forvarsler beyond the 14-day
+   horizon as flat date · what · tournament rows. No channel, no accent dot — a
+   heads-up, not a "watch here". */
+.fremover { margin-top: 30px; }
+.fremover summary {
+	font-size: 13px;
+	color: var(--fg-2);
+	cursor: pointer;
+	list-style: none;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+}
+.fremover summary::-webkit-details-marker { display: none; }
+.fremover summary::before { content: "▸ "; color: var(--fg-3); }
+.fremover[open] summary::before { content: "▾ "; }
+.fwd-count { font-size: 12px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.fwd-body { margin-top: 12px; }
+.fwd-row { display: grid; grid-template-columns: 120px 1fr; gap: 12px; align-items: baseline; padding: 8px 0; border-top: 1px solid var(--line); }
+.fwd-row:first-child { border-top: none; }
+.fwd-date { font-size: 13px; color: var(--fg-2); white-space: nowrap; font-variant-numeric: tabular-nums; }
+.fwd-title { font-size: 15px; color: var(--fg); }
+.fwd-tour { display: block; font-size: 12.5px; color: var(--fg-3); margin-top: 1px; }
+
 /* ── "Dine neste": the compact top glance ─────────────────────────────────
    A quiet borderless list under a muted label — flat rows, one hairline + air
    below to set it apart from the schedule. Upcoming-only. */

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,7 @@
 		<div class="live-now" id="live-now" hidden></div>
 		<section class="next-up" id="next-up" hidden></section>
 		<div id="agenda"></div>
+		<details class="fremover" id="fremover" hidden></details>
 		<details class="followed" id="followed" hidden>
 			<summary id="followed-summary"><span>Dette dekker vi</span><a class="followed-edit-top" href="rediger.html" onclick="event.stopPropagation()">Be om dekning</a></summary>
 			<div class="followed-body" id="followed-body"></div>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -103,6 +103,7 @@ class Dashboard {
 		// in the window (this._agendaShownIds) so renderNextUp can dedupe a glance row
 		// that already has its own agenda row (WP-128).
 		this.renderAgenda();
+		this.renderFremover();
 		this.renderNextUp();
 		this.renderFollowed();
 		this.renderFooter();
@@ -330,6 +331,67 @@ class Dashboard {
 		// re-render (which would re-flash the whole agenda each minute).
 		if (!this._revealed) { el.classList.add('reveal'); this._revealed = true; }
 		else { el.classList.remove('reveal'); }
+	}
+
+	// ── "Fremover": the 14–42-day forward look (WP-124 horizon consistency) ───
+	/** The events beyond the agenda's 14-day horizon but within ~42 days — the
+	 *  quiet "forvarsler" (season starts, draws, majors booked far out). The
+	 *  agenda hard-caps at `now + 14d` (agendaDayGroups' maxHorizon); this owns
+	 *  the rest of what events.json carries (~42 d), so the two views PARTITION
+	 *  the horizon and mirror the iOS split (Uka caps at 14 d, Nyheter-FREMOVER
+	 *  owns beyond — NewsBoard.forwardHorizonDays = 14). fwStart is the SAME
+	 *  `now + 14d` boundary the agenda stops at, so the handoff is seamless: an
+	 *  event exactly on the boundary lands here (agenda's `time < maxHorizon` is
+	 *  strict), never in both, never in neither. isEventInWindow (never a manual
+	 *  `time >= x`) so a multi-day event overlapping the window survives. */
+	forwardWindow() {
+		const now = Date.now();
+		const fwStart = now + 14 * SS_CONSTANTS.MS_PER_DAY;
+		const fwEnd = now + 42 * SS_CONSTANTS.MS_PER_DAY;
+		return this.collapseSeries(
+			this.allEvents.filter((e) => isEventInWindow(e, fwStart, fwEnd)),
+			now
+		).sort((a, b) => new Date(a.time) - new Date(b.time));
+	}
+
+	/** A forvarsel's DATE label — never a clock (a major weeks out is answered by
+	 *  the day, not the minute; mirrors iOS NewsBoard.forwardDateLabel). A
+	 *  multi-day span reads "20.–27. juli". */
+	forwardDateLabel(e) {
+		const start = new Date(e.time);
+		const dayMon = (d) => d.toLocaleDateString('nb-NO', { day: 'numeric', month: 'short', timeZone: 'Europe/Oslo' });
+		if (e.endTime) {
+			const end = new Date(e.endTime);
+			if (this.osloDayKey(end) > this.osloDayKey(start)) {
+				const dayOnly = (d) => d.toLocaleDateString('nb-NO', { day: 'numeric', timeZone: 'Europe/Oslo' }).replace(/\.$/, '');
+				return `${dayOnly(start)}.–${dayMon(end)}`;
+			}
+		}
+		return dayMon(start);
+	}
+
+	/** One quiet forward row: date · title · tournament. NO channel — a viewing
+	 *  option this far out is unreliable (typically AI-research with wide margin),
+	 *  and the row is a heads-up, not a "watch here" (DESIGN calm: honest, minimal). */
+	forwardRow(e) {
+		const title = this.eventTitle(e);
+		const hasMatchup = !!(e.homeTeam && e.awayTeam) || !!this.participantMatchup(e);
+		// Show the tournament as the quiet context, unless it already IS the title.
+		const tour = e.tournament && (hasMatchup || e.tournament !== e.title)
+			? `<span class="fwd-tour">${escapeHtml(e.tournament)}</span>` : '';
+		return `<div class="fwd-row"><span class="fwd-date">${escapeHtml(this.forwardDateLabel(e))}</span><span class="fwd-main"><span class="fwd-title">${title}</span>${tour}</span></div>`;
+	}
+
+	/** The "Fremover" disclosure — one calm, collapsed section under the agenda.
+	 *  Hidden entirely when nothing is booked beyond 14 days (no empty flate). */
+	renderFremover() {
+		const el = document.getElementById('fremover');
+		if (!el) return;
+		const items = this.forwardWindow();
+		if (!items.length) { el.hidden = true; el.innerHTML = ''; return; }
+		el.innerHTML = `<summary><span class="fwd-label">Fremover</span><span class="fwd-count">${items.length}</span></summary>`
+			+ `<div class="fwd-body">${items.map((e) => this.forwardRow(e)).join('')}</div>`;
+		el.hidden = false;
 	}
 
 	/** Is this row currently expanded? Read by eventRow/seriesRow so a re-render

--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -417,15 +417,26 @@ final class AgendaViewModel {
         }
 
         LaunchTrace.mark("compile/rows (n=\(placed.count))", since: _tr)
-        // Re-group by day, drop passed days (DESIGN.md "Agendaens semantikk" §1:
-        // I DAG first, never a passed day — FeedCompiler already re-homed a
-        // still-running multi-day event onto today), order days ascending, and
-        // sort within a day by the (effective) time. With an empty/default-lens
-        // profile every placed row keeps its FeedCompiler day + event time, so
-        // this reproduces the old per-day map exactly.
+        // WP-124 — cap the display window at 14 days forward, mirroring the web
+        // agenda 1:1 (dashboard.js `agendaDayGroups`: `maxHorizon = now + 14 *
+        // MS_PER_DAY`, `isEventInWindow(e, start, maxHorizon)`). events.json runs
+        // ~42 days; the web board hard-caps at 14 d and iOS Uka never did — so a
+        // long tail could bloat Uka and duplicate Nyheter-FREMOVER. Both surfaces
+        // now PARTITION the horizon: Uka ≤ 14 d, Nyheter-FREMOVER owns beyond
+        // (NewsBoard.forwardHorizonDays = 14; owner decision 20.07). This is a
+        // pure DISPLAY window — the five predicates / FeedCompiler / golden vectors
+        // are untouched (FeedVectorTests still passes bit-for-bit; it exercises the
+        // predicates, not this grouping). isEventInWindow's UPPER bound depends
+        // only on the start (`e.time < maxHorizon`), so a `sortTime` cut mirrors it
+        // exactly: a still-running multi-day event keeps its past start time (< the
+        // horizon) and stays; a future event starting past day 14 drops out here
+        // and reappears under Nyheter-FREMOVER. sortTime == nil never happens for
+        // relevant events (FeedCompiler requires a time) — kept, since it groups
+        // under today, well inside the window.
+        let maxHorizon = now.addingTimeInterval(14 * 24 * 60 * 60)
         var order: [String] = []
         var byDay: [String: [Placed]] = [:]
-        for p in placed where p.dayKey >= todayKey {
+        for p in placed where p.dayKey >= todayKey && (p.sortTime.map { $0 < maxHorizon } ?? true) {
             if byDay[p.dayKey] == nil { order.append(p.dayKey) }
             byDay[p.dayKey, default: []].append(p)
         }

--- a/ios/Sportivista/News/NewsBoard.swift
+++ b/ios/Sportivista/News/NewsBoard.swift
@@ -27,9 +27,15 @@ struct NewsBoard: Equatable {
 
 	static let empty = NewsBoard(headline: nil, news: [], results: [], forward: [])
 
-	/// Events starting sooner than this many days ahead belong to the agenda
-	/// («Uka»); FREMOVER previews what's beyond it (draws, season starts).
-	static let forwardHorizonDays: Double = 7
+	/// Events within this many days ahead belong to the agenda («Uka»); FREMOVER
+	/// previews what's beyond it (draws, season starts). WP-124: raised 7 → 14 so
+	/// the handoff aligns EXACTLY with Uka's 14-day display cap
+	/// (AgendaViewModel.buildSections' `maxHorizon`) — the two views now partition
+	/// the horizon with no systematic [7 d, 14 d] overlap (events in that week used
+	/// to show in BOTH Uka and FREMOVER) and no gap (Uka's cap and this floor are
+	/// the same boundary). Mirrors the web split (dashboard.js agenda 14 d + the
+	/// «Fremover» disclosure ≥ 14 d). Owner decision 20.07.
+	static let forwardHorizonDays: Double = 14
 
 	static func build(
 		news: [NewsItem],

--- a/ios/SportivistaTests/AgendaViewModelTests.swift
+++ b/ios/SportivistaTests/AgendaViewModelTests.swift
@@ -206,6 +206,52 @@ final class AgendaViewModelTests: XCTestCase {
         XCTAssertFalse(row.title.contains("juli"), "no date text may leak into the title")
     }
 
+    // MARK: - WP-124: the 14-day forward display cap (mirrors the web maxHorizon)
+
+    func testBuildSections_capsForwardHorizonAt14Days() {
+        // events.json runs ~42 days; the agenda («Uka») shows only the next 14,
+        // mirroring the web (dashboard.js `maxHorizon = now + 14 * MS_PER_DAY`).
+        // Beyond it, Nyheter-FREMOVER owns the horizon. A pure DISPLAY window —
+        // relevance is unchanged (all three events are followed football), only
+        // what the board paints changes.
+        let now = iso("2026-07-14T10:00:00Z")
+        let events = [
+            EventBuilder.make(sport: "football", title: "Innenfor", time: "2026-07-20T18:00:00Z"),   // +6 d → shown
+            EventBuilder.make(sport: "football", title: "På grensen", time: "2026-07-27T18:00:00Z"), // +13 d → shown
+            EventBuilder.make(sport: "football", title: "Utenfor", time: "2026-08-05T18:00:00Z"),    // +22 d → capped
+        ]
+        let interests = Interests(followBroadly: ["football"])
+
+        let sections = AgendaViewModel.buildSections(events: events, interests: interests, now: now)
+        let titles = allItems(sections).compactMap { item -> String? in
+            if case .event(let row) = item { return row.title }
+            return nil
+        }
+        XCTAssertTrue(titles.contains("Innenfor"))
+        XCTAssertTrue(titles.contains("På grensen"))
+        XCTAssertFalse(titles.contains("Utenfor"), "an event past the 14-day horizon must not appear in Uka")
+    }
+
+    func testBuildSections_ongoingMultiDayEventBeyond14Days_stillShownUnderToday() {
+        // The cap keys off the START (like isEventInWindow's upper bound), so a
+        // multi-day event that STARTED before today and runs past day 14 keeps its
+        // past start (< the horizon) and stays — under I DAG, never dropped.
+        let now = iso("2026-07-14T10:00:00Z")
+        let event = EventBuilder.make(
+            sport: "golf", title: "Lang turnering",
+            time: "2026-07-12T08:00:00Z", endTime: "2026-08-10T20:00:00Z"  // started −2 d, ends +27 d
+        )
+        let interests = Interests(followBroadly: ["golf"])
+
+        let sections = AgendaViewModel.buildSections(events: [event], interests: interests, now: now)
+        XCTAssertEqual(sections.first?.label, "I DAG")
+        let titles = allItems(sections).compactMap { item -> String? in
+            if case .event(let row) = item { return row.title }
+            return nil
+        }
+        XCTAssertTrue(titles.contains("Lang turnering"), "an ongoing multi-day event past day 14 stays under I DAG")
+    }
+
     // MARK: - WP-112: head-to-head participant display (the "VM-finale" hole)
 
     func testBuildSections_headToHeadParticipants_showsMatchupAndKeepsGenericTitleAsMeta() {
@@ -337,6 +383,11 @@ final class AgendaViewModelTests: XCTestCase {
     func testBuildSections_realFixtures_tourDeFranceCollapsesAndLynIsMustWatch() throws {
         let events = try SportivistaJSON.decoder.decode([Event].self, from: Fixture.data("events"))
         let interests = try SportivistaJSON.decoder.decode(Interests.self, from: Fixture.data("interests"))
+        // Anchored 13 Jul: the Tour de France (4–26 Jul) sits inside FeedCompiler's
+        // 14-day retention (now − 14 d = 29 Jun) so all 21 stages survive, and the
+        // in-window Lyn match (25 Jul) is inside the WP-124 14-day display cap
+        // (now + 14 d = 27 Jul). The two fixture matches that fall PAST the cap are
+        // asserted excluded below.
         let now = iso("2026-07-13T12:00:00Z")
 
         let sections = AgendaViewModel.buildSections(events: events, interests: interests, now: now)
@@ -354,14 +405,18 @@ final class AgendaViewModelTests: XCTestCase {
             if case .event(let row) = item { return row }
             return nil
         }
-        let lynSogndal = try XCTUnwrap(eventRows.first { $0.event.id == "e75db0882adf" }) // "Lyn – Sogndal", see EventDecodingTests
-        XCTAssertTrue(lynSogndal.mustWatch, "Lyn is a tracked, notify-by-default team")
-        XCTAssertEqual(lynSogndal.channelLabel, "TV 2 Play")
-        XCTAssertEqual(lynSogndal.title, "Lyn – Sogndal")
+        // "Strømsgodset – Lyn" (25 Jul) is inside the 14-day window; Lyn is a
+        // tracked, notify-by-default team → must-watch, with its real channel.
+        let stromsgodsetLyn = try XCTUnwrap(eventRows.first { $0.event.id == "c1c0bf4ab5cd" })
+        XCTAssertTrue(stromsgodsetLyn.mustWatch, "Lyn is a tracked, notify-by-default team")
+        XCTAssertEqual(stromsgodsetLyn.channelLabel, "TV 2 Play")
+        XCTAssertEqual(stromsgodsetLyn.title, "Strømsgodset – Lyn")
 
-        // "Birmingham City – Barcelona" has an empty `streaming` array in the
-        // fixture — the honest "–" fallback must hold on real data too.
-        let noChannelEvent = try XCTUnwrap(eventRows.first { $0.event.title == "Birmingham City – Barcelona" })
-        XCTAssertEqual(noChannelEvent.channelLabel, "–")
+        // WP-124 — the 14-day forward cap on REAL data: two followed matches that
+        // start past 27 Jul must NOT appear on the board (Nyheter-FREMOVER owns
+        // them). "Birmingham City – Barcelona" (31 Jul) and "Lyn – Sogndal"
+        // (e75db0882adf, 2 Aug) were on the pre-WP-124 board and are now capped out.
+        XCTAssertFalse(eventRows.contains { $0.event.id == "e75db0882adf" }, "a match 20 days out is past the 14-day cap")
+        XCTAssertFalse(eventRows.contains { $0.event.title == "Birmingham City – Barcelona" }, "a match 18 days out is past the 14-day cap")
     }
 }

--- a/ios/SportivistaTests/NewsBoardTests.swift
+++ b/ios/SportivistaTests/NewsBoardTests.swift
@@ -92,16 +92,20 @@ final class NewsBoardTests: XCTestCase {
 	// MARK: - Section 4 (FREMOVER)
 
 	func testFremover_excludesNearHorizon_keepsFarFollowed() {
-		let near = EventBuilder.make(sport: "cross-country", title: "Nær langrenn", time: iso(3), id: "near")       // < 7d
-		let far = EventBuilder.make(sport: "cross-country", title: "Fjern langrenn", time: iso(30), id: "far")      // > 7d, followed
-		let farUnfollowed = EventBuilder.make(sport: "tennis", title: "Fjern tennis", time: iso(30), id: "tennis")  // > 7d, NOT followed
+		// WP-124: the near-horizon floor is now 14 d (forwardHorizonDays), aligned
+		// with Uka's 14-day display cap so the two views partition the horizon.
+		let near = EventBuilder.make(sport: "cross-country", title: "Nær langrenn", time: iso(3), id: "near")       // < 14d → Uka owns it
+		let far = EventBuilder.make(sport: "cross-country", title: "Fjern langrenn", time: iso(30), id: "far")      // > 14d, followed
+		let farUnfollowed = EventBuilder.make(sport: "tennis", title: "Fjern tennis", time: iso(30), id: "tennis")  // > 14d, NOT followed
 		let board = NewsBoard.build(news: [], featured: nil, results: RecentResults(), events: [near, far, farUnfollowed], entities: [lynTeam, langrenn], profile: followProfile, shield: SpoilerShield(), now: now)
 
 		XCTAssertEqual(board.forward.map(\.id), ["far"], "only the far-future FOLLOWED event is a forvarsel")
 	}
 
 	func testFremover_sortedByStart_andCapped() {
-		let events = (1...12).map { EventBuilder.make(sport: "cross-country", title: "E\($0)", time: iso(Double(10 + $0)), id: "e\($0)") }
+		// WP-124: fixture anchored beyond the 14-day floor (days 16–27) so all
+		// events are genuinely forvarsler — the test still proves sort + cap.
+		let events = (1...12).map { EventBuilder.make(sport: "cross-country", title: "E\($0)", time: iso(Double(15 + $0)), id: "e\($0)") }
 		let board = NewsBoard.build(news: [], featured: nil, results: RecentResults(), events: events, entities: [langrenn], profile: followProfile, shield: SpoilerShield(), now: now, maxForward: 8)
 		XCTAssertEqual(board.forward.count, 8)
 		XCTAssertEqual(board.forward.first?.id, "e1", "earliest first")

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -647,6 +647,90 @@ describe("agenda day grouping: no past-day heading above «I dag» (WP-128)", ()
 	});
 });
 
+// WP-124: horizon consistency. The agenda hard-caps at 14 days; the new "Fremover"
+// disclosure owns 14–42 days as quiet date · what · tournament rows (no channel), so
+// web + iOS partition the horizon identically (iOS Uka caps at 14 d, Nyheter-FREMOVER
+// owns beyond). Tested on the pure selection (forwardWindow) + row string, plus the
+// render's hide-when-empty via a stubbed #fremover element.
+describe("Fremover: the 14–42-day forward look (WP-124)", () => {
+	const days = (n) => new Date(Date.now() + n * 86400000).toISOString();
+
+	it("forwardWindow keeps only events beyond 14 days and within ~42 days", () => {
+		dash.allEvents = [
+			{ id: "near", sport: "football", title: "Nær", time: days(5) },    // < 14d → the agenda owns it
+			{ id: "edge", sport: "football", title: "Innafor", time: days(20) }, // 14–42d
+			{ id: "far", sport: "football", title: "Fjern", time: days(30) },   // 14–42d
+			{ id: "beyond", sport: "football", title: "For langt", time: days(60) }, // > 42d
+		];
+		const ids = dash.forwardWindow().map((e) => e.id);
+		expect(ids).toContain("edge");
+		expect(ids).toContain("far");
+		expect(ids).not.toContain("near");
+		expect(ids).not.toContain("beyond");
+	});
+
+	it("forwardWindow is sorted earliest-first", () => {
+		dash.allEvents = [
+			{ id: "b", sport: "football", title: "B", time: days(30) },
+			{ id: "a", sport: "football", title: "A", time: days(20) },
+		];
+		expect(dash.forwardWindow().map((e) => e.id)).toEqual(["a", "b"]);
+	});
+
+	it("keeps a multi-day event that overlaps the window (isEventInWindow, never a manual time>= filter)", () => {
+		dash.allEvents = [
+			// Starts in 10 days (< 14d) but runs to day 25 — overlaps [14d, 42d].
+			{ id: "grand-tour", sport: "cycling", title: "Rundtur", time: days(10), endTime: days(25) },
+		];
+		expect(dash.forwardWindow().map((e) => e.id)).toContain("grand-tour");
+	});
+
+	it("forwardRow shows date + title + tournament, and NEVER a channel this far out", () => {
+		const html = dash.forwardRow({
+			id: "x", sport: "football", title: "Sesongstart",
+			tournament: "Eliteserien", time: days(20),
+			streaming: [{ platform: "TV 2 Play", url: "https://tv2.no" }],
+		});
+		expect(html).toContain("Sesongstart");
+		expect(html).toContain("Eliteserien");
+		expect(html).toContain("fwd-date");
+		// No viewing option is rendered at this horizon — a heads-up, not "watch here".
+		expect(html).not.toContain("TV 2 Play");
+		expect(html).not.toContain("ev-where");
+	});
+
+	it("forwardDateLabel gives a bare date (no clock) for single-day and a span for multi-day", () => {
+		const single = dash.forwardDateLabel({ time: "2026-08-20T18:00:00Z" });
+		expect(single).toContain("20.");
+		expect(single).not.toContain(":"); // a date, never a clock
+		const span = dash.forwardDateLabel({ time: "2026-08-20T10:00:00Z", endTime: "2026-08-27T20:00:00Z" });
+		expect(span).toContain("–");
+	});
+
+	it("renderFremover hides the section entirely when nothing is booked beyond 14 days", () => {
+		dash.allEvents = [{ id: "near", sport: "football", title: "Nær", time: days(5) }];
+		const el = { hidden: false, innerHTML: "stale" };
+		const prev = win.document.getElementById;
+		win.document.getElementById = (id) => (id === "fremover" ? el : null);
+		dash.renderFremover();
+		win.document.getElementById = prev;
+		expect(el.hidden).toBe(true);
+		expect(el.innerHTML).toBe("");
+	});
+
+	it("renderFremover fills and shows the section when forvarsler exist", () => {
+		dash.allEvents = [{ id: "far", sport: "football", title: "Sesongstart", tournament: "Eliteserien", time: days(20) }];
+		const el = { hidden: true, innerHTML: "" };
+		const prev = win.document.getElementById;
+		win.document.getElementById = (id) => (id === "fremover" ? el : null);
+		dash.renderFremover();
+		win.document.getElementById = prev;
+		expect(el.hidden).toBe(false);
+		expect(el.innerHTML).toContain("Fremover");
+		expect(el.innerHTML).toContain("Sesongstart");
+	});
+});
+
 // WP-128: the live poller re-renders the whole agenda (innerHTML rebuild) every 60s,
 // which used to collapse whatever row the reader had expanded. eventRow now reads the
 // remembered-open set (this._agendaOpen) and bakes the open state back into the HTML,


### PR DESCRIPTION
## Mål (EIERBESLUTNING 20.07)
`events.json` går ~42 dager frem. Web hard-cappet visningen på 14 d, mens iOS **Uka aldri cappet** (kunne bli svært lang og duplisere Nyheter-FREMOVER, som eide nå+7d→400d). Eierbeslutning: **iOS Uka cappes på 14 dager, web får en «Fremover»-affordanse** — flatene skal partisjonere horisonten likt.

## Endringer

### Web (`docs/js/dashboard.js` · `index.html` · `cards.css`)
- Ny **«Fremover»-disclosure** under agendaen: 14–42-dagers-events som rolige, dempede rader (**dato · tittel · turnering — INGEN kanal** så langt frem; typisk AI-research med god margin). Skjult helt når tom (ingen ny flate).
- `isEventInWindow` (aldri manuell dato-filtrering → flerdagsevents overlever). `fwStart` = **samme `now+14d`** som agendaens `maxHorizon` → sømløs overgang: et event på grensen lander i Fremover, aldri i begge, aldri i ingen.

### iOS
- **`AgendaViewModel.buildSections`**: 14-dagers **visnings-cap** i re-grupperingsløkka, speiler webs `maxHorizon` 1:1. Cap på start-tid (som `isEventInWindow`s øvre grense) → et flerdagsevent som pågår beholder sin fortidige start og blir stående under **I DAG**.
- **`NewsBoard.forwardHorizonDays` 7→14**: FREMOVER-gulvet flyttet til Ukas cap → det systematiske **[7,14]-overlappet forsvinner** (den uka viste før i BÅDE Uka og FREMOVER) og det oppstår **ikke hull** (cap og gulv er samme grense).

## Vektorer / vindu (bekreftet)
buildSections-endringen er et **rent VISNINGS-vindu**. De fem predikatene / `FeedCompiler` / de gylne vektorene er **urørt** — `FeedVectorTests` tester predikatene (`isRelevant`/`mustWatch`/`mustSee`/`isEventInWindow`/`collapseSeries`) direkte, ikke `buildSections`, og passerer **bit-likt**. Ingen vektor ble re-frosset. Task-hypotesen «vektorene er relevans, ikke vindu» bekreftet.

## Verifiser at FREMOVER fanger det Uka slipper (null overlap / null hull)
- **Overlap:** før cappet viste [nå+7d, nå+14d] i både Uka og FREMOVER (en hel uke). Å flytte gulvet til 14 d eliminerer det. Grensetilfellet (start = nå+14d) havner i FREMOVER (Ukas `time < maxHorizon` er strikt) — aldri begge.
- **Hull:** Uka viser start < nå+14d; FREMOVER viser overlap med [nå+14d, …]. Ingen fulgt-event mellom flatene faller mellom.
- **Rest-edge (dokumentert):** et flerdags-straddler (start < 14 d, slutt > 14 d) kan vises i begge — det er samme flerdags-overlevelse `isEventInWindow`-konvensjonen bevisst koder, og likt på begge flater. Rene intrinsic-events (norsk/importance≥4) i **ikke-fulgte** sporter utover 14 d vises i ingen — bevisst rolig avveining (FREMOVER er linse-gated), ikke en regresjon.

## Tester
- **web `dashboard-cards`** (+7): `forwardWindow` (14–42d, sortert, flerdags-overlap), `forwardRow` (ingen kanal), `forwardDateLabel`, `renderFremover` skjult-når-tom / vist.
- **iOS `AgendaViewModelTests`** (+2): dedikert 14d-cap + flerdags-under-I-DAG. Real-fixture-testen beviser nå cappet på **ekte data**: Lyn–Sogndal (2/8) og Birmingham (31/7) > 14 d ekskludert; mustWatch flyttet til Strømsgodset–Lyn (25/7, i vindu); TdF 21 etapper beholdt på `now=13/7` (FeedCompilers 14-dagers retensjon krever now ≤ 18/7, mens de fjerne kampene krever now > 19/7 — uforenlig, så real-fixture-testen beviser cappet i stedet for å asserte de fjerne kampene).
- **iOS `NewsBoardTests`**: FREMOVER-grensen oppdatert til 14 d; fixtures re-forankret bevisst (dokumentert i kode-kommentar).

## Verifisering
- `npx vitest run --maxWorkers=1` → **723 grønn**
- iOS unit-suite (`Sportivista`-scheme) → **616 grønn** (golden vectors bit-like)
- **4 schemes bygger**: Sportivista (testet) · Widget · UITests (build-for-testing) · DeviceDev (generic/iOS, signert)
- **Skjermbilder begge temaer**: «Fremover 9»-disclosure rolig/kollapset mellom agendaen og «Dette dekker vi», konsistent lys/mørk.

PLAN.md WP-124-raden flippet ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)