### PR TITLE
hotfix(iOS): CloudKit-krasj ved oppstart som iOS-app-på-Mac (DeviceDev)

### DIFF
--- a/ios/Sportivista/Profile/ProfileSyncBackend.swift
+++ b/ios/Sportivista/Profile/ProfileSyncBackend.swift
@@ -61,6 +61,17 @@ struct LocalOnlyProfileSync: ProfileSyncBackend {
 enum ProfileSyncBackendFactory {
     static func make() -> any ProfileSyncBackend {
         #if SPORTIVISTA_CLOUDKIT
+        // The iCloud entitlement is provisioned for the iOS DEVICE build — not for
+        // the SAME binary running as an iOS-app-on-Mac ("Designed for iPad", e.g.
+        // when the run destination is "My Mac" instead of the iPhone). There the
+        // container isn't provisioned, so `CKContainer.default()` raises an uncaught
+        // NSException at launch → SIGABRT crash-loop. Cross-device sync is a
+        // nice-to-have, NEVER a launch requirement (LocalOnlyProfileSync is the
+        // documented fallback), so degrade instead of crashing. The Simulator/CI
+        // never compile this branch; the real paid-account iPhone build is unaffected.
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return LocalOnlyProfileSync()
+        }
         return CloudKitProfileSync()
         #else
         return LocalOnlyProfileSync()

--- a/ios/SportivistaTests/ProfileSyncBackendTests.swift
+++ b/ios/SportivistaTests/ProfileSyncBackendTests.swift
@@ -23,6 +23,22 @@ final class ProfileSyncBackendTests: XCTestCase {
 
     // MARK: - LocalOnly / disabled
 
+    // The factory must NEVER crash and NEVER attempt CloudKit where the container
+    // isn't provisioned (iOS-app-on-Mac). In the Simulator/CI build (no
+    // `-D SPORTIVISTA_CLOUDKIT`) it is always LocalOnly; the guard for the CloudKit
+    // build is asserted structurally: on Mac the factory must return a disabled
+    // (local) backend rather than construct CloudKitProfileSync (which raises at
+    // launch on the un-provisioned Mac run — the 20.07 DeviceDev-on-Mac crash-loop).
+    func test_factory_neverCrashes_andIsLocalWhenSyncUnavailable() {
+        let backend = ProfileSyncBackendFactory.make()
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            XCTAssertFalse(backend.isEnabled, "iOS-app-on-Mac must fall back to local-only, never CloudKit")
+        }
+        #if !SPORTIVISTA_CLOUDKIT
+        XCTAssertFalse(backend.isEnabled, "the Simulator/CI build is always local-only")
+        #endif
+    }
+
     func test_localOnly_isNoop() async {
         let coordinator = ProfileSyncCoordinator(backend: LocalOnlyProfileSync())
         let local = ProfileSyncState(rules: [synced("a", at: 10, device: "A")])


### PR DESCRIPTION
## Symptom
`SportivistaDeviceDev quit unexpectedly` — SIGABRT-krasjloop ved oppstart (Mac-ens DiagnosticReports, 20.07 09:15).

## Rotårsak
Appen kjørte som **iOS-app-på-Mac** (platform 7, «Designed for iPad» / run-destinasjon «My Mac»). Stack: ContentView.init default-arg → ProfileSyncBackendFactory.make() → CloudKitProfileSync.init → CKContainer.default() kaster uncaught NSException. DeviceDev kompilerer med `-D SPORTIVISTA_CLOUDKIT` → factory bygde ubetinget CloudKit; containeren er provisjonert for iPhone-bygget, ikke Mac-kjøringen av samme binær.

## Fiks
Factory → LocalOnlyProfileSync når `ProcessInfo.processInfo.isiOSAppOnMac`. Sync er nice-to-have med LocalOnly som dokumentert fallback, aldri oppstartskrav. iPhone-bygget uendret; Simulator/CI kompilerer aldri grenen.

## Verifisering
DeviceDev-schemaet kompilerer (BUILD SUCCEEDED); enhetssuiten 622 grønn (+1 factory-vakt), vektorer bit-like.

## Workaround uten fiksen
Kjør på iPhone eller Simulator, ikke «My Mac».

🤖 Generated with [Claude Code](https://claude.com/claude-code)