### PR TITLE
WP-139: merge-gate selvvern — håndheveren beskytter nå seg selv

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -148,7 +148,7 @@ mennesket, aldri av en agent.
 CI/CD-reviewen (4 read-only agenter) ga 5/6 og en billig herdingspakke. Disjunkte filer per WP så tre parallelle PR-er ikke kolliderer.
 
 | WP-138 | Pre-merge iOS-arkiv-/byggvalidering + permissions på testgatene + doc-forsoning (ci/ios-tests) | 0I+ | WP-137 | 🔬 |
-| WP-139 | merge-gate selvvern (PROTECTED_PATHS + protect-automation dekker merge-gate.js selv) | 0I+ | WP-40 | ⬜ |
+| WP-139 | merge-gate selvvern (PROTECTED_PATHS + protect-automation dekker merge-gate.js selv) | 0I+ | WP-40 | 🔬 |
 | WP-140 | ios-release tag-fotgever-fiks + koherenstest pinner jobbnavn/modell-tier + CLAUDE.md-forsoning | 0I+ | WP-137 | 🔬 |
 
 ---

--- a/scripts/hooks/protect-automation.js
+++ b/scripts/hooks/protect-automation.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 // PreToolUse hook: blocks the AUTONOMOUS CI agents from mutating the automation's
 // OWN protected paths — the workflow definitions, composite actions, safety hooks,
-// and the harness settings that wire them. These are four of the five
-// never-auto-merged paths (see CLAUDE.md "Autonomy model" / scripts/merge-gate.js).
+// the harness settings that wire them, and the merge gate that enforces the whole
+// protected-path invariant. These are five of the six never-auto-merged paths
+// (see CLAUDE.md "Autonomy model" / scripts/merge-gate.js).
 //
 // Why a hook and not just merge-gate.js: merge-gate stops a PR-based self-fixing
 // loop's protected-path change from AUTO-merging, but the five DIRECT-PUSHING
@@ -20,7 +21,7 @@
 // automation, so the hook exits 0 and stays out of the way. Exit 2 blocks the tool
 // call and feeds stderr back to the agent.
 //
-// (interests.json is the fifth protected path; it keeps its own dedicated,
+// (interests.json — the user-owned protected path — keeps its own dedicated,
 // user-owned message in protect-interests.js and is intentionally not repeated
 // here.)
 
@@ -28,14 +29,15 @@ const IN_CI = process.env.GITHUB_ACTIONS === "true" || process.env.CI === "true"
 
 // True when `raw` (however rooted: absolute, repo-relative, or bare-relative)
 // names a protected automation FILE. The three directory classes require a file
-// under them; the harness settings is the one exact file.
+// under them; the harness settings and the merge gate are the two exact files.
 function isProtectedPath(raw) {
 	const s = String(raw || "").replace(/\\/g, "/");
 	return (
 		/(^|\/)\.github\/workflows\/[^/]/.test(s) ||
 		/(^|\/)\.github\/actions\/[^/]/.test(s) ||
 		/(^|\/)scripts\/hooks\/[^/]/.test(s) ||
-		/(^|\/)\.claude\/settings\.json$/.test(s)
+		/(^|\/)\.claude\/settings\.json$/.test(s) ||
+		/(^|\/)scripts\/merge-gate\.js$/.test(s) // the enforcer itself (never self-weaken)
 	);
 }
 
