### PR TITLE
WP-133: Eliteserien + Ingebrigtsen-entiteter + Norge-dedup + onboarding-pakke-repek

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -137,7 +137,7 @@ mennesket, aldri av en agent.
 | WP-130 | Pipeline-kvalitet: refaktor-auditens quick-wins | 0I | — | ✅ #338 merget 20.07 — containsName-memo, haystack-dedup ×3, én fillesing, configDirPath (+2 env-bugfiks), 2 døde eksporter, flattenStats, golf mergeEvents |
 | WP-131 | Interests-arv-sanering: eier-personlige flagg ut av publiserte artefakter | 0I | WP-96 | 🔬 |
 | WP-132 | Onboarding: quick-picks-først + generiske pakker + assistent-intro (dyp personalisering) | 0I | WP-129 | 🔬 quick-picks er første steg for alle (samtale = sekundær «…eller fortell med egne ord»); pakker generisert (norsk-fotball=landslaget, ny vintersport-pakke, CS2=EWC-major, dropp Lyn/100T/rain/Barcelona) og grunnfestet mot entities.json; nytt assistent-intro-steg med 3 trykkbare dyp-personaliserings-eksempler (linse/følg/spoiler) + «prøv nå»; eval-corpus-case `intro-01` + oppdaterte onboarding-UI-flyter |
-| WP-133 | Entitets-dekning: Eliteserien + Ingebrigtsen + Norge-dedup + pakke-repek | 0I | WP-132 | ⬜ |
+| WP-133 | Entitets-dekning: Eliteserien + Ingebrigtsen + Norge-dedup + pakke-repek | 0I | WP-132 | 🔬 tracked.json seedet (manual-seed WP-133) med `eliteserien-2026` (league) + `jakob-ingebrigtsen` (athlete) — begge dekket i catalog.json men manglet entitet; Norge/Norway-dublett konsolidert til én `norge`-entitet via kuratert known-alias-tabell i build-entities (sports-config reordnet Norge-først); «Norsk fotball»→Eliteserien+landslaget, «Friidrett»→Warholm+Ingebrigtsen (dropp EM-omvei); iOS-fixture (entities+manifest) re-frosset; regresjonstester; ingen docs/data rørt (pipeline republiserer) |
 | WP-134 | Visningsbugs: tekst-forskyvning/feil størrelse (eier-dogfooding 20.07) | 0I | — | ⬜ |
 
 ---
@@ -1957,5 +1957,42 @@ ingen endring i assistent-armene/FM-prompter; ingen serverendring. **Aksept:**
 onboarding-UI-flyt grønn (quick-picks-først), pakkene grunnfester mot
 entities.json-id-er som finnes, eval-corpus-case for ett intro-eksempel
 (0E-regelen), full unit-suite + 4 schemes + vektorer, skjermbilder begge temaer.
