### PR TITLE
WP-138: pre-merge iOS-byggvalidering + least-privilege permissions + doc-forsoning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
-# Den universelle PR-gaten: npm-suiten (~620 tester, sekunder) kjører på HVER
-# PR uansett hva den rører — dette er sjekken branch-beskyttelsen krever
-# («web-tests»). Før denne fantes gatet testene bare selvhelings-loopene
-# (som re-kjører dem selv i merge-gate.js); PR-er fra mennesker/hovedløkka
-# hadde ingen maskinell gate i det hele tatt.
+# Web-testgaten: npm-suiten (~620 tester, sekunder) kjører på HVER PR og på
+# push til main som rører scripts/tests/docs-js/package/vitest.
+#
+# «Required»-nyansen (rettet WP-138): sjekken «web-tests» er IKKE plattform-
+# håndhevet. Repo-rulesetet «main-gates» har bare deletion + non_fast_forward,
+# og main har ingen klassisk branch-protection — altså INGEN server-side
+# required status checks. Den REELLE gaten er script-side: de tre selvhelings-
+# loopene (ui-fix/self-repair/improve) kjører scripts/merge-gate.js, som venter
+# på grønn CI (`gh pr checks --watch --fail-fast`) før de auto-merger. Menneske-
+# PR-er og direkte-push til main forbigår dermed CI — den gater loopenes auto-
+# merge, ikke main. (Før ci.yml fantes gatet ingenting menneske-/hovedløkke-PR-er
+# maskinelt; loopene re-kjørte testene selv inne i merge-gate.js.)
 name: CI
 
 on:
@@ -15,6 +22,12 @@ on:
       - "docs/js/**"
       - "package*.json"
       - "vitest.config.js"
+
+# Ren test-gate: leser bare ut koden (checkout). Ingen jobb her skriver til
+# repoet, så minste privilegium er contents: read (WP-138). Utelatt tidligere,
+# så workflowen arvet repo-defaultens videre GITHUB_TOKEN-scope.
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,13 +1,21 @@
 # iOS-testgaten: Swift-unit-suiten (hostless bundles via Sportivista-skjemaet,
-# inkl. golden-vektorene som pinner JS↔Swift bit-likt) på PR-er som rører ios/.
-# Offentlig repo ⇒ macOS-runnere er gratis. Sekretløs: simulator-tester
-# signerer ikke (CODE_SIGNING_ALLOWED=NO er prosjekt-default). UI-testene
-# kjøres IKKE her (lokale/agent-drevne mot det deterministiske harnesset).
+# inkl. golden-vektorene som pinner JS↔Swift bit-likt) + en usignert device-
+# byggvalidering (WP-138, se steget «Valider device-bygg» under) på PR-er som
+# rører ios/. Offentlig repo ⇒ macOS-runnere er gratis. Sekretløs: verken
+# simulator-testene eller device-byggvalideringen signerer (CODE_SIGNING_ALLOWED=NO).
+# UI-testene kjøres IKKE her (lokale/agent-drevne mot det deterministiske harnesset).
 #
-# Workflowen kjører på ALLE PR-er og hopper selv over macOS-jobben når ios/
-# er urørt: branch-beskyttelsen krever sjekken «ios-tests», og en workflow
-# med paths-filter rapporterer aldri på urelaterte PR-er (sjekken ville stått
-# evig «expected»). En skippet jobb tilfredsstiller required checks.
+# Workflowen kjører på ALLE PR-er og hopper selv over macOS-jobben når ios/ er
+# urørt via en billig detect-jobb. Hvorfor sjekken må RAPPORTERE en konklusjon
+# (skip teller som grønn) i stedet for å stå evig «expected»: det er IKKE
+# plattform-håndhevet branch-protection som krever den — rulesetet «main-gates»
+# har bare deletion + non_fast_forward, main har ingen klassisk branch-protection,
+# og det finnes ingen server-side required status checks. Men de tre selvhelings-
+# loopenes scripts/merge-gate.js venter på ALLE PR-ens checks
+# (`gh pr checks --watch --fail-fast`) før auto-merge; en sjekk som aldri
+# konkluderer ville hengt den gaten. Menneske-PR-er og direkte-push til main
+# forbigår CI. (Rettet WP-138: påstanden om «required checks branch protection»
+# her var faktisk feil.)
 name: iOS Tests
 
 on:
@@ -17,6 +25,13 @@ on:
     paths:
       - "ios/**"
       - ".github/workflows/ios-tests.yml"
