### PR TITLE
WP-136: ferskhets-herding — brief dag-vakt (iOS+web) + foregrunn-re-eval

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -140,7 +140,7 @@ mennesket, aldri av en agent.
 | WP-133 | Entitets-dekning: Eliteserien + Ingebrigtsen + Norge-dedup + pakke-repek | 0I | WP-132 | ✅ #348 merget 20.07 |
 | WP-134 | Visningsbugs: tekst-forskyvning/feil størrelse (eier-dogfooding 20.07) | 0I | — | ✅ #349 merget 20.07 |
 | WP-135 | Agenda-tid klippes av bred deltaker-tittel (standard str., eier-skjermbilde 20.07) | 0I | WP-112 | ✅ #351 merget 20.07 — TimeColumn definert ScaledMetric-bredde (fjernet fixedSize-forgiftning) + agenda-width demo-seed; AX-reflow urørt, korte rader pikselidentiske|
-| WP-136 | Ferskhets-herding: brief dag-vakt (iOS+web) + re-evaluer ved foregrunn/dagskifte | 0I | WP-121 | ⬜ |
+| WP-136 | Ferskhets-herding: brief dag-vakt (iOS+web) + re-evaluer ved foregrunn/dagskifte | 0I | WP-121 | 🔬 |
 
 ---
 

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -118,23 +118,33 @@ class Dashboard {
 		el.innerHTML = this.emphasize(escapeHtml(this.heroHeadline()));
 	}
 