+
+### WP-133 · Entitets-dekning: Eliteserien + Ingebrigtsen + Norge-dedup + pakke-repek
+**Bakgrunn (WP-132-oppfølging):** WP-132 grunnfestet startpakkene mot
+`entities.json`, men to entiteter manglet selv om `catalog.json` dekker dem:
+**Eliteserien** (tier2.tournaments) hadde ingen entitet — kun `obos-ligaen-2026`
+(eierens Lyn-nivå) — så «Norsk fotball»-pakken falt tilbake til bare landslaget;
+og **Jakob Ingebrigtsen** (tier2.athletes) manglet helt (kun Warholm fantes), så
+«Friidrett» måtte rute gjennom EM-turneringen. Årsak: `build-entities.js` bygger
+entities.json fra tracked.json/sports-config.js/norwegian-golfers.json — IKKE fra
+katalogen. I tillegg lå landslaget som DUBLETT `norway` + `norge` (sports-config
+lister begge stavemåter; WP-125s `isNicknameForm` folder dem ikke siden ingen er
+initialform av den andre) → samme lens-miss-klasse som 100T.
+**Innhold:** (1) SEED (manuell seeding tillatt ved launch): `scripts/config/tracked.json`
+får en `leagues`-entry `eliteserien-2026` (Eliteserien, football) + en `athletes`-entry
+`jakob-ingebrigtsen` (athletics), begge med `addedBy: "manual-seed WP-133"` og
+evidens som siterer `catalog.json#tier2.*`; research-agenten reconcilierer mot
+katalogen senere. Seedet bor i `scripts/config/` (kilden build-entities leser),
+IKKE i `docs/data/` (pipeline-eid, publisert) — pipelinen republiserer entities/
+tracked på neste kjøring. (2) NORGE-DEDUP: kuratert **known-alias-tabell** i
+build-entities (`KNOWN_ALIAS_GROUPS = [["norway","norge"]]` → `isKnownAlias` inn i
+`termsOverlap`) — bevisst valgt over en generisk kryss-språk-heuristikk fordi den
+er kirurgisk (bare de listede stavemåtene folder, kan aldri over-merge to reelle
+lag; same-sport+same-type håndheves fortsatt av upsert). sports-config reordnet
+`["…","Norge","Norway"]` så den konsoliderte entiteten blir `norge` (norsk
+visningsnavn), «Norway» folder inn som alias. (3) PAKKE-REPEK (StarterPacks.swift):
+«Norsk fotball» → Eliteserien + landslaget (`eliteserien-2026`, `norge`);
+«Friidrett» → Warholm + Ingebrigtsen (dropper `em-friidrett-2026`-omveien).
+(4) FIXTURE-REFRYS: iOS `Fixtures/entities.json` (+`manifest.json` sha/bytes) får
+de tre entitets-endringene konsistent. **Ikke-mål:** ingen konkrete events legges
+til (research/fetchere dekker terminlistene); ingen katalogendring (den dekket
+allerede begge); ingen berøring av `docs/data/`, interests.json eller beskyttede
+stier. **Aksept:** vitest grønn (build-entities-regresjonstester for Norge-dedup +
+produksjonsvakt, tracked-schema, feed-vectors, manifest); sandbox
+`build-entities → build-events → validate-events` rent (/tmp, ikke docs/data);
+full iOS unit-suite + 4 schemes + gylne vektorer bit-like etter fixture-refrys
+(`test_starterPacks_areGroundedAndUnique` fortsatt grønn — pakkene grunnfester mot
+de nye id-ene).
 
 

--- a/ios/Sportivista/Onboarding/StarterPacks.swift
+++ b/ios/Sportivista/Onboarding/StarterPacks.swift
@@ -25,14 +25,13 @@
 //  so those render as the Norwegian names you'd actually watch, not a flat
 //  foreign leaderboard.
 //
+//  WP-133 — Eliteserien and Jakob Ingebrigtsen are now grounded server-side
+//  (both seeded as entities in tracked.json → entities.json), so "Norsk fotball"
+//  follows Eliteserien + the national team and "Friidrett" follows Warholm +
+//  Ingebrigtsen directly. WP-133 also consolidated the Norway/Norge national-team
+//  duplicate into a single `norge` entity (curated known-alias in build-entities).
+//
 //  Grounding notes (why some owner-named entities aren't literal ids):
-//    • Eliteserien has no entity server-side yet (only OBOS-ligaen is grounded,
-//      which is the owner's own tier) — so "Norsk fotball" grounds on the
-//      broadly-meaningful national team. Adding Eliteserien to the catalog is a
-//      server change, out of WP-132's scope.
-//    • Jakob Ingebrigtsen has no athlete entity yet — "Friidrett" grounds on
-//      Warholm + EM friidrett `throughNorwegians`, which surfaces every Norwegian
-//      (Ingebrigtsen included) when they compete.
 //    • Grand Slams / golf majors beyond The Open have no entities — following
 //      Ruud/Hovland already surfaces their matches in those tournaments.
 //    • Winter sport (skiskyting/langrenn/alpint/hopp) grounds on the four
