### PR TITLE
Opprydding: profil klartekst (dropp overflødig E2E) + data-strategi

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1891,6 +1891,48 @@ golf-buggen 5×, fiksen var kode; WP-93: vaktene ble deterministiske sjekker)
 er kvote frigjort permanent. Prinsipp: en AI-løkke som gjentar samme funn ≥3×
 skal produsere en kode-/skjema-endring, ikke flere AI-kjøringer.
 
+## BRUKERDATA → PRODUKTFORBEDRING (eier-drøfting 20.07.2026) · dossier-tillegg
+
+Eier-instinkt: profil-data (hva folk følger/preferanser) er verdifullt for å
+forbedre appen når massen vokser; E2E på en sport-følgeliste er unødvendig. Begge
+deler stemmer — men de er ULIKE spørsmål, og ett teknisk faktum avgjør rammen:
+
+**Bærende faktum:** profilen ligger i brukerens EGEN private CloudKit-DB. Den er
+usynlig for oss som utvikler — uansett kryptering. Å fjerne E2E (gjort 20.07,
+`cleanup-profile-plaintext`) ga web-lesbarhet, IKKE utvikler-innsyn. «Bruk dataen»
+krever derfor en egen, bevisst innsamlingsvei; det er ikke en krypterings-spak.
+
+**To akser (vidt ulik kostnad):**
+
+- **A · Forbedre FOR den enkelte** (appen tilpasser seg deg) — allerede støttet
+  on-device: `BehaviorCounter` (G-counter i profilen) + `MemoryFact` +
+  assistentens minne. Null personvern-kost, ingen infra, ingen samtykke. **Den
+  umiddelbare gevinsten — utvid her først** (adaptive defaults, assistent-minne,
+  «du åpner alltid golf → løft det»). Alt beregnet lokalt, ett byte forlater aldri
+  enheten. Passer eksakt to-lags-arkitekturen (kost skalerer med dekning, ikke
+  brukere).
+
+- **B · Lære PÅ TVERS av brukere** (aggregat → bedre defaults/dekning/onboarding)
+  — krever innsamlingsvei siden privat-DB er usynlig. Rangert etter risiko:
+  1. **Mine follow-requestene** (`follow.yml` → GitHub-issues) — allerede
+     OFFENTLIGE. «Hva ber folk om å følge» er gratis, ikke-personlig, i dag.
+     Kobler til WP-23 gap-voting + WP-96 etterspørselsmodell.
+  2. **Opt-in anonymt aggregat via CloudKit PUBLIC database** — null-infra
+     (Apple hoster), utvikler-lesbar (ulikt privat-DB), gratis på denne skalaen,
+     blir i Apple-økosystemet. Bruker skriver frivillig «anon følger entitet X»;
+     vi spør public-DB om popularitet. Den elegante på-merket-veien når (1) ikke
+     rekker.
+  3. **Ekte telemetri/backend** — siste utvei; bryter null-infra + personvern-
+     posisjonen («dine data rører aldri serveren vår» er tillitskapital, brukes
+     opp én gang) + GDPR-plikter (samtykke, personvernerklæring, databehandler).
+
+**Anbefaling:** start med **A (on-device) + B.1 (offentlige follow-requests)** —
+null risiko, null infra, verdi i dag. **B.2** når tverr-bruker-signal faktisk
+trengs. **B.3** kun ved bevisst posisjons-skifte. Personvern-linjen, om noen, hold
+den på ASSISTENT-MINNET (litt mer personlig enn følge-lista), aldri på følges.
+Status: rammeverk besluttet; ingen innsamling bygget. NESTE når prioritert:
+skissere A-utvidelsen (adaptive defaults fra `BehaviorCounter`) som egen WP.
+
 ## FASE 1 · Norge-lansering (Q4 2026, dossier P400/P500) — skisse
 
 - **WP-20 · Kildemigrering til primærkilder** (P400 regel #1): erstatt tvkampen-scraperen

--- a/ios/Sportivista/Profile/CloudKitProfileSync.swift
+++ b/ios/Sportivista/Profile/CloudKitProfileSync.swift
@@ -6,9 +6,13 @@
 //  the profile syncs to the USER'S OWN private CloudKit database — inside THEIR
 //  iCloud quota, in THEIR private zone, NEVER our server. There is no Sportivista
 //  backend in this path at all; Apple moves the bytes between the user's own
-//  devices. The free-text fields (a rule's `reason`, a note's text) ride in
-//  `encryptedValues`, so they are end-to-end encrypted where CloudKit supports
-//  it (a custom zone in the private DB — which is exactly what we create).
+//  devices. The profile is stored as PLAINTEXT in that private DB — deliberately,
+//  not E2E. Rationale: a sports follow-list ("I follow Liverpool") is low
+//  sensitivity, E2E (`encryptedValues`) was over-engineering, and it is exactly
+//  what blocked web sync — CloudKit JS cannot decrypt E2E fields. Plaintext keeps
+//  the SAME privacy boundary that matters (the data lives ONLY in the user's own
+//  private DB, never our server) while making one clean channel readable by BOTH
+//  the app and the user's own web sign-in.
 //
 //  ONE record per rule (recordName = entityId), matching the server's
 //  `tracked.json` "one entry per entity" shape. Deletions replicate as tombstone
@@ -16,14 +20,11 @@
 //  deletions — so a peer holding a stale live copy cannot resurrect an
 //  unfollowed entity (the same tombstone discipline the merge enforces).
 //
-//  THE WEB CHANNEL (`ProfileSnapshot`): CloudKit JS in a browser CANNOT decrypt
-//  `encryptedValues`, so the per-record path above is invisible to the web. To
-//  sync with the web we ALSO publish one PLAINTEXT snapshot per device
-//  (`writeSnapshot` → a ProfileShareCodec payload in a `payload` field, recordName
-//  = this device) and fold every device's snapshot back in on `pull`. The native
-//  iOS↔iOS path stays E2E; the snapshot is the deliberately-plaintext bridge (its
-//  content is still ONLY in the user's own private DB — never shared, never our
-//  server). See docs/icloud-sync-setup.md.
+//  THE WEB CHANNEL (`ProfileSnapshot`): a browser can't page the per-record types,
+//  so we ALSO publish one plaintext snapshot per device (`writeSnapshot` → a
+//  ProfileShareCodec payload in a `payload` field, recordName = this device) and
+//  fold every device's snapshot back in on `pull`. Same private DB, same
+//  plaintext posture. See docs/icloud-sync-setup.md.
 //
 //  ACCOUNT CONSTRAINT (binding): the free personal team (DEVELOPMENT_TEAM
 //  9LVCB72DT8) cannot provision the CloudKit entitlement on a device build
@@ -52,10 +53,10 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
         static let rule = "ProfileRule"
         static let episodic = "EpisodicNote"
         static let counter = "Counter"
-        /// WP — the web-readable channel: one record per device, a single PLAINTEXT
+        /// WP — the web-readable channel: one record per device, a single
         /// `payload` field (a ProfileShareCodec string of the device's full merged
-        /// state). CloudKit JS can read this (it CANNOT read the encryptedValues on
-        /// the record types above), so this is how the browser learns the profile.
+        /// state). A browser can't page the per-record types above, so this one
+        /// record is how the browser learns the whole profile in a single read.
         static let snapshot = "ProfileSnapshot"
     }
 
