### PR TITLE
WP-138 slice 2: affinitets-løft i «Det du følger» + renummerering (134→138)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2040,7 +2040,7 @@ full iOS unit-suite + 4 schemes + gylne vektorer bit-like etter fixture-refrys
 (`test_starterPacks_areGroundedAndUnique` fortsatt grønn — pakkene grunnfester mot
 de nye id-ene).
 
-### WP-134 · Adaptiv personalisering on-device (akse A — «forbedre FOR brukeren»)
+### WP-138 · Adaptiv personalisering on-device (akse A — «forbedre FOR brukeren»)
 **Bakgrunn (data-strategi 20.07, seksjonen «BRUKERDATA → PRODUKTFORBEDRING»):**
 akse A er den umiddelbare, personvern-frie gevinsten — appen tilpasser seg DEG
 lokalt, null byte forlater enheten. Signalet finnes ALLEREDE: `BehaviorCounter`
@@ -2048,7 +2048,7 @@ lokalt, null byte forlater enheten. Signalet finnes ALLEREDE: `BehaviorCounter`
 `open`/`expand`/`dismiss` per entitet OG per sport (`behavior|open|<entityId>` /
 `behavior|open|s:<sport>`, `MemoryModels.swift:154-187`). I dag KONSUMERES det bare
 passivt — vist i «Hva jeg vet om deg» (`WhatIKnowView`) og lett brukt av
-assistenten — men INGENTING ordner eller løfter feeden ut fra det. WP-134 lukker
+assistenten — men INGENTING ordner eller løfter feeden ut fra det. WP-138 lukker
 den løkka: observert atferd → en mild, deterministisk affinitets-vekt.
 **Innhold:** (1) AFFINITET (ny ren funksjon, testbar, `Feed/` el. `Profile/`):
 `affinity(entityId|sport) = w_open·open + w_expand·expand − w_dismiss·dismiss`,

--- a/ios/Sportivista/Memory/Affinity.swift
+++ b/ios/Sportivista/Memory/Affinity.swift
@@ -2,7 +2,7 @@
 //  Affinity.swift
 //  Sportivista
 //
-//  WP-134 — on-device adaptive personalisation (axis A: "improve FOR the user").
+//  WP-138 — on-device adaptive personalisation (axis A: "improve FOR the user").
 //  Turns the observed `BehaviorStat` signal (open / expand / dismiss per entity
 //  and per sport — already recorded, already synced E2E-free via the CloudKit
 //  snapshot) into a mild, deterministic per-subject affinity score.

