### PR TITLE
WP-134 slice 1: Affinity-kjerne + forklarbarhet (on-device akse A)

### DIFF
--- a/ios/Sportivista/Memory/Affinity.swift
+++ b/ios/Sportivista/Memory/Affinity.swift
@@ -1,0 +1,98 @@
+//
+//  Affinity.swift
+//  Sportivista
+//
+//  WP-134 — on-device adaptive personalisation (axis A: "improve FOR the user").
+//  Turns the observed `BehaviorStat` signal (open / expand / dismiss per entity
+//  and per sport — already recorded, already synced E2E-free via the CloudKit
+//  snapshot) into a mild, deterministic per-subject affinity score.
+//
+//  DESIGN CONTRACT (the whole point of keeping it "mild"):
+//   • It is a TIE-BREAK / LIFT, never a relevance gate. It changes nothing about
+//     WHICH events are relevant / must-watch / must-see — only the order where
+//     order is otherwise arbitrary. The golden feed-vectors must stay bit-like.
+//   • It never re-sorts the chronological agenda (time is sacred) and never hides
+//     anything. A dismiss lowers a lift; it never removes.
+//   • It is explainable (surfaced in "Hva jeg vet om deg"), never a black box.
+//   • Pure + Foundation-only → fully unit-tested with no store/UI in sight.
+//
+
+import Foundation
+
+struct Affinity: Equatable, Sendable {
+
+    /// A dismiss is a stronger (negative) signal than a glance-open is positive,
+    /// and an expand ("hvorfor vises denne" / open a series) is a deeper positive
+    /// than a plain open. Asymmetric on purpose.
+    static let weightOpen = 1.0
+    static let weightExpand = 1.5
+    static let weightDismiss = 2.0
+
+    /// Saturation constant for the bounded squash: the raw score is squashed into
+    /// (-1, 1) so one heavy-usage day can never dominate the ranking.
+    static let saturation = 20.0
+
+    private let rawByEntity: [String: Double]
+    private let rawBySport: [String: Double]
+
+    /// Build from the behaviour stats a `MemoryState` already exposes.
+    init(behavior: [BehaviorStat]) {
+        var entity: [String: Double] = [:]
+        var sport: [String: Double] = [:]
+        for stat in behavior {
+            let contribution = Self.weight(stat.kind) * Double(stat.total)
+            if stat.isSport {
+                sport[stat.token, default: 0] += contribution
+            } else {
+                entity[stat.token, default: 0] += contribution
+            }
+        }
+        rawByEntity = entity
+        rawBySport = sport
+    }
+
+    private static func weight(_ kind: BehaviorKind) -> Double {
+        switch kind {
+        case .open: return weightOpen
+        case .expand: return weightExpand
+        case .dismiss: return -weightDismiss
+        }
+    }
+
+    /// Raw (un-squashed) accumulation for a subject — 0 for an unseen one.
+    func rawScore(entityId: String? = nil, sport: String? = nil) -> Double {
+        var raw = 0.0
+        if let id = entityId { raw += rawByEntity[id] ?? 0 }
+        if let s = sport { raw += rawBySport[s] ?? 0 }
+        return raw
+    }
+
+    /// The affinity in (-1, 1): a bounded, monotone, deterministic squash of the
+    /// raw score. 0 for an unseen subject; negative when dismissals dominate.
+    /// Combining an event's entity AND sport sums their raw scores, then squashes.
+    func score(entityId: String? = nil, sport: String? = nil) -> Double {
+        Self.squash(rawScore(entityId: entityId, sport: sport))
+    }
+
+    /// `x / (k + |x|)` — monotone increasing, odd (so dismissals go negative),
+    /// bounded in (-1, 1), 0 at 0. No `tanh`/Foundation-math surprises.
+    static func squash(_ x: Double) -> Double {
+        x / (saturation + Swift.abs(x))
+    }
+
+    /// The subjects with the STRONGEST positive affinity, most-engaged first —
+    /// for the "du åpner golf oftest" explainability line and any tie-break lift.
+    /// Ties broken by token for determinism. Non-positive scores are excluded.
+    func topSubjects(limit: Int = 3) -> [(token: String, isSport: Bool, score: Double)] {
+        var all: [(token: String, isSport: Bool, score: Double)] = []
+        for (id, raw) in rawByEntity where raw > 0 { all.append((id, false, Self.squash(raw))) }
+        for (s, raw) in rawBySport where raw > 0 { all.append((s, true, Self.squash(raw))) }
+        all.sort { a, b in
+            if a.score != b.score { return a.score > b.score }
+            return a.token < b.token
+        }
+        return Array(all.prefix(max(0, limit)))
+    }
+
+    var isEmpty: Bool { rawByEntity.isEmpty && rawBySport.isEmpty }
+}