+
+# Ren test-/byggvalideringsgate: begge jobbene leser bare ut koden (checkout +
+# git diff + xcodegen/xcodebuild, ingen signering). Ingenting skriver til repoet,
+# så minste privilegium er contents: read (WP-138). Utelatt tidligere, så
+# workflowen arvet repo-defaultens videre GITHUB_TOKEN-scope.
+permissions:
+  contents: read
 
 concurrency:
   group: ios-tests-${{ github.ref }}
@@ -104,3 +119,47 @@ jobs:
           SUMMARY=$(xcrun xcresulttool get test-results summary --path TestResults.xcresult)
           echo "$SUMMARY" | grep -E '"result"|"passedTests"|"failedTests"'
           echo "$SUMMARY" | grep -q '"result" : "Passed"'
+
+      # WP-138: pre-merge device-BYGGVALIDERING (usignert). Steget over bygger
+      # BARE `Sportivista`-skjemaet FOR SIMULATOR — det rører ALDRI
+      # `SportivistaDeviceDev`-targetet som release-lanen (ios-release.yml)
+      # faktisk arkiverer og laster til TestFlight. Uten dette steget fanges
+      # arkiv-formfeil først ETTER merge, i release-lanen, der «TestFlight
+      # slutter stille å oppdatere» (klassen som bet 18.07).
+      #
+      # Hva build-for-device HER fanger (build-time-delen av arkiv-klassen):
+      #   • device-only kompilering av CloudKit-stien bak `-D SPORTIVISTA_CLOUDKIT`
+      #     — Simulator-`Sportivista` har IKKE den flaggen og kompilerer den
+      #     ALDRI, så en brekt sync-sti er grønn i sim men feiler på TestFlight;
+      #   • den ekte arm64-enhets-slicen (iphoneos-SDK, ikke simulator-SDK);
+      #   • device-Info.plist prosesseres + bakes (UIDeviceFamily fra
+      #     TARGETED_DEVICE_FAMILY, MinimumOSVersion fra deployment target,
+      #     CFBundleVersion/-ShortVersionString via $(...)-referansene) — en
+      #     malformert plist eller brukket referanse feiler her;
+      #   • widget-appex-en embeddes + valideres (ValidateEmbeddedBinary) — brutt
+      #     target-medlemskap i widgeten faller ut her.
+      #
+      # Hvorfor `build` og IKKE et fullt `archive`: de RENE ASC-OPPLASTINGS-
+      # valideringene («1,2»-familiens iPad-orienteringskrav, encryption-
+      # compliance-spørsmålet) er submission-side — de krever et signert opplast
+      # og kan IKKE valideres før signering, så et usignert `archive` fanger dem
+      # ikke heller; det ville bare lagt Release-kompilering + arkiv-pakking på
+      # toppen uten ekstra dekning. build-for-device gir arkiv-FORMEN uten
+      # pakkingen. `CODE_SIGNING_ALLOWED/REQUIRED=NO` gjør steget signeringsfritt
+      # og dermed ikke-flaky: runneren har verken identitet, profil eller
+      # ASC-nøkkel. Gjenbruker samme `build/ci-derived-data` som testene
+      # (WP-107-cachen) → inkrementelt bygg, ikke kaldt hver gang.
+      - name: Valider device-bygg (usignert)
+        working-directory: ios
+        run: |
+          set -o pipefail
+          # Ingen «|| true»: pipefail lar xcodebuild-exit gate steget. «** BUILD
+          # SUCCEEDED **» matcher alltid på suksess (så grep bobler ikke opp en
+          # falsk feil), og en BUILD FAILED gir non-zero → steget feiler høylytt.
+          xcodebuild build \
+            -project Sportivista.xcodeproj \
+            -scheme SportivistaDeviceDev \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath build/ci-derived-data \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO \
+            2>&1 | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED|^\*\* "

--- a/PLAN.md
+++ b/PLAN.md
@@ -147,7 +147,7 @@ mennesket, aldri av en agent.
 
 CI/CD-reviewen (4 read-only agenter) ga 5/6 og en billig herdingspakke. Disjunkte filer per WP så tre parallelle PR-er ikke kolliderer.
 
-| WP-138 | Pre-merge iOS-arkiv-/byggvalidering + permissions på testgatene + doc-forsoning (ci/ios-tests) | 0I+ | WP-137 | ⬜ |
+| WP-138 | Pre-merge iOS-arkiv-/byggvalidering + permissions på testgatene + doc-forsoning (ci/ios-tests) | 0I+ | WP-137 | 🔬 |
 | WP-139 | merge-gate selvvern (PROTECTED_PATHS + protect-automation dekker merge-gate.js selv) | 0I+ | WP-40 | ⬜ |
 | WP-140 | ios-release tag-fotgever-fiks + koherenstest pinner jobbnavn/modell-tier + CLAUDE.md-forsoning | 0I+ | WP-137 | ⬜ |
 