@@ -66,8 +67,9 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
     private let snapshotDeviceID: String
 
     /// Defaults to the app's default container's PRIVATE database and a dedicated
-    /// custom zone (custom zones are what enable `encryptedValues`). A different
-    /// container id can be injected for a future multi-container setup.
+    /// custom zone (kept for record grouping + a future `fetchRecordZoneChanges`
+    /// delta sync). A different container id can be injected for a future
+    /// multi-container setup.
     init(container: CKContainer = .default(), zoneName: String = "SportivistaProfile") {
         self.database = container.privateCloudDatabase
         self.zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: CKCurrentUserDefaultName)
@@ -107,7 +109,7 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
     private func fetchRules() async throws -> [SyncedRule] {
         try await fetchAll(type: RecordType.rule).compactMap { record in
             guard
-                let json = record.encryptedValues["ruleJSON"] as? Data,
+                let json = record["ruleJSON"] as? Data,
                 let rule = try? Self.jsonDecoder.decode(InterestRule.self, from: json),
                 let modifiedAt = record["modifiedAt"] as? Date,
                 let deviceID = record["deviceID"] as? String
@@ -124,11 +126,11 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
                 let createdAt = record["createdAt"] as? Date
             else { return nil }
             var payload: [String: String] = [:]
-            if let data = record.encryptedValues["payloadJSON"] as? Data,
+            if let data = record["payloadJSON"] as? Data,
                let decoded = try? Self.jsonDecoder.decode([String: String].self, from: data) {
                 payload = decoded
             }
-            let note = record.encryptedValues["note"] as? String
+            let note = record["note"] as? String
             let resolvedAt = record["resolvedAt"] as? Date
             return EpisodicNote(id: record.recordID.recordName, kind: kind, createdAt: createdAt,
                                 payload: payload, note: note, resolvedAt: resolvedAt)
@@ -194,7 +196,7 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
     private func ruleRecord(_ r: SyncedRule) throws -> CKRecord {
         let record = CKRecord(recordType: RecordType.rule,
                               recordID: CKRecord.ID(recordName: r.entityId, zoneID: zoneID))
-        record.encryptedValues["ruleJSON"] = try Self.jsonEncoder.encode(r.rule) as CKRecordValue
+        record["ruleJSON"] = try Self.jsonEncoder.encode(r.rule) as CKRecordValue
         record["modifiedAt"] = r.modifiedAt as CKRecordValue
         record["deviceID"] = r.deviceID as CKRecordValue
         record["deleted"] = Int64(r.deleted ? 1 : 0) as CKRecordValue
@@ -206,8 +208,8 @@ final class CloudKitProfileSync: ProfileSyncBackend, @unchecked Sendable {
                               recordID: CKRecord.ID(recordName: n.id, zoneID: zoneID))
         record["kind"] = n.kind as CKRecordValue
         record["createdAt"] = n.createdAt as CKRecordValue
-        record.encryptedValues["payloadJSON"] = try Self.jsonEncoder.encode(n.payload) as CKRecordValue
-        if let note = n.note { record.encryptedValues["note"] = note as CKRecordValue }
+        record["payloadJSON"] = try Self.jsonEncoder.encode(n.payload) as CKRecordValue
+        if let note = n.note { record["note"] = note as CKRecordValue }
         if let resolvedAt = n.resolvedAt { record["resolvedAt"] = resolvedAt as CKRecordValue }
         return record
     }

--- a/ios/Sportivista/Profile/ProfileSyncBackend.swift
+++ b/ios/Sportivista/Profile/ProfileSyncBackend.swift
@@ -8,10 +8,12 @@
 //
 //    • CloudKitProfileSync   the real thing — the USER'S OWN private CloudKit
 //                            database (their iCloud quota, never our server),
-//                            record-per-rule, `encryptedValues` on the free-text
-//                            fields. Compiles on the Simulator + in CI (the
-//                            CloudKit SDK is present) but only RUNS where a paid
-//                            account + the iCloud entitlement exist (WP-17).
+//                            record-per-rule, PLAINTEXT (not E2E — a sports
+//                            follow-list is low sensitivity, and plaintext is what
+//                            lets the user's own web sign-in read it too). Compiles
+//                            on the Simulator + in CI (the CloudKit SDK is present)
+//                            but only RUNS where a paid account + the iCloud
+//                            entitlement exist (WP-17).
 //    • LocalOnlyProfileSync  a no-op fallback — what the free-account
 //                            `SportivistaDeviceDev` build uses (no CloudKit entitlement
 //                            on a free personal team), so the phone install keeps
@@ -40,11 +42,10 @@ protocol ProfileSyncBackend: Sendable {
     /// record deletions, so a peer can't resurrect an unfollowed entity.
     func push(_ pushSet: PushSet) async throws
 
-    /// Publish this device's FULL merged state as a single PLAINTEXT snapshot the
-    /// WEB can read. CloudKit JS cannot decrypt the per-record `encryptedValues`
-    /// the E2E path uses, so `push` alone is invisible to a browser; the snapshot
-    /// is the web-readable channel (a ProfileShareCodec payload in one record,
-    /// recordName = this device). The CRDT guarantees the two channels converge.
+    /// Publish this device's FULL merged state as a single snapshot the WEB reads
+    /// in one shot (a browser can't easily page the per-record types), a
+    /// ProfileShareCodec payload in one record, recordName = this device. The CRDT
+    /// guarantees the per-record and snapshot channels converge.
     /// Default: no-op — only CloudKitProfileSync overrides it.
     func writeSnapshot(_ state: ProfileSyncState) async throws
 }


### PR DESCRIPTION
Eier-beslutning 20.07: E2E på en sport-følgeliste er over-engineering og var nettopp det som blokkerte web-sync. Fjerner `encryptedValues` fra per-record-stien → én klartekst-vei. Samme personvern-grense som betyr noe (data lever kun i brukerens egen private CloudKit-DB, aldri vår server).

## Kode
- `CloudKitProfileSync`: `record.encryptedValues[...]` → `record[...]` for ruleJSON/payloadJSON/note. Custom zone beholdes for record-gruppering + framtidig `fetchRecordZoneChanges`. Header + kommentarer rettet.
- `ProfileSyncBackend`-doc oppdatert. `ProfileSyncBackendTests` + `FeedVectorTests` grønne.

## PLAN.md
Ny strategi-seksjon «BRUKERDATA → PRODUKTFORBEDRING». Bærende faktum: privat CloudKit-DB er usynlig for utvikler uansett kryptering → «bruk dataen» krever egen innsamlingsvei, ikke en E2E-spak. To akser: (A) forbedre FOR brukeren on-device (BehaviorCounter/MemoryFact, null personvern-kost — utvid her først), (B) lære på tvers: B.1 offentlige follow-requests → B.2 opt-in CloudKit PUBLIC-DB → B.3 telemetri (siste utvei). Anbefaling: A + B.1 nå.

## Utløser ved merge
iOS → TestFlight (ios/**-endring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)