### PR TITLE
web: hele siden bak Sign in with Apple

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -76,3 +76,24 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 ::selection { background: var(--accent); color: var(--accent-ink); }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+/* Whole-web-behind-login gate (eier-beslutning 21.07): body.gated hides all the
+   content and shows the Sign in with Apple overlay. Calm, one amber accent, no
+   spinner (DESIGN.md). The gate toggles via the #auth-gate `hidden` attribute. */
+body.gated .masthead,
+body.gated main,
+body.gated .site-footer { display: none !important; }
+.auth-gate { display: none; }
+body.gated .auth-gate {
+	display: flex; position: fixed; inset: 0; z-index: 100;
+	align-items: center; justify-content: center; padding: 24px; background: var(--bg);
+}
+.auth-gate-inner {
+	max-width: 420px; display: flex; flex-direction: column; align-items: center;
+	gap: 20px; text-align: center;
+}
+.auth-gate .wordmark { font-size: 30px; font-weight: 700; letter-spacing: -0.02em; }
+.auth-gate .wordmark-colon { color: var(--accent); }
+.auth-gate-lead { color: var(--fg-2); font-size: 15px; line-height: 1.55; margin: 0; }
+.auth-signin { min-height: 44px; display: flex; justify-content: center; }
+.auth-error { color: #FF453A; font-size: 13.5px; line-height: 1.5; margin: 0; max-width: 32ch; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,19 @@
 	<link rel="stylesheet" href="css/layout.css">
 	<link rel="stylesheet" href="css/cards.css">
 </head>
-<body>
+<body class="gated">
+	<!-- Whole-web-behind-login (eier-beslutning 21.07): nothing renders until Sign
+	     in with Apple. `body.gated` hides the content (base.css); auth-gate reveals
+	     it after sign-in. A missing token / failed CloudKit load shows a calm error
+	     here, never a blank page. -->
+	<div id="auth-gate" class="auth-gate">
+		<div class="auth-gate-inner">
+			<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
+			<p class="auth-gate-lead">Din personlige sportsoversikt. Logg inn med Apple for å se det du følger — synket med iPhone-appen via din egen iCloud.</p>
+			<div id="apple-sign-in-button" class="auth-signin"></div>
+			<p class="auth-error" id="auth-error" hidden></p>
+		</div>
+	</div>
 	<header class="masthead">
 		<div class="wrap masthead-inner">
 			<div class="mast-row mast-row-top">
@@ -59,8 +71,12 @@
 		<a id="app-promo-link" class="footer-alt footer-app" href="#" hidden title="Sportivista som iPhone-app — varsler, widget og assistent på lomma">Få iPhone-appen</a>
 		<span id="footer-stale" class="footer-stale" hidden></span>
 		<span id="footer-usage" class="footer-usage" hidden></span>
+		<span id="apple-sign-out-button" class="footer-signout" title="Logg ut av iCloud"></span>
 	</footer>
 
+	<script src="js/icloud-config.js"></script>
+	<script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" async></script>
+	<script src="js/icloud-sync.js"></script>
 	<script src="js/shared-constants.js"></script>
 	<script src="js/lens.js"></script>
 	<script src="js/profile-sync.js"></script>
@@ -73,6 +89,25 @@
 	<script src="js/profile-ui.js"></script>
 	<script src="js/chrome.js"></script>
 	<script>
+		// Whole-web-behind-login boot: dashboard.js's DOMContentLoaded calls
+		// window.ssBootGate(dashboard) when present (else inits directly — dev/test).
+		// Here we wait for the async CloudKit JS, then hand off to the auth gate;
+		// the board's init() runs only AFTER a successful Apple sign-in.
+		window.ssBootGate = function (dashboard) {
+			const tokenSet = window.SPORTIVISTA_ICLOUD && window.SPORTIVISTA_ICLOUD.apiToken;
+			if (!window.ssICloud || typeof ssICloud.gate !== 'function' || !tokenSet) {
+				dashboard.init(); // no gate configured → open (local dev / stripped build)
+				return;
+			}
+			let tries = 0;
+			const t = setInterval(() => {
+				const ready = typeof CloudKit !== 'undefined';
+				if (ready || ++tries > 40) { // ~10s, then gate shows the CloudKit-missing error
+					clearInterval(t);
+					ssICloud.gate({ onAuthed: () => dashboard.init() });
+				}
+			}, 250);
+		};
 		if ('serviceWorker' in navigator) {
 			window.addEventListener('load', () => {
 				navigator.serviceWorker.register('sw.js').then((reg) => {

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -608,4 +608,10 @@ class Dashboard {
 window.Dashboard = Dashboard;
 const dashboard = new Dashboard();
 window.dashboard = dashboard;
-document.addEventListener('DOMContentLoaded', () => dashboard.init());
+document.addEventListener('DOMContentLoaded', () => {
+	// Whole-web-behind-login: the board renders only after Sign in with Apple.
+	// index.html defines ssBootGate, which waits for CloudKit JS + auth, then calls
+	// dashboard.init(). If no gate is wired (dev / test / stripped build), init now.
+	if (typeof window.ssBootGate === 'function') window.ssBootGate(dashboard);
+	else dashboard.init();
+});

--- a/docs/js/icloud-sync.js
+++ b/docs/js/icloud-sync.js
@@ -140,5 +140,33 @@ window.ssICloud = (function () {
 		}
 	}
 
-	return { enabled, init, sync, mergeSnapshots, recordPayload, snapshotRecord, webRecordName };
+	/** Whole-web-behind-login gate: the page shows NOTHING until the user signs in
+	 *  with Apple. Reveals the board (after a first iCloud sync) on auth; re-shows
+	 *  the gate on sign-out. Never leaves a blank page — a missing token / failed
+	 *  CloudKit JS load shows a calm error in the gate, not emptiness.
+	 *  Elements (in index.html): #auth-gate (overlay), #apple-sign-in-button (CloudKit
+	 *  populates it), #auth-error (message), and body.gated (CSS hides the content). */
+	function gate(opts) {
+		const onAuthed = (opts && opts.onAuthed) || (() => {});
+		const gateEl = () => document.getElementById('auth-gate');
+		const errEl = () => document.getElementById('auth-error');
+		const showGate = () => { const g = gateEl(); if (g) g.hidden = false; if (document.body) document.body.classList.add('gated'); };
+		const showError = (m) => { showGate(); const e = errEl(); if (e) { e.textContent = m; e.hidden = false; } };
+		const reveal = async () => {
+			const e = errEl(); if (e) e.hidden = true;
+			try { await sync(); } catch { /* offline-first: reveal on the local profile anyway */ }
+			onAuthed();
+			if (document.body) document.body.classList.remove('gated');
+			const g = gateEl(); if (g) g.hidden = true;
+		};
+		if (typeof CloudKit === 'undefined') { showError('Kunne ikke laste iCloud-innlogging. Sjekk nettforbindelsen og last siden på nytt.'); return; }
+		if (!cfg.apiToken) { showError('iCloud-innlogging er ikke konfigurert.'); return; }
+		if (!configure()) { showError('iCloud-innlogging er utilgjengelig akkurat nå.'); return; }
+		showGate();
+		container.setUpAuth().then((userIdentity) => { if (userIdentity) reveal(); }).catch(() => showError('Kunne ikke starte Apple-innlogging. Last siden på nytt — og sjekk at du åpner sportivista.com.'));
+		container.whenUserSignsIn().then(reveal).catch(() => {});
+		container.whenUserSignsOut().then(showGate).catch(() => {});
+	}
+
+	return { enabled, init, gate, sync, mergeSnapshots, recordPayload, snapshotRecord, webRecordName };
 })();

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Sportivista v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-7';
+const CACHE_NAME = 'sportivista-v1-8';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [


### PR DESCRIPTION
Eier-beslutning: web låses ned bak iCloud-innlogging. Ingenting rendres før Sign in with Apple; profilen er iCloud (ingen lokal-only-divergens).

- #auth-gate-overlay + body.gated skjuler innhold til innlogging; logg-ut i footer.
- icloud-sync.js gate(): configure → setUpAuth → (auth) sync + avslør / (sign-out) vis gate. ALDRI blank side — token/CloudKit-feil gir rolig feilmelding.
- dashboard.js utsetter init til etter innlogging (ssBootGate); uten gate (dev/test) initer direkte.
- base.css gate-stiler; sw cache-bump.

Verifisert med screenshot (board skjult, gate vist). Suite 817 grønn. Docs-only → ingen TestFlight.

Tradeoff (godkjent): CloudKit JS blir single point of failure for hele siden → derfor tydelig feiltilstand. rediger/activity ikke gatet enda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)