@@ -124,12 +123,14 @@ enum StarterPacks {
         StarterPack(
             id: "norsk-fotball",
             title: "Norsk fotball",
-            subtitle: "Landslaget — herrer og kvinner",
-            reason: "Lagt til fra startpakken «Norsk fotball» — det norske landslaget.",
+            subtitle: "Eliteserien og landslaget",
+            reason: "Lagt til fra startpakken «Norsk fotball» — Eliteserien og det norske landslaget.",
             rules: [
-                // The national team is the one broadly-meaningful Norwegian
-                // football follow (not the owner's club). Eliteserien has no
-                // grounded entity yet (server-side), so the pack lands on it.
+                // The two broadly-meaningful Norwegian football follows (not the
+                // owner's club): the top league + the national team. Both are now
+                // grounded server-side (WP-133 seeded Eliteserien as an entity and
+                // consolidated the Norway/Norge national-team duplicate to `norge`).
+                StarterRule("eliteserien-2026", "Eliteserien", sport: "football", type: "league"),
                 StarterRule("norge", "Norge", sport: "football", type: "team"),
             ]
         ),
@@ -150,13 +151,14 @@ enum StarterPacks {
         StarterPack(
             id: "friidrett",
             title: "Friidrett",
-            subtitle: "Karsten Warholm og norsk friidrett i mesterskapene",
-            reason: "Lagt til fra startpakken «Friidrett».",
+            subtitle: "Karsten Warholm og Jakob Ingebrigtsen",
+            reason: "Lagt til fra startpakken «Friidrett» — Karsten Warholm og Jakob Ingebrigtsen.",
             rules: [
+                // The two marquee Norwegian track stars, both grounded server-side.
+                // WP-133 seeded Ingebrigtsen as an entity, so the pack follows him
+                // directly instead of routing through the EM-tournament workaround.
                 StarterRule("karsten-warholm", "Karsten Warholm", sport: "athletics", type: "athlete"),
-                // EM through the Norwegians surfaces every Norwegian (Ingebrigtsen
-                // included) when they compete — Ingebrigtsen has no own entity yet.
-                StarterRule("em-friidrett-2026", "EM friidrett 2026", sport: "athletics", type: "tournament", lens: .throughNorwegians),
+                StarterRule("jakob-ingebrigtsen", "Jakob Ingebrigtsen", sport: "athletics", type: "athlete"),
             ]
         ),
         StarterPack(

--- a/ios/SportivistaTests/Fixtures/entities.json
+++ b/ios/SportivistaTests/Fixtures/entities.json
@@ -28,6 +28,13 @@
     "type": "league"
   },
   {
+    "id": "eliteserien-2026",
+    "name": "Eliteserien",
+    "aliases": [],
+    "sport": "football",
+    "type": "league"
+  },
+  {
     "id": "viktor-hovland",
     "name": "Viktor Hovland",
     "aliases": [
@@ -48,6 +55,13 @@
   {
     "id": "karsten-warholm",
     "name": "Karsten Warholm",
+    "aliases": [],
+    "sport": "athletics",
+    "type": "athlete"
+  },
+  {
+    "id": "jakob-ingebrigtsen",
+    "name": "Jakob Ingebrigtsen",
     "aliases": [],
     "sport": "athletics",
     "type": "athlete"
@@ -285,16 +299,11 @@
     ]
   },
   {
-    "id": "norway",
-    "name": "Norway",
-    "aliases": [],
-    "sport": "football",
-    "type": "team"
-  },
-  {
     "id": "norge",
     "name": "Norge",
-    "aliases": [],
+    "aliases": [
+      "Norway"
+    ],
     "sport": "football",
     "type": "team"
   },

--- a/ios/SportivistaTests/Fixtures/manifest.json
+++ b/ios/SportivistaTests/Fixtures/manifest.json
@@ -25,8 +25,8 @@
       "sourceLastUpdated": "2026-07-13T16:25:00.760Z"
     },
     "entities.json": {
-      "bytes": 8582,
-      "sha256": "7184ef03f0b0d755097e3fc46d0cc17ceb0657b57b2c668d13ccc8ae47a09d9c"
+      "bytes": 9009,
+      "sha256": "3926429be55dc1be9ad01b98a2a888ad9e0e429390698921975c42487bd2b3de"
     },
     "esports.json": {
       "bytes": 120,

--- a/ios/SportivistaTests/OnboardingTests.swift
+++ b/ios/SportivistaTests/OnboardingTests.swift
@@ -134,11 +134,11 @@ final class OnboardingTests: XCTestCase {
                        "the winter pack follows the four sport-level entities (WP-64/116) — off-season, so it matches nothing yet, but the follows are real")
     }
 
-    func test_footballPack_isTheNationalTeam_notTheOwnersClub() {
+    func test_footballPack_isEliteserienAndTheNationalTeam_notTheOwnersClub() {
         let vm = makeVM()
         vm.toggleStarterPack(pack("norsk-fotball"))
-        XCTAssertEqual(vm.profile.rules.map(\.entityId), ["norge"],
-                       "«Norsk fotball» follows the national team, not the owner's club (WP-132 de-personalisation)")
+        XCTAssertEqual(vm.profile.rules.map(\.entityId), ["eliteserien-2026", "norge"],
+                       "«Norsk fotball» follows Eliteserien + the national team, not the owner's club (WP-132 de-personalisation, WP-133 grounds Eliteserien)")
     }
 
     func test_cs2Pack_isGeneralised_notTheOwnersTeam() {

--- a/scripts/build-entities.js
+++ b/scripts/build-entities.js
@@ -45,11 +45,21 @@
  * matched events/news stamped with the other (a real lens-miss). `isNicknameForm`
  * (below) closes it: "100T" now folds in as an ALIAS of "100 Thieves", one id.
  *
- * Known, accepted limitation: dedup still needs a token overlap OR an
- * initial-form match. Purely alternate spellings with no shared token AND no
- * abbreviation relationship (e.g. "Norway" vs. "Norge") are NOT folded and end
- * up as separate entities. Fine for this WP — matching against event text still
- * works either way, just under two ids; true synonym-resolution is future work.
+ * WP-133: dedup ALSO fires for a curated cross-language SYNONYM — the "Norway"
+ * ⇄ "Norge" class. Two spellings of the same national side share no token and
+ * are not initial-forms of each other, so the token-overlap / initial-form rules
+ * above never fold them; left un-folded, sports-config's own "Norway"/"Norge"
+ * pair became two team entities, so a fan following one never matched events
+ * stamped with the other (the WP-125 lens-miss class, again). `isKnownAlias`
+ * (below) closes it via an explicit, curated table — deliberately narrower than a
+ * generic cross-language heuristic: only the exact listed spellings fold, so it
+ * can never over-merge two genuinely different teams.
+ *
+ * Known, accepted limitation: dedup still needs a token overlap, an initial-form
+ * match, OR a curated known-alias pair. Purely alternate spellings with no shared
+ * token, no abbreviation relationship, and no table entry are NOT folded and end
+ * up as separate entities. Matching against event text still works either way,
+ * just under two ids; general synonym-resolution is future work.
  *
  * NOTE ON TYPE ACCURACY: tracked.json files a few entries under its "leagues"
  * bucket that are really clubs (e.g. "fc-barcelona"), because tracked.json
@@ -269,13 +279,42 @@ function isNicknameForm(a, b) {
 	return false;
 }
 
-/** Do two term sets share a word-boundary or nickname/initial-form match? */
+/**
+ * WP-133: curated cross-language synonym groups for NATIONAL TEAMS — the
+ * "Norway" ⇄ "Norge" class. Each group lists spellings (already normalizeText'd:
+ * lowercased, diacritics folded) of ONE and the same entity. Kept intentionally
+ * small and explicit: an entry only folds the exact spellings it names, so it
+ * cannot over-merge two genuinely different teams the way a generic
+ * cross-language heuristic might. Same-sport + same-type is still enforced by the
+ * caller (upsert), so a "Norge" in a different sport is unaffected. Extend as
+ * more national sides enter the config (e.g. ["sweden", "sverige"]).
+ */
+const KNOWN_ALIAS_GROUPS = [
+	["norway", "norge"],
+];
+
+/**
+ * WP-133: are a and b two listed spellings of the same known entity (national
+ * team)? True only when both normalized terms appear in the SAME curated group.
+ */
+function isKnownAlias(a, b) {
+	const na = normalizeText(a).trim();
+	const nb = normalizeText(b).trim();
+	if (!na || !nb || na === nb) return false;
+	return KNOWN_ALIAS_GROUPS.some((group) => group.includes(na) && group.includes(nb));
+}
+
+/**
+ * Do two term sets share a word-boundary, nickname/initial-form, or curated
+ * known-alias (WP-133) match?
+ */
 function termsOverlap(aTerms, bTerms) {
 	for (const a of aTerms) {
 		for (const b of bTerms) {
 			if (normalizeText(a).trim() === normalizeText(b).trim()) return true;
 			if (containsName(a, b) || containsName(b, a)) return true;
 			if (isNicknameForm(a, b)) return true;
+			if (isKnownAlias(a, b)) return true;
 		}
 	}
 	return false;

--- a/scripts/config/sports-config.js
+++ b/scripts/config/sports-config.js
@@ -33,7 +33,12 @@ export const sportsConfig = {
 			custom: true
 		},
 		norwegian: {
-			teams: ["FK Lyn Oslo", "Lyn", "Norway", "Norge"],
+			// WP-133: "Norge" before "Norway" so the consolidated national-team
+			// entity is `norge` (the Norwegian display name); build-entities folds
+			// "Norway" in as an alias via the curated known-alias table. Order is
+			// registration priority only — fetcher relevance filtering treats this
+			// list as a set, so the reorder is behaviourally inert there.
+			teams: ["FK Lyn Oslo", "Lyn", "Norge", "Norway"],
 			filterMode: "focused"
 		},
 		streaming: {

--- a/scripts/config/tracked.json
+++ b/scripts/config/tracked.json
@@ -62,6 +62,18 @@
         "https://obosligaenkamper.com/lyn/"
       ],
       "priority": "high"
+    },
+    {
+      "id": "eliteserien-2026",
+      "name": "Eliteserien",
+      "sport": "football",
+      "reason": "Manuelt seedet (WP-133) for å tette et entitets-dekningshull: catalog.json dekker Eliteserien (tier2.tournaments) — øverste norske fotballnivå — men build-entities.js bygger entities.json fra tracked.json/sports-config.js/norwegian-golfers.json (IKKE katalogen), så det fantes ingen Eliteserien-entitet å grunnfeste mot. Uten den falt WP-132s «Norsk fotball»-startpakke tilbake til bare landslaget, og et web-/app-søk på «Eliteserien» hadde ingen stabil id (kun OBOS-ligaen — eierens Lyn-nivå — var grunnfestet). Denne seed-entryen gir Eliteserien en stabil entitet (type league); research-agenten reconcilierer den mot katalogen på neste kjøring. Ingen konkrete kamper legges til her (statiske fetchere + research dekker terminlista) — dette er ren entitets-bokføring.",
+      "addedAt": "2026-07-20T12:00:00Z",
+      "addedBy": "manual-seed WP-133",
+      "evidence": [
+        "catalog.json#tier2.tournaments"
+      ],
+      "priority": "high"
     }
   ],
   "athletes": [
@@ -184,6 +196,18 @@
       ],
       "expires": "2026-08-03T23:59:59Z",
       "priority": "medium"
+    },
+    {
+      "id": "jakob-ingebrigtsen",
+      "name": "Jakob Ingebrigtsen",
+      "sport": "athletics",
+      "reason": "Manuelt seedet (WP-133) for å tette et entitets-dekningshull: catalog.json dekker Jakob Ingebrigtsen (tier2.athletes) — Norges største friidrettsstjerne — men entities.json manglet ham helt (kun Warholm fantes blant friidrettsutøverne), så WP-132s «Friidrett»-startpakke måtte grunnfeste på Warholm + EM-turneringen «gjennom de norske» i stedet for Ingebrigtsen direkte, og et søk på «Ingebrigtsen» hadde ingen stabil id. Denne seed-entryen gir ham en stabil entitet (type athlete); research-agenten reconcilierer mot katalogen på neste kjøring. Ingen konkrete stevner legges til her (research dekker startlistene når de slippes — Ingebrigtsen står trolig over EM 2026 pga. sykdom/akilles-op, VG 8. juli) — dette er ren entitets-bokføring.",
+      "addedAt": "2026-07-20T12:00:00Z",
+      "addedBy": "manual-seed WP-133",
+      "evidence": [
+        "catalog.json#tier2.athletes"
+      ],
+      "priority": "high"
     }
   ],
   "tournaments": [

--- a/tests/build-entities.test.js
+++ b/tests/build-entities.test.js
@@ -153,6 +153,46 @@ describe("buildEntityIndex", () => {
 		expect(teams.map((e) => e.name).sort()).toEqual(["Real Madrid", "Real Mallorca"]);
 	});
 
+	// WP-133: cross-language national-team consolidation (the Norway/Norge lens-miss class).
+	it("consolidates a cross-language national-team duplicate into ONE entity (Norway ⇒ alias of Norge)", () => {
+		// The real source: sports-config lists BOTH "Norge" and "Norway" so the
+		// football relevance filter matches either spelling; un-folded they became
+		// `norge` + `norway`, so following one never matched events stamped with the
+		// other. The two share no token and are not initial-forms, so only the curated
+		// known-alias table folds them. "Norge" is listed first → wins the id.
+		const fakeSportsConfig = {
+			football: { sport: "football", norwegian: { teams: ["Norge", "Norway"] } },
+		};
+		const entities = buildEntityIndex(tmpDir("ss-entities-national-"), fakeSportsConfig);
+		const teams = entities.filter((e) => e.sport === "football" && e.type === "team");
+		expect(teams).toHaveLength(1); // one national team, not two
+		expect(teams[0].id).toBe("norge"); // Norwegian display name wins the id
+		expect(teams[0].name).toBe("Norge");
+		expect(teams[0].aliases).toContain("Norway"); // the other spelling folds in as an alias
+	});
+
+	it("known-alias folding is surgical — two unrelated single-word teams stay separate", () => {
+		// The curated table only folds the exact listed spellings; a country NOT
+		// grouped with another (e.g. "Norway" vs "Denmark") must remain two entities.
+		const fakeSportsConfig = {
+			football: { sport: "football", norwegian: { teams: ["Norway", "Denmark"] } },
+		};
+		const entities = buildEntityIndex(tmpDir("ss-entities-national-safe-"), fakeSportsConfig);
+		const teams = entities.filter((e) => e.sport === "football" && e.type === "team");
+		expect(teams).toHaveLength(2);
+		expect(teams.map((e) => e.name).sort()).toEqual(["Denmark", "Norway"]);
+	});
+
+	it("folds the real sports-config Norway/Norge pair into a single `norge` entity (production guard)", () => {
+		// Non-vacuous: build against the REAL default config (which lists both
+		// spellings) and assert the pair is consolidated with no stray `norway`.
+		const entities = buildEntityIndex();
+		const national = entities.filter((e) => e.sport === "football" && (e.id === "norge" || e.id === "norway"));
+		expect(national.map((e) => e.id)).toEqual(["norge"]);
+		expect(entities.find((e) => e.id === "norge").aliases).toContain("Norway");
+		expect(entities.find((e) => e.id === "norway")).toBeUndefined();
+	});
+
 	it("guards the built index against same-type nickname/initial-form duplicates (normalized comparison)", () => {
 		// Independent (normalized) mirror of the relation the generator now folds,
 		// so this is a genuine regression guard, not a tautology: within any


### PR DESCRIPTION
## WP-133 — entitets-dekning

Tetter to entitets-dekningshull WP-132 avdekket. `catalog.json` dekker allerede
**Eliteserien** (`tier2.tournaments`) og **Jakob Ingebrigtsen** (`tier2.athletes`),
men `build-entities.js` bygger `entities.json` fra `tracked.json` /
`sports-config.js` / `norwegian-golfers.json` — **ikke** katalogen — så ingen av
dem hadde en entitet å grunnfeste onboarding-pakkene mot. I tillegg lå landslaget
som **dublett** `norway` + `norge` (WP-125s `isNicknameForm` folder dem ikke siden
ingen er initialform av den andre).

### Endringer

**(1) Seed (`scripts/config/tracked.json`)** — manuell seeding er sanksjonert ved
launch (tracked.json seedes manuelt, research-agenten reconcilierer mot katalogen
etterpå). Lagt til `leagues`-entry `eliteserien-2026` (Eliteserien, football) +
`athletes`-entry `jakob-ingebrigtsen` (athletics), begge med
`addedBy: "manual-seed WP-133"` og evidens som siterer `catalog.json#tier2.*`
(tracked-schema-testens provenienskrav).

**Del (4)-analyse — hvor bor seedet?** `build-entities.js` leser
`configDirPath()` = `scripts/config/` (bekreftet i `helpers.js`). `docs/data/tracked.json`
er den **publiserte** kopien (pipeline-eid, skrevet av `build-events.js`). Seedet
er derfor lagt i **`scripts/config/tracked.json`** (kilden build-entities leser),
og **ingenting i `docs/data/` er rørt** — den statiske pipelinen republiserer
`entities.json`/`tracked.json` på neste kjøring. Ikke en beskyttet sti; ikke
`interests.json`.

**(2) Norge-dedup (`scripts/build-entities.js` + `scripts/config/sports-config.js`)**
— valgte en **kuratert known-alias-tabell** (`KNOWN_ALIAS_GROUPS = [["norway","norge"]]`
→ `isKnownAlias` inn i `termsOverlap`) fremfor en generisk kryss-språk-heuristikk.
Begrunnelse: tabellen er **kirurgisk** (bare de listede stavemåtene folder, kan
aldri over-merge to reelle lag; `same-sport`+`same-type` håndheves fortsatt av
`upsert`) — laveste risiko. `sports-config` reordnet `["…","Norge","Norway"]` så
den konsoliderte entiteten blir `norge` (norsk visningsnavn) med «Norway» som alias.

**(3) Pakke-repek (`StarterPacks.swift`)** — «Norsk fotball» → Eliteserien +
landslaget (`eliteserien-2026`, `norge`); «Friidrett» → Warholm + Ingebrigtsen
(dropper `em-friidrett-2026`-omveien). `test_starterPacks_areGroundedAndUnique`
fortsatt grønn; `test_footballPack_*` oppdatert til `["eliteserien-2026","norge"]`.

**(4) iOS-fixture** — `entities.json` (+ `manifest.json` sha/bytes) re-frosset
konsistent med de tre entitets-endringene (SyncClient-hashen bekreftes dynamisk i
`SyncTestSupport.canonicalManifestData`, men fixture-manifestet er også oppdatert
for intern konsistens).

**Regresjonstester** (`tests/build-entities.test.js`): Norge/Norway → én `norge`
med «Norway»-alias; known-alias er kirurgisk (Norway/Denmark holdes adskilt);
produksjonsvakt mot ekte config.

### Verifisering
- `npx vitest run --maxWorkers=1` → **752 tester grønne** (46 filer).
- Sandbox `build-entities → build-events → validate-events` (/tmp, **ikke** docs/data): rent, 57 events / 0 errors; `eliteserien-2026` + `jakob-ingebrigtsen` + konsolidert `norge` bekreftet.
- iOS unit-suite: **624 tester, 0 failures** (1 skip = opt-in RealFMEval), inkl. SyncClient/Onboarding/EntityServedParity/gylne FeedVector-vektorer.
- Alle **4 schemes** bygger (Sportivista, WidgetExtension, DeviceDev, UITests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)