--- a/ios/Sportivista/Memory/WhatIKnowView.swift
+++ b/ios/Sportivista/Memory/WhatIKnowView.swift
@@ -123,6 +123,15 @@ struct WhatIKnowView: View {
     private var behaviorSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle("ATFERD (\(memory.behavior.count))")
+            // WP-134: make the adaptive signal explainable — the subject you engage
+            // with most. This is the same affinity used as a mild tie-break/lift;
+            // showing it keeps the personalisation transparent, never a black box.
+            if let top = topAffinitySubject {
+                Text("Sterkest tilknytning: \(top) — jeg løfter dette litt når rekkefølgen ellers er lik.")
+                    .font(.sportivistaTabular(.caption, weight: .regular))
+                    .foregroundStyle(SportivistaTokens.label.opacity(0.6))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             ForEach(memory.behavior) { stat in
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(stat.kind.label) \(behaviorSubject(stat))")
@@ -195,6 +204,13 @@ struct WhatIKnowView: View {
 
     private func behaviorSubject(_ stat: BehaviorStat) -> String {
         stat.isSport ? SportVocabulary.display(for: stat.token) : viewModel.entityName(stat.token)
+    }
+
+    /// WP-134 — the strongest-affinity subject, resolved to a readable name, for
+    /// the explainability line above. Nil when nothing has positive affinity yet.
+    private var topAffinitySubject: String? {
+        guard let first = Affinity(behavior: memory.behavior).topSubjects(limit: 1).first else { return nil }
+        return first.isSport ? SportVocabulary.display(for: first.token) : viewModel.entityName(first.token)
     }
 
     private func dateLabel(_ date: Date) -> String {

--- a/ios/SportivistaTests/AffinityTests.swift
+++ b/ios/SportivistaTests/AffinityTests.swift
@@ -1,0 +1,80 @@
+//
+//  AffinityTests.swift
+//  SportivistaTests
+//
+//  WP-134 — the pure affinity function: monotone in engagement, bounded/saturating
+//  so a heavy day can't dominate, dismiss-dominant (negative), unseen == 0, and
+//  entity+sport combine. No store, no UI.
+//
+
+import XCTest
+
+final class AffinityTests: XCTestCase {
+
+    private func stat(_ kind: BehaviorKind, _ token: String, sport: Bool, total: Int) -> BehaviorStat {
+        BehaviorStat(key: "behavior|\(kind.rawValue)|\(sport ? "s:" : "e:")\(token)",
+                     kind: kind, token: token, isSport: sport, total: total)
+    }
+
+    func test_unseenSubjectIsZero() {
+        let a = Affinity(behavior: [])
+        XCTAssertEqual(a.score(entityId: "carlsen"), 0)
+        XCTAssertEqual(a.score(sport: "golf"), 0)
+        XCTAssertTrue(a.isEmpty)
+    }
+
+    func test_moreOpensIsHigher_monotone() {
+        let few = Affinity(behavior: [stat(.open, "hovland", sport: false, total: 2)])
+        let many = Affinity(behavior: [stat(.open, "hovland", sport: false, total: 10)])
+        XCTAssertGreaterThan(many.score(entityId: "hovland"), few.score(entityId: "hovland"))
+        XCTAssertGreaterThan(few.score(entityId: "hovland"), 0)
+    }
+
+    func test_expandOutweighsOpen() {
+        let opened = Affinity(behavior: [stat(.open, "x", sport: false, total: 4)])
+        let expanded = Affinity(behavior: [stat(.expand, "x", sport: false, total: 4)])
+        XCTAssertGreaterThan(expanded.score(entityId: "x"), opened.score(entityId: "x"))
+    }
+
+    func test_dismissDominates_goesNegative() {
+        let a = Affinity(behavior: [
+            stat(.open, "x", sport: false, total: 2),
+            stat(.dismiss, "x", sport: false, total: 3), // -2*3 = -6 vs +2 → net negative
+        ])
+        XCTAssertLessThan(a.score(entityId: "x"), 0)
+    }
+
+    func test_scoreIsBounded_saturates() {
+        let huge = Affinity(behavior: [stat(.open, "x", sport: false, total: 100_000)])
+        let s = huge.score(entityId: "x")
+        XCTAssertLessThan(s, 1.0, "squash is bounded below 1")
+        XCTAssertGreaterThan(s, 0.99, "but a very heavy signal approaches 1")
+    }
+
+    func test_squashIsOddAndZeroAtZero() {
+        XCTAssertEqual(Affinity.squash(0), 0)
+        XCTAssertEqual(Affinity.squash(-5), -Affinity.squash(5), accuracy: 1e-12)
+    }
+
+    func test_entityAndSportCombine() {
+        let a = Affinity(behavior: [
+            stat(.open, "hovland", sport: false, total: 3),
+            stat(.open, "golf", sport: true, total: 5),
+        ])
+        // Combining the event's entity AND sport sums the raw scores → higher than either alone.
+        let both = a.score(entityId: "hovland", sport: "golf")
+        XCTAssertGreaterThan(both, a.score(entityId: "hovland"))
+        XCTAssertGreaterThan(both, a.score(sport: "golf"))
+    }
+
+    func test_topSubjects_ranksMostEngagedFirst_excludesNonPositive() {
+        let a = Affinity(behavior: [
+            stat(.open, "golf", sport: true, total: 10),
+            stat(.open, "chess", sport: true, total: 2),
+            stat(.dismiss, "esports", sport: true, total: 5), // negative → excluded
+        ])
+        let top = a.topSubjects(limit: 3)
+        XCTAssertEqual(top.map(\.token), ["golf", "chess"], "most-engaged first, negative dropped")
+        XCTAssertTrue(top.allSatisfy { $0.isSport })
+    }
+}


### PR DESCRIPTION
Første slice av WP-134 (adaptiv personalisering on-device, akse A): gjør det allerede-sporede `BehaviorCounter`-signalet (open/expand/dismiss per entitet/sport) til en mild, deterministisk affinitets-vekt.

## Kode
- `Memory/Affinity.swift` — ren Foundation-only funksjon. `raw = w_open·open + w_expand·expand − w_dismiss·dismiss` (asymmetrisk: dismiss tyngst, expand > open), squashet til (−1,1) via `x/(k+|x|)` så én tung dag aldri dominerer. `topSubjects()` for løft + forklarbarhet. Ligger i Memory/ (ikke Feed/) for å ikke dra `BehaviorStat` inn i widget-target.
- `WhatIKnowView` — «Sterkest tilknytning: X» forklarbarhets-linje. Tilpasningen er synlig, aldri en svart boks.
- `AffinityTests` (8): monotoni, expand>open, dismiss-dominans, metning/grense, odde squash, entitet+sport-kombinering, topSubjects.

## Kontrakt holdt
INGEN berøring av `isRelevant`/`mustWatch`/`isMustSee`/agenda-kronologi. **FeedVectorTests bit-like** (kjørt sammen med AffinityTests, 14 grønne). Affinitet er et løft PÅ toppen, ikke en ny relevans-gate.

## Slice 2 (dokumentert i WP-134)
Wire løftet inn i «Neste opp»/quick-pick-rekkefølge/assistent-defaults (tie-break der rekkefølge er vilkårlig).

## Utløser ved merge
iOS → TestFlight (ios/**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)