-	/** The editorial headline when it's fresh, else the calm fallback. */
-	heroHeadline() {
-		const headline = this.featuredIsFresh()
+	/** The editorial headline when it's fresh, else the calm fallback. `now`
+	 *  injectable so a foreground/day-rollover re-render (and the tests) can prove
+	 *  the day-gate at a chosen instant. */
+	heroHeadline(now = Date.now()) {
+		const headline = this.featuredIsFresh(now)
 			? this.featured?.blocks?.find((b) => b.type === 'headline')?.text
 			: null;
 		return headline || this.heroFallback();
 	}
 
-	/** featured.json is trustworthy only while it's recent (~20h). A quota-skipped
-	 *  editorial run leaves yesterday's brief in place; showing it on, say, finale
-	 *  day ("finalen venter i morgen") is a factual error. No/undateable generatedAt
-	 *  ⇒ not fresh (fall back) — we won't stand behind a brief we can't date. */
-	featuredIsFresh() {
+	/** The editorial brief is trustworthy only on the Oslo calendar DAY it was
+	 *  generated. Its language is day-relative ("i kveld"/"i morgen"), so a brief
+	 *  that outlives its Oslo day is a factual error: a quota-skipped editorial run
+	 *  that leaves yesterday's brief up — or a 15:00 evening brief still cached the
+	 *  next morning — reads wrong the instant the Oslo day rolls (19.07: yesterday's
+	 *  "finalen venter i kveld" stayed up through finale day; WP-136). Show it ONLY
+	 *  while `generatedAt` is TODAY in Oslo — a pure calendar-day compare
+	 *  (osloDayKey), no "N hours" heuristic, so the brief never survives its own day.
+	 *  No/undateable generatedAt ⇒ not fresh (fall back) — we won't stand behind a
+	 *  brief we can't date. (Supersedes the WP-111 ~20h window, which still showed an
+	 *  evening brief the next morning.) */
+	featuredIsFresh(now = Date.now()) {
 		const ts = this.featured?.generatedAt;
 		if (!ts) return false;
-		const age = Date.now() - new Date(ts).getTime();
-		return Number.isFinite(age) && age < 20 * SS_CONSTANTS.MS_PER_HOUR;
+		const gen = new Date(ts);
+		if (Number.isNaN(gen.getTime())) return false;
+		return this.osloDayKey(gen) === this.osloDayKey(new Date(now));
 	}
 
 	/** Calm fallback when the editorial agent hasn't written a headline yet. */

--- a/ios/Sportivista/ContentView.swift
+++ b/ios/Sportivista/ContentView.swift
@@ -524,6 +524,16 @@ struct ContentView: View {
             guard phase == .active else { return }
             Task { await assistant.runBackgroundSync(using: profileSync) }
             guard oldPhase == .background else { return }
+            // WP-136: re-evaluate the DAY-GATED Nyheter brief with a fresh `now` on
+            // EVERY return from background — independent of the 15-min data-freshness
+            // gate below and of whether the sync changes anything. A brief that was
+            // «i dag» when the app was backgrounded must disappear once the Oslo day
+            // has rolled (overnight reopen), WITHOUT waiting for a new download. This
+            // reuses the WP-107 off-main coalescing build (NewsModel.rebuild →
+            // nonisolated computeBoard, lazy EntityIndex), so foreground stays
+            // instant — the board just re-lenses a moment later off the main thread;
+            // no decode/matching on main, no timer.
+            news.rebuild()
             if !foregroundRefreshInFlight,
                ForegroundSyncGate.shouldRefresh(lastSync: dataStore.lastSync, now: Date()) {
                 foregroundRefreshInFlight = true

--- a/ios/Sportivista/News/NewsBoard.swift
+++ b/ios/Sportivista/News/NewsBoard.swift
@@ -59,11 +59,32 @@ struct NewsBoard: Equatable {
 			.prefix(maxNews)
 
 		return NewsBoard(
-			headline: featured?.headline,
+			headline: freshHeadline(featured, now: now),
 			news: Array(matchedNews),
 			results: footballResultRows(results.football, lens: lens, index: index, shield: shield),
 			forward: forwardRows(events, lens: lens, index: index, now: now, max: maxForward)
 		)
+	}
+
+	// MARK: - Section 1 day-gate (brief freshness, WP-136)
+
+	/// The editorial brief's headline, but ONLY while it is from the CURRENT Oslo
+	/// calendar day. The brief's language is day-relative ("i kveld"/"i morgen"),
+	/// so a brief that outlives its Oslo day is a factual error (19.07: yesterday's
+	/// "VM-finalen i kveld" showed the day after the final). The exact guard the web
+	/// hero uses (dashboard.js `featuredIsFresh`): a pure Oslo calendar-day compare
+	/// via `FeedCompiler.osloDayKey` — no "N hours" heuristic, so the brief never
+	/// survives its own day. A brief with no `generatedAt` is undateable ⇒ hidden
+	/// (we won't stand behind a brief we can't date). Re-checked on EVERY board build
+	/// with the caller's `now`, so a return to the foreground / a day rollover
+	/// (ContentView rebuilds the board with a fresh `now`) drops yesterday's brief
+	/// without any new download — a cheap date compare, no work on the main thread.
+	private static func freshHeadline(_ featured: FeaturedBrief?, now: Date) -> String? {
+		guard let featured, let headline = featured.headline,
+		      let generatedAt = featured.generatedAt,
+		      FeedCompiler.osloDayKey(generatedAt) == FeedCompiler.osloDayKey(now)
+		else { return nil }
+		return headline
 	}
 
 	// MARK: - RESULTAT (followed teams)

--- a/ios/SportivistaTests/NewsBoardTests.swift
+++ b/ios/SportivistaTests/NewsBoardTests.swift
@@ -40,9 +40,57 @@ final class NewsBoardTests: XCTestCase {
 	// MARK: - Section 1 (headline)
 
 	func testHeadline_fromFeatured() {
-		let brief = FeaturedBrief(mode: "morning", blocks: [FeaturedBrief.Block(type: "headline", text: "Hei")])
+		// WP-136: the brief now carries a `generatedAt` on the CURRENT Oslo day
+		// (else it is day-gated out — see the day-gate tests below).
+		let brief = FeaturedBrief(generatedAt: now, mode: "morning", blocks: [FeaturedBrief.Block(type: "headline", text: "Hei")])
 		let board = NewsBoard.build(news: [], featured: brief, results: RecentResults(), events: [], entities: [], profile: followProfile, shield: SpoilerShield(), now: now)
 		XCTAssertEqual(board.headline, "Hei")
+	}
+
+	// MARK: - Section 1 day-gate (WP-136)
+	// The brief is shown ONLY on the Oslo calendar day of its `generatedAt`. Its
+	// language is day-relative ("i kveld"/"i morgen"), so a brief that outlives its
+	// Oslo day is a factual error (20.07: yesterday's "VM-finalen i kveld" still
+	// showed the day after the final). `now` injected so the midnight boundary is
+	// deterministic. Oslo is UTC+2 in July (CEST): Oslo midnight 2026-07-20 =
+	// 2026-07-19T22:00:00Z.
+
+	private func date(_ iso: String) -> Date { ISO8601DateFormatter().date(from: iso)! }
+
+	private func headline(generatedAt iso: String?, now: Date) -> String? {
+		let brief = FeaturedBrief(
+			generatedAt: iso.map { date($0) }, mode: "morning",
+			blocks: [FeaturedBrief.Block(type: "headline", text: "Finalen venter i kveld.")])
+		return NewsBoard.build(news: [], featured: brief, results: RecentResults(), events: [], entities: [], profile: followProfile, shield: SpoilerShield(), now: now).headline
+	}
+
+	func testBrief_shownWhenGeneratedSameOsloDay() {
+		let now = date("2026-07-20T06:00:00Z")                               // Oslo 08:00, 20 July
+		XCTAssertEqual(headline(generatedAt: "2026-07-20T03:00:00Z", now: now), // Oslo 05:00, 20 July — today
+		               "Finalen venter i kveld.")
+	}
+
+	func testBrief_hiddenWhenGeneratedYesterdayOslo() {
+		let now = date("2026-07-20T06:00:00Z")                               // Oslo 08:00, 20 July
+		// Yesterday's 15:00 evening brief, still cached the next morning — the 20.07 bug.
+		XCTAssertNil(headline(generatedAt: "2026-07-19T13:00:00Z", now: now))  // Oslo 15:00, 19 July
+	}
+
+	func testBrief_droppedTheInstantOsloDayRolls() {
+		// `now` just after Oslo midnight into 20 July; the brief is 1h old but from 19 July.
+		let now = date("2026-07-19T22:30:00Z")                               // Oslo 00:30, 20 July
+		XCTAssertNil(headline(generatedAt: "2026-07-19T21:30:00Z", now: now))  // Oslo 23:30, 19 July
+	}
+
+	func testBrief_keptWhenGeneratedJustAfterOsloMidnight() {
+		let now = date("2026-07-19T22:30:00Z")                               // Oslo 00:30, 20 July
+		XCTAssertEqual(headline(generatedAt: "2026-07-19T22:15:00Z", now: now), // Oslo 00:15, 20 July — today
+		               "Finalen venter i kveld.")
+	}
+
+	func testBrief_hiddenWhenUndateable() {
+		// No `generatedAt` — we won't stand behind a brief we can't date.
+		XCTAssertNil(headline(generatedAt: nil, now: date("2026-07-20T06:00:00Z")))
 	}
 
 	// MARK: - Section 2 (NYTT)

--- a/ios/SportivistaTests/NewsModelTests.swift
+++ b/ios/SportivistaTests/NewsModelTests.swift
@@ -94,6 +94,33 @@ final class NewsModelTests: XCTestCase {
 		XCTAssertLessThanOrEqual(model.buildCount, 2, "a burst coalesces to at most two builds")
 	}
 
+	// MARK: - WP-136 — day-gated brief re-evaluates on a fresh-`now` rebuild
+
+	/// The foreground / day-rollover path (ContentView calls `news.rebuild()` on a
+	/// return from background): the SAME cached brief must disappear once the Oslo
+	/// day has rolled — a fresh-`now` rebuild re-checks the day-gate, no new sync,
+	/// and the whole build stays on the WP-107 off-main coalescing path.
+	func test_rebuild_reEvaluatesBriefDayGate_onNewNow() async throws {
+		let cache = CacheStore(rootDirectory: FileManager.default.temporaryDirectory
+			.appendingPathComponent("sportivista-wp136-\(UUID().uuidString)", isDirectory: true))
+		// A brief generated 05:00 Oslo on 20 July (2026-07-20T03:00:00Z, CEST = UTC+2).
+		let featured = #"{"generatedAt":"2026-07-20T03:00:00Z","mode":"morning","blocks":[{"type":"headline","text":"Dagens brief."}]}"#
+		try cache.write(Data(featured.utf8), filename: "featured.json")
+		let model = makeModel(cache: cache, profileStore: tempProfileStore())
+		let iso = ISO8601DateFormatter()
+
+		// Opened the SAME Oslo day (08:00, 20 July) → the brief shows.
+		model.rebuild(now: iso.date(from: "2026-07-20T06:00:00Z")!)
+		await model.awaitQuiescent()
+		XCTAssertEqual(model.board.headline, "Dagens brief.", "shown on its own Oslo day")
+
+		// Reopened the NEXT Oslo day (08:00, 21 July) with the SAME cached brief —
+		// a fresh-`now` rebuild (the foreground path) must drop it, no re-sync.
+		model.rebuild(now: iso.date(from: "2026-07-21T06:00:00Z")!)
+		await model.awaitQuiescent()
+		XCTAssertNil(model.board.headline, "the brief disappears once the Oslo day has rolled")
+	}
+
 	// MARK: - Off-main guarantee
 
 	func test_guard_tripsWhenBuildRunsOnMainThread() throws {

--- a/scripts/agents/editorial.md
+++ b/scripts/agents/editorial.md
@@ -54,5 +54,12 @@ Rules:
   omit the claim (say what you know for certain instead). This is the eier-funn:
   a morning brief said "Hovland ut i tredje runde" hours after he missed the cut.
 - Calm and plain — no hype, no emoji, no clickbait.
+- **The client DAY-GATES this brief (WP-136).** Both surfaces — the web hero and the
+  iOS «I DIN VERDEN I DAG» line — show the headline ONLY on the Oslo calendar day of
+  `generatedAt`, then fall back; a brief never outlives its own day. So day-relative
+  language ("i kveld" / "i morgen") is safe: it can never render on the wrong day
+  (that gate is what killed the 20.07 bug — yesterday's "VM-finalen i kveld" showing
+  the day after the final). No agent behaviour change is required; just always write
+  an accurate `generatedAt` (you already do).
 - Your only output is `docs/data/featured.json`. Never modify
   `scripts/config/interests.json` — it is user-owned; you read it, nothing more.

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -164,30 +164,50 @@ describe("detail title (share/report) names the participants", () => {
 	});
 });
 
-// WP-111: editorial (featured.json) is a "nice extra" that can be quota-skipped for
-// a day. A stale brief is a factual error on the hero (19.07: yesterday's "finalen
-// venter i morgen" stayed up all through finale day). Discard anything > ~20h old.
-describe("editorial freshness guard on the hero headline", () => {
-	const HOUR = 3600000;
-	const brief = (ageHours) => ({
-		generatedAt: new Date(Date.now() - ageHours * HOUR).toISOString(),
+// WP-136: the editorial brief is DAY-GATED — shown only on the Oslo calendar day
+// it was generated. Its language is day-relative ("i kveld"/"i morgen"), so a brief
+// that outlives its Oslo day is a factual error (20.07: yesterday's "VM-finalen i
+// kveld" stayed up the day after the final). A pure Oslo calendar-day compare, `now`
+// injected so the midnight boundary is deterministic. Supersedes the WP-111 "~20h"
+// window, which still showed a 15:00 evening brief the next morning. Oslo is UTC+2 in
+// July (CEST): Oslo midnight 2026-07-20 = 2026-07-19T22:00:00Z.
+describe("editorial brief day-gate on the hero headline (WP-136)", () => {
+	const briefAt = (iso) => ({
+		generatedAt: iso,
 		blocks: [{ type: "headline", text: "Finalen venter i kveld." }],
 	});
 
-	it("uses a fresh editorial headline (generatedAt within ~20h)", () => {
-		dash.featured = brief(3);
-		expect(dash.featuredIsFresh()).toBe(true);
-		expect(dash.heroHeadline()).toContain("Finalen venter");
+	it("shows a brief generated earlier TODAY (same Oslo day)", () => {
+		const now = Date.parse("2026-07-20T06:00:00Z");   // Oslo 08:00, 20 July
+		dash.featured = briefAt("2026-07-20T03:00:00Z");  // Oslo 05:00, 20 July — today
+		expect(dash.featuredIsFresh(now)).toBe(true);
+		expect(dash.heroHeadline(now)).toContain("Finalen venter");
 	});
 
-	it("discards a stale headline (> 20h) and falls back to the calm default", () => {
-		dash.featured = brief(30);
-		expect(dash.featuredIsFresh()).toBe(false);
-		expect(dash.heroHeadline()).toBe(dash.heroFallback());
-		expect(dash.heroHeadline()).not.toContain("Finalen venter");
+	it("hides YESTERDAY's evening brief the next morning (the 20.07 bug)", () => {
+		const now = Date.parse("2026-07-20T06:00:00Z");   // Oslo 08:00, 20 July
+		dash.featured = briefAt("2026-07-19T13:00:00Z");  // Oslo 15:00, 19 July — evening brief, yesterday
+		expect(dash.featuredIsFresh(now)).toBe(false);
+		expect(dash.heroHeadline(now)).toBe(dash.heroFallback());
+		expect(dash.heroHeadline(now)).not.toContain("Finalen venter");
 	});
 
-	it("treats a featured brief with no generatedAt as untrustworthy (fall back)", () => {
+	it("drops the brief the instant the Oslo day rolls (midnight boundary)", () => {
+		// `now` just after Oslo midnight into 20 July; the brief is 1h old but from 19 July.
+		const now = Date.parse("2026-07-19T22:30:00Z");   // Oslo 00:30, 20 July
+		dash.featured = briefAt("2026-07-19T21:30:00Z");  // Oslo 23:30, 19 July — yesterday
+		expect(dash.featuredIsFresh(now)).toBe(false);
+		expect(dash.heroHeadline(now)).toBe(dash.heroFallback());
+	});
+
+	it("keeps a brief generated just AFTER Oslo midnight (same new day)", () => {
+		const now = Date.parse("2026-07-19T22:30:00Z");   // Oslo 00:30, 20 July
+		dash.featured = briefAt("2026-07-19T22:15:00Z");  // Oslo 00:15, 20 July — today
+		expect(dash.featuredIsFresh(now)).toBe(true);
+		expect(dash.heroHeadline(now)).toContain("Finalen venter");
+	});
+
+	it("treats a brief with no generatedAt as untrustworthy (fall back)", () => {
 		dash.featured = { blocks: [{ type: "headline", text: "Udatert." }] };
 		expect(dash.featuredIsFresh()).toBe(false);
 		expect(dash.heroHeadline()).toBe(dash.heroFallback());


### PR DESCRIPTION
## Hvorfor

Eierprinsipp (20.07): appen skal ALLTID føles fresh. Konkret bug: appen viste gårsdagens brief «VM-finalen i kveld: Spania mot Argentina på NRK» (generert 19.07) dagen etter finalen. Dagens publiserte `featured.json` var fersk og korrekt, men klienten viste den bufrede gårsdags-briefen. Dag-relativt språk («i kveld»/«i morgen») blir feil når Oslo-døgnet ruller.

## Ett felles ferskhetsprinsipp

Vis briefen **KUN hvis `generatedAt` er inneværende Oslo-kalenderdag** — ren dato-sammenligning i Oslo-tid, ingen «N timer»-heuristikk. Da forsvinner «i kveld»-briefen i det Oslo-døgnet ruller, mens dagens morgen/kvelds-brief (05:00/15:00) vises normalt.

### (a) iOS — `NewsBoard.build`
Ny `freshHeadline(_:now:)` dag-gater headline via `FeedCompiler.osloDayKey(generatedAt) == osloDayKey(now)` (gjenbruker eksisterende Oslo-dato-helper, ingen ny TZ-konstant). Udaterbar brief (ingen `generatedAt`) skjules. `NewsView:104 if let headline` skjuler seksjonen rent. Ren dato-sammenligning — ingen main-tråd-jobb.

### (b) Web — `dashboard.js`
`featuredIsFresh()` byttet fra `< 20t` til samme «samme Oslo-dag»-regel (`osloDayKey`); `now` injiserbar (default `Date.now()`). `heroFallback` uendret.

### (c) Foregrunn/dagskifte-re-eval — `ContentView`
`news.rebuild()` ved retur fra bakgrunn (`scenePhase .active`, `oldPhase == .background`), uavhengig av 15-min-ferskhetsgaten og av om synk endret noe. En brief som var «i dag» da appen ble bakgrunnet forsvinner etter midnatt **uten ny nedlasting**. Gjenbruker WP-107 av-main-tråden-koalesceringen (nonisolated `computeBoard`, lat `EntityIndex`) — foregrunn forblir øyeblikkelig, briefen re-lenses et øyeblikk senere off-main. Ingen per-sekund-timer.

### (d) Editorial-kontrakt
`editorial.md` noterer at klienten dag-gater briefen (så en brief aldri overlever sin egen dag). Ingen atferdsendring i agenten.

## Ytelse (eierkrav: ingenting skal henge)
Dag-vakten er en billig dato-sammenligning. Foregrunn-rebuilden legger INGEN dekoding/lens-matching på main-tråden — den går gjennom det eksisterende WP-60/107-maskineriet (koalescering, MainThreadGuard, lat EntityIndex). WP-60/107 MainThreadGuard-/koalesceringstestene er fortsatt grønne.

## Verifisering
- **Web:** `npx vitest run --maxWorkers=1` → 755 passerte (46 filer). 6 nye dag-vakt-tester, inkl. Oslo-midnatt-grense med injisert `now` (i går → fallback, i dag → vist).
- **iOS unit-suite:** 630 tester, 0 feil. 5 nye `NewsBoardTests` dag-vakt-tester + 1 `NewsModelTests` re-eval-test (fersk `now` → gårsdagens brief skjules uten ny synk).
- **Gylne feed-vektorer:** `FeedVectorTests` bit-like/uendret (ren visnings-/ferskhetslogikk).
- **4 schemes bygger:** Sportivista (test), SportivistaWidgetExtension, SportivistaUITests (build-for-testing), SportivistaDeviceDev (generic/iOS).
- **Skjermbilder:** `npm run screenshot` begge temaer OK — dagens ferske brief vises i hero-linjen (mørk + lys).

## Ikke-mål (urørt)
Sync-protokollen, live-linjen (WP-126), agenda-dag-grupperingen (WP-128), onboarding, editorial-agentens output-form, `docs/data/`. Web-fallbacken (`heroFallback`) uendret.

PLAN.md: WP-136 ⬜→🔬.

🤖 Generated with [Claude Code](https://claude.com/claude-code)