--- a/ios/Sportivista/Memory/WhatIKnowView.swift
+++ b/ios/Sportivista/Memory/WhatIKnowView.swift
@@ -123,7 +123,7 @@ struct WhatIKnowView: View {
     private var behaviorSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle("ATFERD (\(memory.behavior.count))")
-            // WP-134: make the adaptive signal explainable — the subject you engage
+            // WP-138: make the adaptive signal explainable — the subject you engage
             // with most. This is the same affinity used as a mild tie-break/lift;
             // showing it keeps the personalisation transparent, never a black box.
             if let top = topAffinitySubject {
@@ -206,7 +206,7 @@ struct WhatIKnowView: View {
         stat.isSport ? SportVocabulary.display(for: stat.token) : viewModel.entityName(stat.token)
     }
 
-    /// WP-134 — the strongest-affinity subject, resolved to a readable name, for
+    /// WP-138 — the strongest-affinity subject, resolved to a readable name, for
     /// the explainability line above. Nil when nothing has positive affinity yet.
     private var topAffinitySubject: String? {
         guard let first = Affinity(behavior: memory.behavior).topSubjects(limit: 1).first else { return nil }

--- a/ios/Sportivista/Profile/FollowPresenter.swift
+++ b/ios/Sportivista/Profile/FollowPresenter.swift
@@ -83,14 +83,24 @@ struct FollowPresenter {
     // MARK: - Sectioning by rule type
 
     /// The rules grouped into their display groups, in canonical order, dropping
-    /// empty groups. Order within a group is preserved (the profile is already
-    /// sorted by (sport, name)).
-    func sections(for rules: [InterestRule]) -> [FollowSection] {
-        var byGroup: [FollowGroup: [InterestRule]] = [:]
-        for rule in rules { byGroup[group(for: rule), default: []].append(rule) }
+    /// empty groups. Within a group, WP-138 applies a mild affinity LIFT: the
+    /// entities you engage with most float up, with the profile's existing
+    /// (sport, name) order as a STABLE tie-break — so an EMPTY affinity (a fresh
+    /// user, or no signal) reproduces today's order byte-for-byte. This is a lift
+    /// where the intra-group order was otherwise arbitrary (alphabetical), never a
+    /// change to WHICH rules appear.
+    func sections(for rules: [InterestRule], affinity: Affinity = Affinity(behavior: [])) -> [FollowSection] {
+        var byGroup: [FollowGroup: [(rule: InterestRule, idx: Int)]] = [:]
+        for (i, rule) in rules.enumerated() { byGroup[group(for: rule), default: []].append((rule, i)) }
         return FollowGroup.allCases.compactMap { g in
             guard let rs = byGroup[g], !rs.isEmpty else { return nil }
-            return FollowSection(group: g, rules: rs)
+            let lifted = rs.sorted { a, b in
+                let sa = affinity.score(entityId: a.rule.entityId, sport: a.rule.sport)
+                let sb = affinity.score(entityId: b.rule.entityId, sport: b.rule.sport)
+                if sa != sb { return sa > sb }
+                return a.idx < b.idx            // stable → empty affinity keeps original order
+            }
+            return FollowSection(group: g, rules: lifted.map(\.rule))
         }
     }
 

--- a/ios/Sportivista/Profile/FollowedListView.swift
+++ b/ios/Sportivista/Profile/FollowedListView.swift
@@ -62,7 +62,7 @@ struct FollowedListView: View {
                 }
                 .listRowBackground(SportivistaTokens.cell)
             } else if let snap = snapshot {
-                ForEach(snap.presenter.sections(for: rules)) { section in
+                ForEach(snap.presenter.sections(for: rules, affinity: Affinity(behavior: viewModel.memory.behavior))) { section in
                     Section {
                         ForEach(section.rules) { rule in
                             NavigationLink {

--- a/ios/SportivistaTests/AffinityTests.swift
+++ b/ios/SportivistaTests/AffinityTests.swift
@@ -2,7 +2,7 @@
 //  AffinityTests.swift
 //  SportivistaTests
 //
-//  WP-134 — the pure affinity function: monotone in engagement, bounded/saturating
+//  WP-138 — the pure affinity function: monotone in engagement, bounded/saturating
 //  so a heavy day can't dominate, dismiss-dominant (negative), unseen == 0, and
 //  entity+sport combine. No store, no UI.
 //

--- a/ios/SportivistaTests/FollowPresenterTests.swift
+++ b/ios/SportivistaTests/FollowPresenterTests.swift
@@ -87,6 +87,25 @@ final class FollowPresenterTests: XCTestCase {
         XCTAssertEqual(sections.map(\.group.header), ["UTØVERE", "LAG", "SPORTER"])
     }
 
+    // WP-138 — the affinity lift within a group (safe: not feed-vector-covered).
+    func test_sections_affinityLiftsEngagedEntity_emptyKeepsOriginalOrder() {
+        let idx = EntityIndex([
+            Entity(id: "a-1", name: "Aaa", sport: "tennis", type: "athlete"),
+            Entity(id: "a-2", name: "Bbb", sport: "tennis", type: "athlete"),
+            Entity(id: "a-3", name: "Ccc", sport: "tennis", type: "athlete"),
+        ])
+        let p = FollowPresenter(feed: feed(), index: idx, now: now)
+        let rules = [rule("a-1", "Aaa", "tennis"), rule("a-2", "Bbb", "tennis"), rule("a-3", "Ccc", "tennis")]
+
+        // Empty affinity → original order preserved byte-for-byte (stable tie-break).
+        XCTAssertEqual(p.sections(for: rules).first?.rules.map(\.entityId), ["a-1", "a-2", "a-3"])
+
+        // Engagement with a-3 (opened 5×) lifts it to the top; the rest keep order.
+        let behavior = [BehaviorStat(key: "behavior|open|e:a-3", kind: .open, token: "a-3", isSport: false, total: 5)]
+        let lifted = p.sections(for: rules, affinity: Affinity(behavior: behavior)).first?.rules.map(\.entityId)
+        XCTAssertEqual(lifted, ["a-3", "a-1", "a-2"])
+    }
+
     // MARK: - Next events (KOMMENDE + subtitle)
 
     func test_nextEvents_forTournament_matchesByHaystack() {


### PR DESCRIPTION
**Renummerering:** adaptiv-personalisering-arbeidet ble feilnummerert WP-134, men WP-134/135/136/137 er allerede tatt (dogfooding-fikser + auto-TestFlight). Rettet til **WP-138** (første ledige) i Affinity/WhatIKnowView/FollowPresenter/PLAN + testene. (Merget #362/#363s commit-meldinger sier fortsatt 134 — historikk; kilden er nå konsistent WP-138.)

**Slice 2 — wire løftet inn i en faktisk forbruker:**
- `FollowPresenter.sections(for:affinity:)` sorterer innen hver gruppe etter (affinitets-score ↓, opprinnelig indeks som STABIL tie-break). Tom affinitet → dagens (sport,navn)-rekkefølge byte-for-byte. Et løft der intra-gruppe-rekkefølgen ellers var vilkårlig, aldri en endring i HVILKE rader som vises.
- `FollowedListView` sender `Affinity(behavior: viewModel.memory.behavior)` inn.
- `FollowPresenterTests`: tom affinitet bevarer rekkefølge; engasjert entitet løftes øverst.

**Kontrakt holdt:** FeedVectorTests bit-like (kjørt sammen, grønne). Affinitet er et løft i en ikke-vektor-dekket flate, aldri en relevans-gate.

Utløser iOS → TestFlight ved merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)