### PR TITLE
WP-135: agenda-tid klippes ikke lenger av bred tittel — tittelen brekker (standard str.)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -139,7 +139,7 @@ mennesket, aldri av en agent.
 | WP-132 | Onboarding: quick-picks-først + generiske pakker + assistent-intro (dyp personalisering) | 0I | WP-129 | ✅ #347 merget 20.07 |
 | WP-133 | Entitets-dekning: Eliteserien + Ingebrigtsen + Norge-dedup + pakke-repek | 0I | WP-132 | ✅ #348 merget 20.07 |
 | WP-134 | Visningsbugs: tekst-forskyvning/feil størrelse (eier-dogfooding 20.07) | 0I | — | ✅ #349 merget 20.07 |
-| WP-135 | Agenda-tid klippes av bred deltaker-tittel (standard str., eier-skjermbilde 20.07) | 0I | WP-112 | ⬜ |
+| WP-135 | Agenda-tid klippes av bred deltaker-tittel (standard str., eier-skjermbilde 20.07) | 0I | WP-112 | 🔬 |
 
 ---
 

--- a/ios/Sportivista/Agenda/AgendaView.swift
+++ b/ios/Sportivista/Agenda/AgendaView.swift
@@ -461,30 +461,60 @@ private struct SportSymbolView: View {
 /// multi-day window ("13.–20. juli") reads a notch quieter (`.footnote`) so a
 /// week-long range stays compact and doesn't shove the title off the row — it is
 /// a date span, not a clock. Either way it lives in the SAME left column (never
-/// merged into the title). `.fixedSize` lets it take exactly the width it needs;
-/// the min width keeps "HH:mm" rows aligned.
+/// merged into the title).
+///
+/// WP-135 — the standard-size CLOCK reserves a DEFINITE (Dynamic-Type-scaled)
+/// column width rather than `.fixedSize(horizontal: true)`. A fixed-size intrinsic
+/// column let the enclosing HStack COUPLE the clock's width to the title's
+/// single-line intrinsic width during ideal-size negotiation: at certain widths a
+/// wide matchup title ("100 Thieves – Ninjas in Pyjamas") kept the row on one
+/// line and pushed the whole HStack past the cell, so the leading clock clipped
+/// ("15:00" → ":00") instead of the title wrapping (owner report 20.07, standard
+/// text size). A definite reserved width breaks that coupling — the clock ALWAYS
+/// gets its column and the flexible title takes the residual and wraps. `58` at
+/// the default content size is byte-identical to the old `minWidth: 58`, and
+/// `@ScaledMetric` grows the column in lock-step with the `.body` clock text so a
+/// large "23:59" still fits. A multi-day WINDOW keeps `.fixedSize` — it genuinely
+/// needs its full intrinsic width reserved (WP-99), and its rarer title-truncation
+/// edge is the accepted trade for that (a date span must never itself wrap/clip).
 private struct TimeColumn: View {
     let text: String
 
     @Environment(\.dynamicTypeSize) private var dtSize
+    /// The reserved clock column width — `58` at the default content size (the old
+    /// `minWidth`), scaled up with Dynamic Type so a big clock stays whole. Only
+    /// applied to the standard-size clock case (see `body`).
+    @ScaledMetric(relativeTo: .body) private var clockColumnWidth = 58
 
     /// A clock always carries ":"; a window ("13.–20. juli") or honest "–"
     /// never does.
     private var isClock: Bool { text.contains(":") }
+    private var isAX: Bool { dtSize.isAccessibilitySize }
 
     var body: some View {
-        Text(text)
+        let label = Text(text)
             .font(isClock ? .sportivistaTabular(.body, weight: .semibold) : .sportivistaTabular(.footnote, weight: .medium))
             .foregroundStyle(SportivistaTokens.label)
             // WP-134: at Accessibility sizes the column is on its own line (see
-            // AgendaRowScaffold), so it no longer needs to win width against the
-            // title — let a wide window WRAP instead of forcing its intrinsic
-            // width with `.fixedSize`, and drop the min-width alignment padding.
-            // At standard sizes the original behaviour is preserved exactly.
-            .lineLimit(dtSize.isAccessibilitySize ? 2 : 1)
-            .fixedSize(horizontal: !dtSize.isAccessibilitySize, vertical: false)
-            .frame(minWidth: dtSize.isAccessibilitySize ? nil : 58, alignment: .leading)
-            .padding(.top, isClock ? 0 : 2)
+            // AgendaRowScaffold), so a wide window may WRAP to two lines.
+            .lineLimit(isAX ? 2 : 1)
+
+        Group {
+            if !isAX && isClock {
+                // Standard CLOCK — a DEFINITE, Dynamic-Type-scaled column (no
+                // `.fixedSize` intrinsic coupling; see the type's doc comment).
+                label
+                    .frame(width: clockColumnWidth, alignment: .leading)
+            } else {
+                // Standard WINDOW keeps `.fixedSize` to reserve its full intrinsic
+                // width (WP-99); `minWidth: 58` is its unchanged alignment floor.
+                // AX puts the column on its own line, so it reserves nothing.
+                label
+                    .fixedSize(horizontal: !isAX, vertical: false)
+                    .frame(minWidth: isAX ? nil : 58, alignment: .leading)
+            }
+        }
+        .padding(.top, isClock ? 0 : 2)
     }
 }
 

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -346,6 +346,15 @@ struct ContentView: View {
                     agenda.reloadFromCache(now: Date())
                     agenda.applyFilter(AgendaFilter(sports: ["golf"]))
                 }
+                // WP-135: the agenda ROW-WIDTH bug class — a wide matchup title
+                // ("100 Thieves – Ninjas in Pyjamas") that pushed the fixed-size
+                // time column off the left edge. Seeds a wide-title clock row +
+                // a short-title control + a multi-day WINDOW row so the fix can
+                // be verified (time whole, title wrapped, window intact) offline.
+                if mode == "agenda-width" {
+                    AgendaWidthDemoSeed.seed(profileStore: profileStore)
+                    agenda.reloadFromCache(now: Date())
+                }
                 // WP-19/WP-83: seed a small profile so the share panel shows a
                 // real QR + link (the export needs a non-empty profile). Rendered
                 // full-screen via demoOverlay (a `.sheet` is a no-op in the launch

--- a/ios/Sportivista/Demo/AgendaWidthDemoSeed.swift
+++ b/ios/Sportivista/Demo/AgendaWidthDemoSeed.swift
@@ -1,0 +1,95 @@
+//
+//  AgendaWidthDemoSeed.swift
+//  Sportivista
+//
+//  WP-135 — DEBUG-only screenshot harness for the agenda ROW-WIDTH bug class
+//  (owner screenshot 20.07, STANDARD text size): a wide matchup title
+//  ("100 Thieves – Ninjas in Pyjamas") pushed the fixed-size time column off the
+//  LEFT cell edge, clipping the clock ("15:00" → ":00"), instead of the title
+//  wrapping to two lines. A neighbouring row with a SHORT title ("100 Thieves –
+//  Falcons") showed its time in full — proving the row layout, not the data, was
+//  at fault (participants are empty on these events; the title comes straight
+//  through AgendaFormat).
+//
+//  This seeds a fixed board that exercises the three invariants of DESIGN.md
+//  § Radens anatomi at once, so the whole class has deterministic, offline
+//  coverage in the screenshot catalogue:
+//    1. a WIDE-title clock row (the reported clip) — time must stay whole, title
+//       must wrap to ≤2 lines;
+//    2. a SHORT-title clock row (the control) — must render pixel-identically;
+//    3. a multi-day golf WINDOW row (a "d.–d. MMM" date span in the time column)
+//       — must still reserve and show its full width (the WP-99 reason the clock
+//       column was fixed-size, and why WINDOWS keep `.fixedSize`).
+//
+//  Never compiled into a release build (`#if DEBUG`), and lives in
+//  Sportivista/Demo/ (WP-48) so only the app targets pick it up.
+//
+
+#if DEBUG
+import Foundation
+
+enum AgendaWidthDemoSeed {
+
+	/// Seed the cache + a broad esports/golf/football profile, then the caller
+	/// reloads the agenda.
+	static func seed(profileStore: ProfileStore, now: Date = Date()) {
+		let cache = CacheStore()
+		let iso = ISO8601DateFormatter()
+		iso.formatOptions = [.withInternetDateTime]
+		func at(_ offsetHours: Double) -> String { iso.string(from: now.addingTimeInterval(offsetHours * 3600)) }
+		func at(days: Double) -> String { iso.string(from: now.addingTimeInterval(days * 86400)) }
+
+		let events: [[String: Any]] = [
+			// The reported clip: a wide matchup title at a CLOCK time. Participants
+			// are deliberately EMPTY (matching the real data) so the title flows
+			// through AgendaFormat unchanged — the row layout is the whole subject.
+			// After WP-135 the time stays whole and the title wraps to two lines.
+			[
+				"sport": "esports", "title": "100 Thieves – Ninjas in Pyjamas",
+				"tournament": "StarSeries Fall EU-kvalik",
+				"time": at(2), "norwegian": false,
+				"streaming": [["platform": "Twitch"]],
+			],
+			// The control: a short title at a clock time — its time always showed
+			// in full, so this row must stay pixel-identical across the fix.
+			[
+				"sport": "esports", "title": "100 Thieves – Falcons",
+				"tournament": "BLAST Bounty S2",
+				"time": at(4), "norwegian": false,
+				"streaming": [["platform": "Twitch"]],
+			],
+			// An even wider title, to prove the wrap holds well past the reported
+			// width (belt-and-suspenders — the clip must never return at any width).
+			[
+				"sport": "football", "title": "Vålerenga Fotball – Rosenborg Ballklub",
+				"tournament": "Eliteserien",
+				"time": at(6), "homeTeam": "Vålerenga Fotball", "awayTeam": "Rosenborg Ballklub",
+				"streaming": [["platform": "TV 2 Play"]],
+			],
+			// The WP-99 multi-day WINDOW row — must keep reserving its full width
+			// and never wrap/clip; the time column's fixed reservation exists FOR
+			// this shape, and the fix must not regress it.
+			[
+				"sport": "golf", "title": "The Open Championship", "tournament": "PGA Tour",
+				"time": at(-6), "endTime": at(days: 3), "norwegian": true,
+				"venue": "Royal Portrush",
+				"streaming": [["platform": "TV 2 Play", "url": "https://play.tv2.no"]],
+			],
+		]
+
+		let interests: [String: Any] = [
+			"followBroadly": ["esports", "football", "golf"],
+			"alwaysTrack": ["athletes": [], "teams": [], "tournaments": []],
+		]
+
+		write(events, "events.json", cache)
+		write(interests, "interests.json", cache)
+		try? cache.writeSyncState(SyncState(etag: nil, appliedFiles: [:], lastSync: now))
+	}
+
+	private static func write(_ object: Any, _ filename: String, _ cache: CacheStore) {
+		guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+		try? cache.write(data, filename: filename)
+	}
+}
+#endif


### PR DESCRIPTION
## Buggen (eier-skjermbilde 20.07, STANDARD tekststørrelse)

I «Uka»-agendaen klippes klokkeslettet på venstre kortkant når deltaker-/kamp-tittelen er bred:
- kl 13:00 UTC = **15:00 Oslo**, tittel «100 Thieves – Ninjas in Pyjamas» → tiden viste bare «:00» («15» klippet av kortkanten);
- nabo-rad med kort tittel «100 Thieves – Falcons» → «19:30» vist helt.

Altså **radlayouten, ikke dataene** (participants er tomme på disse events; tittelen kommer rett gjennom `AgendaFormat`).

## Rotårsak

`AgendaRowScaffold` standard-gren: `HStack { dot; TimeColumn.fixedSize.layoutPriority(1); symbol; RowBody(maxWidth:.infinity); markers }`. Den `.fixedSize(horizontal:true)`-baserte tidskolonnen koblet HStackens **ideal-størrelse** til tittelens **1-linjes intrinsic-bredde**. Ved enkelte bredder holdt SwiftUI tittelen på én linje og skjøv hele HStacken forbi cellen; `Button(.plain)`-labelen sentreres ved overflyt → klipp på **ledende** kant → «15» forsvinner. Klassisk `fixedSize`-søsken-forgiftning.

## Fiksen (`AgendaView.swift` → `TimeColumn`)

Standard-størrelse **KLOKKE** reserverer nå en **definitiv, Dynamic-Type-skalert** kolonnebredde:
```swift
@ScaledMetric(relativeTo: .body) private var clockColumnWidth = 58
…
if !isAX && isClock { label.frame(width: clockColumnWidth, alignment: .leading) }
else               { label.fixedSize(horizontal: !isAX, vertical: false)
                          .frame(minWidth: isAX ? nil : 58, alignment: .leading) }
```
- **Definitiv bredde** (ikke `.fixedSize`) bryter koblingen: klokka får alltid kolonnen sin, den fleksible tittelen får `tilgjengelig − klokke − symbol − markører` og **tvinges til å brekke** (≤2 linjer, aldri trunkert til «…»).
- **58 pt ved standard str. = gamle `minWidth: 58` byte-likt** (`@ScaledMetric` returnerer basisverdien ved referanse-kategorien `.large`; enhver «HH:mm» tabular `.body`-klokke er < 58 pt bred, så gammel og ny gjengir 58 pt). Ingen regresjon i rolig tetthet.
- **Flerdags-VINDU beholder `.fixedSize`** (WP-99) — en dato-span må reservere hele intrinsic-bredden og aldri selv brekke/klippe.
- **AX-grenen (WP-134-reflow) er urørt** (else-grenen gir byte-identisk `.fixedSize(horizontal:false)` + `minWidth:nil` ved AX).

Varig demo-modus `agenda-width` (`AgendaWidthDemoSeed`) gir bug-klassen deterministisk offline-dekning i skjermkatalogen: bred klokke-tittel + kort kontroll + enda bredere tittel + flerdags-vindu.

## Reproduksjon & før/etter (sim, iPhone 17 / SE, iOS 26.5)

Ærlig funn: **iOS 26-simulatoren gjengir dette som en `List`-rad som _gir etter_ (tittelen brekker / trunkerer til «…») i stedet for å overflyte** — jeg fikk **ikke** tids-klippet til å reprodusere i sim på noen bredde (320 / 375 / 402 pt) × noen standard-størrelse (large→xxxL). Eierens iPhone 16 Pro kjører også iOS 26 og er 402 pt, så klippet er en **kniv-egg / Display-Zoom-manifestasjon på ekte enhet** av nettopp den skjøre `fixedSize`-forhandlingen fiksen fjerner. Verifisering i sim bekrefter derfor **invariantene + null regresjon**:

- **FØR (uendret kode) og ETTER (fiks)** med samme 4-rads seed er **layout-identiske** (dark + light, standard str.): flerdags-vindu «20.–23. juli» reservert og helt; alle klokker helt; «100 Thieves – Ninjas / in Pyjamas» og «Vålerenga Fotball – / Rosenborg Ballklub» brekker til to linjer; korte rader uendret. (Kun minutt-sifrene skiller, siden tider er relative til launch.)
- **AX (accessibility-extra-large):** WP-134-reflow intakt — tid/vindu + sport-symbol på egen linje over full-bredde, aldri-trunkert tittel («The Open Champi-onship»).

Bilder ikke committet (PLAN-regel 8) — beskrevet over.

## Verifisering

- `npx vitest run --maxWorkers=1` → **753 grønne** (46 filer).
- iOS unit-suite (`Sportivista`-schemet) → **624 grønne**, 1 skip (opt-in RealFM-eval), 0 feil — **gylne feed-vektorer BIT-LIKE** (ren layout-endring rører ingen matching/kompilering).
- **Alle 4 schemes bygger:** Sportivista, SportivistaWidgetExtension, SportivistaUITests (build-for-testing), SportivistaDeviceDev.

## Regresjonsvern

Ren layout er vanskelig å enhets-teste; invarianten er dokumentert i `TimeColumn`s doc-kommentar (hvorfor klokke = definitiv bredde, hvorfor vindu = `.fixedSize`, hvorfor 58 pt er byte-likt ved standard), og bug-klassen har nå varig visuell dekning via `agenda-width`-demoen.

PLAN.md: WP-135 ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)