### PR DESCRIPTION
Fra CI/CD-reviewen 20.07 (karakter 5/6). Tre herdinger på de to test-gatene — **BESKYTTET STI (`.github/workflows/**`), eier merger, IKKE auto-merge**.

## 1. Pre-merge iOS device-byggvalidering (ios-tests.yml)
Nytt steg **«Valider device-bygg (usignert)»** i macos-jobben (som alt bare kjører når `ios/` er endret, via detect-self-skip):

```
xcodebuild build -scheme SportivistaDeviceDev -destination 'generic/platform=iOS' \
  -derivedDataPath build/ci-derived-data CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
```

**Hvorfor:** simulator-testene bygger bare `Sportivista`-skjemaet FOR SIMULATOR. De rører aldri `SportivistaDeviceDev`-targetet som release-lanen (`ios-release.yml`) faktisk arkiverer og laster til TestFlight. Uten dette fanges arkiv-formfeil (Info.plist / TARGETED_DEVICE_FAMILY / deployment target / provisioning-form / widget-embed — klassen som bet 18.07) først ETTER merge, i release-lanen, der «TestFlight slutter stille å oppdatere».

**Hva build-for-device fanger (build-time-delen av arkiv-klassen):**
- device-only kompilering av CloudKit-stien bak `-D SPORTIVISTA_CLOUDKIT` — Simulator-`Sportivista` har ikke flaggen og kompilerer den ALDRI (en brekt sync-sti er grønn i sim, feiler på TestFlight)
- ekte arm64-enhets-slice (iphoneos-SDK)
- device-Info.plist prosesseres + bakes: `UIDeviceFamily=[1]`, `MinimumOSVersion=26.0`, `CFBundleVersion=4` (via `$(...)`-referansene — malformert plist / brukket referanse feiler her)
- widget-appex embeddes + valideres (ValidateEmbeddedBinary)

**Hvorfor `build` og IKKE fullt `archive`:** de rene ASC-OPPLASTINGS-valideringene («1,2»-familiens iPad-orienteringskrav, encryption-compliance-spørsmålet) er submission-side — de krever et signert opplast og kan ikke valideres før signering, så et usignert `archive` fanger dem ikke heller; det ville bare lagt Release-kompilering + arkiv-pakking på toppen uten ekstra dekning. `CODE_SIGNING_ALLOWED/REQUIRED=NO` gjør steget signeringsfritt → ikke-flaky (runneren har verken identitet, profil eller ASC-nøkkel). Gjenbruker samme `build/ci-derived-data` som testene (WP-107-cachen) → inkrementelt.

**Verifisert lokalt på main-tilstand:** `** BUILD SUCCEEDED **` (også med tømt derived-data). Bekreftet at bygget baker `UIDeviceFamily=[1]` / `ITSAppUsesNonExemptEncryption=false` / `MinimumOSVersion=26.0` / `CFBundleVersion=4` i device-Info.plist og embedder+validerer `SportivistaWidget.appex`.

## 2. Least-privilege permissions
Eksplisitt `permissions: contents: read` på **både** ci.yml og ios-tests.yml. Rene test-/byggvaliderings-gater skriver ikke til repoet (checkout + git diff + xcodegen/xcodebuild); tidligere arvet de repo-defaultens videre GITHUB_TOKEN-scope. (`actions/cache` og `actions/checkout` klarer seg med read.)

## 3. Doc-forsoning (kun ci.yml + ios-tests.yml)
Topp-kommentarene påsto at web-tests/ios-tests er «required checks branch protection enforces» — **faktisk feil**. Verifisert: rulesetet `main-gates` har bare `deletion` + `non_fast_forward`, main har ingen klassisk branch-protection, ingen server-side required status checks. Reell gate er **script-side** i `scripts/merge-gate.js` for de tre selvhelings-loopene (`gh pr checks --watch --fail-fast`, linje 98); menneske-PR-er og direkte-push forbigår CI. Kommentarene sier nå dette presist og nøkternt. (`merge-gate.js` / CLAUDE.md urørt — andre WP-er eier dem.)

## Verifisering
- Ny build-for-device-invokasjon kjørt lokalt på main-tilstand → **BUILD SUCCEEDED** (også kald)
- `npx vitest run tests/workflows.test.js` → 7/7 grønn (den nye jobben/steget bryter ikke antakelsene)
- Full iOS unit-suite urørt → 630 tester, 1 skippet (opt-in RealFM), 0 feil, **TEST SUCCEEDED**
- Full web-suite → 46 filer / 755 tester grønn
- Begge YAML-filer parser

PLAN.md WP-138 ⬜→🔬 (samme PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)