### PR TITLE
icloud: aktiver web-sync (Development-token) + dato-skjør testfiks

### DIFF
--- a/docs/js/icloud-config.js
+++ b/docs/js/icloud-config.js
@@ -16,7 +16,10 @@
 
 window.SPORTIVISTA_ICLOUD = {
 	containerIdentifier: 'iCloud.app.sportivista.ios',
-	apiToken: '', // <-- paste the origin-restricted web token to turn iCloud sync ON
-	environment: 'production', // 'development' while testing against a Debug device build
+	// Origin-restricted Development web token (sportivista.com + chaerem.github.io).
+	// Public + origin-locked → safe to commit. Swap for a Production token (and set
+	// environment:'production') once the schema is deployed to Production.
+	apiToken: 'e6bf806bb7dd49e9c4519fca24e2714d747b0b102ed36aac61c20282a746c10d',
+	environment: 'development', // matches where the schema currently lives
 	zoneName: 'SportivistaProfile',
 };

--- a/docs/js/icloud-sync.js
+++ b/docs/js/icloud-sync.js
@@ -91,6 +91,11 @@ window.ssICloud = (function () {
 		if (!database) return null;
 		try {
 			const zoneName = cfg.zoneName || 'SportivistaProfile';
+			// Ensure the custom zone exists — either side may bootstrap it, so a web
+			// user who signs in BEFORE any device has written still gets a working
+			// zone (else the query fails with "zone not found"). Best-effort: a
+			// re-save of an existing zone / an unsupported call is harmless.
+			try { await database.saveRecordZones([{ zoneID: { zoneName } }]); } catch { /* exists / unsupported */ }
 			const resp = await database.performQuery({ recordType: RECORD_TYPE, zoneID: { zoneName } });
 			if (resp.hasErrors) return null;
 			const before = ssProfileLoad();
@@ -128,8 +133,9 @@ window.ssICloud = (function () {
 		async function whenSignedIn() {
 			say('Synker med iCloud …');
 			const res = await sync();
-			if (!res) { say('iCloud-synk er ikke tilgjengelig akkurat nå.'); return; }
-			say(`Synket med iCloud · la til ${res.added}, fjernet ${res.removed}.`);
+			if (!res) { say('Logget inn, men synk er ikke tilgjengelig akkurat nå — prøv igjen om litt.'); return; }
+			if (!res.added && !res.removed) say('Synket med iCloud — alt er oppdatert.');
+			else say(`Synket med iCloud · la til ${res.added}, fjernet ${res.removed}.`);
 			onSynced(res);
 		}
 	}

--- a/tests/build-port-report.test.js
+++ b/tests/build-port-report.test.js
@@ -213,14 +213,20 @@ describe("port 4 · participant status", () => {
 describe("integration · standalone CLI against a temp data dir", () => {
 	it("reads the pipeline outputs and writes a coloured port-report.json", () => {
 		const dataDir = tmpDir("ss-port-cli-");
-		fs.writeFileSync(path.join(dataDir, "coverage-audit.json"), JSON.stringify({ auditedAt: hoursAgo(6), gaps: [{ severity: "high", firstSeen: daysAgo(2), recurrences: 1, interest: "Tour de France" }] }));
-		fs.writeFileSync(path.join(dataDir, "verify-log.json"), JSON.stringify({ runAt: hoursAgo(6), checked: 10, amended: 1, notes: [] }));
+		// The CLI evaluates freshness against the REAL clock (Date.now()), so the
+		// fixtures must be relative to real-now — NOT the fixed test `NOW` — else a
+		// simple calendar rollover makes fresh files look stale (green → yellow).
+		const rNow = Date.now();
+		const rHoursAgo = (h) => new Date(rNow - h * 3600000).toISOString();
+		const rDaysAgo = (d) => new Date(rNow - d * 86400000).toISOString();
+		fs.writeFileSync(path.join(dataDir, "coverage-audit.json"), JSON.stringify({ auditedAt: rHoursAgo(6), gaps: [{ severity: "high", firstSeen: rDaysAgo(2), recurrences: 1, interest: "Tour de France" }] }));
+		fs.writeFileSync(path.join(dataDir, "verify-log.json"), JSON.stringify({ runAt: rHoursAgo(6), checked: 10, amended: 1, notes: [] }));
 		fs.writeFileSync(path.join(dataDir, "calibration-ledger.jsonl"), [
-			JSON.stringify({ checkedAt: hoursAgo(20), source: "pgatour.com", agreed: true }),
-			JSON.stringify({ checkedAt: hoursAgo(20), source: "pgatour.com", agreed: false }),
+			JSON.stringify({ checkedAt: rHoursAgo(20), source: "pgatour.com", agreed: true }),
+			JSON.stringify({ checkedAt: rHoursAgo(20), source: "pgatour.com", agreed: false }),
 		].join("\n") + "\n");
-		fs.writeFileSync(path.join(dataDir, "build-alert.json"), JSON.stringify({ ok: true, checkedAt: hoursAgo(1) }));
-		fs.writeFileSync(path.join(dataDir, "manifest.json"), JSON.stringify({ generatedAt: hoursAgo(1), files: {} }));
+		fs.writeFileSync(path.join(dataDir, "build-alert.json"), JSON.stringify({ ok: true, checkedAt: rHoursAgo(1) }));
+		fs.writeFileSync(path.join(dataDir, "manifest.json"), JSON.stringify({ generatedAt: rHoursAgo(1), files: {} }));
 		fs.writeFileSync(path.join(dataDir, "catalog.json"), JSON.stringify({ tier1: ["cycling"], tier2: { tournaments: [{ name: "Tour de France", aliases: ["TdF"], sport: "cycling" }] } }));
 
 		execFileSync("node", ["scripts/build-port-report.js"], { env: { ...process.env, SPORTSYNC_DATA_DIR: dataDir } });

--- a/tests/icloud-sync.test.js
+++ b/tests/icloud-sync.test.js
@@ -69,7 +69,11 @@ describe("mergeSnapshots", () => {
 });
 
 describe("enabled", () => {
-	it("is false with no token (sync stays off, board keeps working)", () => {
-		expect(W.ssICloud.enabled()).toBe(false); // icloud-config ships an empty token
+	it("is false when CloudKit JS isn't loaded, even with a token (sandbox has no CloudKit)", () => {
+		// The token is set in icloud-config.js, but enabled() also requires the
+		// CloudKit JS library — absent in the vm sandbox — so sync stays off here
+		// and the board keeps working on the local/QR profile.
+		expect(typeof W.CloudKit).toBe("undefined");
+		expect(W.ssICloud.enabled()).toBe(false);
 	});
 });


### PR DESCRIPTION
Aktiverer iCloud web-sync med Development-tokenet eieren genererte, + en pre-eksisterende dato-skjør testfiks som ellers blokkerer all CI i dag.

## iCloud
- `icloud-config.js`: origin-låst Development web-API-token (sportivista.com + chaerem.github.io), `environment: development` (der skjemaet ligger nå). Offentlig + origin-låst → trygt å committe.
- `icloud-sync.js`: `ensureZone` før query (begge sider kan bootstrappe custom-zonen, så web-innlogging før noen enhet har skrevet ikke feiler på «zone not found»); roligere status-meldinger.

## Testfiks (urelatert, pre-eksisterende)
`build-port-report` integrasjonstest skrev fixtures relativt til fast `NOW` men kjører CLI mot ekte `Date.now()` → dato-rollover (→ 21.07) fikk ferske filer til å se stale ut (green→yellow). Nå ekte-nå-relative helpere i testen.

Suiten grønn (792). Utløser web-deploy (docs/) ved merge; ingen ios/ → ingen TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)