@@ -44,7 +46,7 @@ function isProtectedPath(raw) {
 // redirect, tee, in-place editors, node fs writes) — reads/greps pass. This is
 // defense-in-depth, not a sandbox; the Write/Edit path above is the real channel.
 function bashMutatesProtected(cmd) {
-	const frag = String.raw`(?:\.github\/(?:workflows|actions)\/|scripts\/hooks\/|\.claude\/settings\.json)`;
+	const frag = String.raw`(?:\.github\/(?:workflows|actions)\/|scripts\/hooks\/|scripts\/merge-gate\.js|\.claude\/settings\.json)`;
 	const redirectsInto = new RegExp(String.raw`>>?\s*[^\s;&|<>]*${frag}`).test(cmd);
 	const pipesInto = new RegExp(String.raw`\btee\b[^;&|]*${frag}`).test(cmd);
 	const mutatesInPlace = new RegExp(String.raw`\b(?:sed\s+-i|mv|cp|rm|truncate|dd)\b[^;&|]*${frag}`).test(cmd);
@@ -76,9 +78,10 @@ process.stdin.on("end", () => {
 	if (touches) {
 		console.error(
 			"BLOCKED by hook: that path is a protected automation path (.github/workflows/**, " +
-			".github/actions/**, scripts/hooks/**, or .claude/settings.json). An unattended CI agent " +
-			"must not rewrite the workflows, composite actions, safety hooks, or harness settings that " +
-			"gate the automation itself. A human must author changes to these files."
+			".github/actions/**, scripts/hooks/**, .claude/settings.json, or scripts/merge-gate.js). " +
+			"An unattended CI agent must not rewrite the workflows, composite actions, safety hooks, " +
+			"harness settings, or the merge gate that gate the automation itself. A human must author " +
+			"changes to these files."
 		);
 		process.exit(2);
 	}

--- a/scripts/merge-gate.js
+++ b/scripts/merge-gate.js
@@ -6,9 +6,9 @@
  * ONE place enforces the invariant "protected paths are never auto-merged".
  * Finds the newest open PR whose head branch starts with <branch-prefix> and:
  *   1. If it touches a protected path → leave it OPEN, label `needs-review`.
- *      Protected: the workflows (the automation's own defs + this gate), the
+ *      Protected: the workflows (the automation's own defs + gates), the
  *      composite actions, the safety hooks, the hook wiring (.claude/settings.json),
- *      and the user-owned interests.json.
+ *      the user-owned interests.json, and THIS enforcer script itself.
  *   2. Otherwise re-run the tests ourselves as a deterministic hard gate
  *      (npm ci + npm test, plus validate-events for self-repair) and auto-merge.
  *      A failing gate command throws → the workflow step fails loudly and the
@@ -22,12 +22,18 @@ import { pathToFileURL } from "url";
 
 // Paths that must never ship unattended. Kept in sync with CLAUDE.md
 // ("Protected paths — never auto-merged") and the agent prompts.
+// The last entry protects THIS file: the enforcer must be at least as protected
+// as the paths it guards. merge-gate.js lives in scripts/ (not scripts/hooks/),
+// so without an explicit anchor a self-fixing loop could "refactor" the gate —
+// weakening or disabling PROTECTED_PATHS — and auto-merge it once tests are green
+// (its own test being auto-mergeable too). Guarding it here forces human review.
 export const PROTECTED_PATHS = [
 	/^\.github\/workflows\//, // the automation's own definitions and gates
 	/^\.github\/actions\//, // composite actions the workflows invoke
 	/^scripts\/hooks\//, // the safety hooks (interests protection, post-write validate)
 	/^scripts\/config\/interests\.json$/, // user-owned; AI never writes here
 	/^\.claude\/settings\.json$/, // wires the safety hooks into the harness
+	/^scripts\/merge-gate\.js$/, // the enforcer itself — guards against self-weakening
 ];
 
 export function findProtectedPaths(files) {

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -114,6 +114,8 @@ describe("protect-automation hook (CI-gated: blocks agents from mutating protect
 		["safety hook (bare-relative)", "scripts/hooks/validate-after-write.js"],
 		["harness settings (absolute)", "/repo/.claude/settings.json"],
 		["harness settings (bare-relative)", ".claude/settings.json"],
+		["merge gate (absolute)", "/repo/scripts/merge-gate.js"], // WP-139: the enforcer itself
+		["merge gate (bare-relative)", "scripts/merge-gate.js"],
 	];
 	for (const [label, file_path] of protectedFiles) {
 		it(`blocks Write to ${label} in CI with exit 2`, () => {
@@ -160,6 +162,15 @@ describe("protect-automation hook (CI-gated: blocks agents from mutating protect
 		expect(r.status).toBe(2);
 	});
 
+	it("blocks sed -i / redirect targeting the merge gate in CI (WP-139)", () => {
+		for (const command of [
+			"sed -i '' 's/6/0/' scripts/merge-gate.js",
+			"echo 'x' > scripts/merge-gate.js",
+		]) {
+			expect(runHook(hook, { tool_name: "Bash", tool_input: { command } }, CI).status, command).toBe(2);
+		}
+	});
+
 	it("ALLOWS a local operator (no CI) to edit a protected automation file", () => {
 		const r = spawnSync("node", [hook], {
 			input: JSON.stringify({ tool_name: "Write", tool_input: { file_path: "/repo/.github/workflows/research-agent.yml", content: "x" } }),
@@ -187,6 +198,7 @@ describe("protect-automation hook (CI-gated: blocks agents from mutating protect
 			"scripts/fetch/index.js",
 			"scripts/agents/research.md",
 			".claude/skills/norwegian-rights/SKILL.md",
+			"tests/merge-gate.test.js", // WP-139: the gate's OWN test is deliberately NOT protected
 		]) {
 			expect(runHook(hook, { tool_name: "Write", tool_input: { file_path, content: "{}" } }, CI).status, file_path).toBe(0);
 		}

--- a/tests/merge-gate.test.js
+++ b/tests/merge-gate.test.js
@@ -21,16 +21,17 @@ function fakeIo({ prs = [], files = [] } = {}) {
 }
 
 describe("findProtectedPaths", () => {
-	it("blocks all five protected paths", () => {
+	it("blocks all six protected paths", () => {
 		const blocked = [
 			".github/workflows/static-pipeline.yml",
 			".github/actions/setup/action.yml",
 			"scripts/hooks/protect-interests.js",
 			"scripts/config/interests.json",
 			".claude/settings.json",
+			"scripts/merge-gate.js", // the enforcer itself — guards against self-weakening
 		];
 		expect(findProtectedPaths(blocked)).toEqual(blocked);
-		expect(PROTECTED_PATHS.length).toBe(5);
+		expect(PROTECTED_PATHS.length).toBe(6);
 	});
 
 	it("does not block safe paths, including near-misses", () => {
@@ -43,6 +44,7 @@ describe("findProtectedPaths", () => {
 				".claude/skills/norwegian-rights/SKILL.md", // skills are agent-editable
 				"tests/interests-schema.test.js",
 				"package.json",
+				"tests/merge-gate.test.js", // the gate's OWN test is deliberately NOT protected (loops may extend coverage)
 			]),
 		).toEqual([]);
 	});
@@ -82,6 +84,20 @@ describe("runMergeGate", () => {
 		expect(io.calls.labels).toEqual([[42, "needs-review"]]);
 		expect(io.calls.merged).toEqual([]);
 		expect(io.calls.runs).toEqual([]); // not even test-gated — it simply waits for a human
+		expect(io.calls.outputs.merged).toBe("false");
+	});
+
+	it("a PR that refactors the gate itself stays OPEN with needs-review (never merged)", () => {
+		// WP-139: the enforcer must be at least as protected as what it guards — a loop
+		// "refactoring" merge-gate.js must NOT auto-merge (that could weaken PROTECTED_PATHS).
+		const io = fakeIo({ prs: pr, files: ["scripts/merge-gate.js", "tests/merge-gate.test.js"] });
+		const res = runMergeGate({ prefix: "self-repair/" }, io);
+		expect(res.merged).toBe(false);
+		expect(res.reason).toBe("protected-path");
+		expect(res.blocked).toEqual(["scripts/merge-gate.js"]); // the test file is deliberately NOT protected
+		expect(io.calls.labels).toEqual([[42, "needs-review"]]);
+		expect(io.calls.merged).toEqual([]);
+		expect(io.calls.runs).toEqual([]);
 		expect(io.calls.outputs.merged).toBe("false");
 	});
 


### PR DESCRIPTION
## WP-139 · merge-gate selvvern (BESKYTTET STI — eier merger, IKKE auto-merge)

CI/CD-reviewens (20.07) viktigste sikkerhetsfunn: `scripts/merge-gate.js` er SELV-håndheveren for de fem beskyttede stiene, men var **ikke selv beskyttet**. Den ligger i `scripts/` (ikke `scripts/hooks/`), så den var hverken i sitt eget `PROTECTED_PATHS` eller i `protect-automation.js` sin `isProtectedPath`. Konsekvens: en `improve`/`self-repair`/`ui-fix`-PR som «refaktorerer merge-gate.js» ble **ikke** blokkert → auto-merges hvis testene er grønne (sammen med sin egen test, som også er auto-mergebar), og kunne dermed svekke/deaktivere `PROTECTED_PATHS`. Håndheveren må være minst like beskyttet som det den beskytter.

### Endringer
- **`scripts/merge-gate.js`** — la til `/^scripts\/merge-gate\.js$/` i `PROTECTED_PATHS` (nå **seks** stier), samme regex-ankrete stil som de andre fem, med forklarende kommentar over listen. **Ingen endring i gate-LOGIKKEN** (`waitForChecks`/`runMergeGate`-flyten urørt) — kun sti-settet.
- **`scripts/hooks/protect-automation.js`** — la `scripts/merge-gate.js` i `isProtectedPath` (eksakt-fil, alle rot-varianter) og i `bashMutatesProtected`s `frag` (redirect/tee/sed -i/mv/writeFileSync), så en direkte-pushende CI-agent heller ikke kan Write/Edit/Bash-mutere håndheveren. Oppdatert header-kommentar (nå «fem av seks») + BLOCKED-meldingen.
- **Tester** — `tests/merge-gate.test.js`: en PR som rører `scripts/merge-gate.js` blir blokkert (`needs-review`, ingen merge, ingen test-run), `PROTECTED_PATHS.length === 6`, og testfilen selv er en eksplisitt near-miss (IKKE beskyttet). `tests/hooks.test.js`: protect-automation blokkerer Write/Edit/sed/redirect mot `merge-gate.js` i CI (absolutt + bare-relativ), tillater lokal operatør, og tillater skriv til testfilen.

### Beslutning: beskytt gaten, IKKE gatens egen test
Jeg beskytter **`scripts/merge-gate.js` selv, men IKKE `tests/merge-gate.test.js`**. En `PROTECTED_PATH` betyr at ENHVER PR som rører den blir stående for menneske-merge. Gaten selv er der invarianten kan **svekkes** (endre `PROTECTED_PATHS`, kortslutte flyten) → må gates av et menneske. Testfilen kan derimot bare **styrke** kontrakten (en svekket gate ville få de nye assertions til å feile), og å beskytte den ville hindre `improve`-løkken i å legge til testdekning der. Rubrikker/andre filer vurdert og bevisst utelatt — kun håndheveren selv er sikkerhetskritisk.

### Dokumentasjonsnote (for WP-140)
CLAUDE.md sier fortsatt «**fem** beskyttede stier» flere steder (Autonomi-modellen, «Rules for automated/agent changes», protect-automation-header-referansen). Tallet bør nå si «**seks**». **Ikke rettet her** — WP-140 eier dok-forsoningen; flagget slik at den fanges der.

### Verifisering
- `npx vitest run tests/merge-gate.test.js tests/hooks.test.js tests/workflows.test.js --maxWorkers=1` → 58/58 grønn
- Full `npx vitest run --maxWorkers=1` → **46 filer / 761 tester grønn**

🤖 Generated with [Claude Code](https://claude.com/claude-code)