### PR TITLE
web: gate rediger + activity (hele web bak innlogging)

### DIFF
--- a/docs/activity.html
+++ b/docs/activity.html
@@ -64,7 +64,7 @@
 		.back-link:hover { color: var(--accent); }
 	</style>
 </head>
-<body>
+<body class="gated">
 	<header class="masthead">
 		<div class="wrap masthead-inner">
 			<div class="mast-row mast-row-top">
@@ -99,7 +99,14 @@
 		<a class="back-link" href="./">← oversikten</a>
 	</footer>
 
+	<!-- Whole-web-behind-login: CloudKit JS + the shared gate (gate-boot.js). -->
+	<script src="js/icloud-config.js"></script>
+	<script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" async></script>
 	<script src="js/shared-constants.js"></script>
+	<script src="js/lens.js"></script>
+	<script src="js/profile-sync.js"></script>
+	<script src="js/icloud-sync.js"></script>
+	<script src="js/gate-boot.js"></script>
 	<script src="js/theme.js"></script>
 	<script>
 		// Repo slug (SS_REPO) and escapeHtml come from shared-constants.js; theme

--- a/docs/js/gate-boot.js
+++ b/docs/js/gate-boot.js
@@ -1,0 +1,44 @@
+// gate-boot.js — the shared whole-web-behind-login gate for the SECONDARY pages
+// (rediger.html, activity.html). index.html has its own inline wiring (it must
+// also defer the board's heavy init until after auth). Here the page's own init
+// runs normally and populates content that `body.gated` keeps hidden until Sign
+// in with Apple reveals it.
+//
+// Each page includes: icloud-config.js + cloudkit.js + icloud-sync.js + this.
+// No token configured → no-op (the page stays open, e.g. local dev / stripped).
+
+(function () {
+	var cfg = window.SPORTIVISTA_ICLOUD;
+	if (!cfg || !cfg.apiToken || !window.ssICloud || typeof window.ssICloud.gate !== 'function') return;
+
+	if (document.body) document.body.classList.add('gated');
+
+	// Inject a default overlay if the page didn't declare its own #auth-gate.
+	function ensureOverlay() {
+		if (document.getElementById('auth-gate')) return;
+		var g = document.createElement('div');
+		g.id = 'auth-gate';
+		g.className = 'auth-gate';
+		g.innerHTML = '<div class="auth-gate-inner">'
+			+ '<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>'
+			+ '<p class="auth-gate-lead">Logg inn med Apple for å fortsette.</p>'
+			+ '<div id="apple-sign-in-button" class="auth-signin"></div>'
+			+ '<p class="auth-error" id="auth-error" hidden></p></div>';
+		document.body.appendChild(g);
+	}
+
+	function start() {
+		if (document.body) document.body.classList.add('gated');
+		ensureOverlay();
+		var tries = 0;
+		var t = setInterval(function () {
+			if (typeof CloudKit !== 'undefined' || ++tries > 40) {
+				clearInterval(t);
+				window.ssICloud.gate({ onAuthed: function () { /* page init already ran; gate reveals the content */ } });
+			}
+		}, 250);
+	}
+
+	if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start);
+	else start();
+})();

--- a/docs/rediger.html
+++ b/docs/rediger.html
@@ -63,7 +63,7 @@
 		.edit-foot a { color: var(--accent); }
 	</style>
 </head>
-<body>
+<body class="gated">
 	<header class="masthead">
 		<div class="wrap masthead-inner">
 			<div class="mast-row mast-row-top">
@@ -86,79 +86,23 @@
 			<div id="add-suggestions" class="add-suggestions"></div>
 		</section>
 
-		<details class="add-box import-box" id="import-box">
-			<summary><h2 style="display:inline">Importer fra telefonen</h2></summary>
-			<p class="muted">Åpne appen din, del profilen som QR-kode eller lenke, og lim inn lenken her. Da får denne nettleseren de samme lagene og utøverne du følger — bare på din enhet, aldri via vår server.</p>
-			<textarea id="import-payload" class="add-search" rows="3" placeholder="Lim inn sportivista://profile?… eller lenken fra appen" style="width:100%;resize:vertical;font-family:inherit"></textarea>
-			<button type="button" id="import-run" class="btn">Slå sammen</button>
-			<p class="muted" id="import-status" hidden></p>
-		</details>
-
-		<details class="add-box icloud-box" id="icloud-box" hidden>
-			<summary><h2 style="display:inline">Synk med iCloud</h2></summary>
-			<p class="muted">Logg inn med Apple-ID-en din, så synker profilen automatisk begge veier med iPhone-appen — via din egen private iCloud, aldri via vår server.</p>
-			<div id="apple-sign-in-button"></div>
-			<div id="apple-sign-out-button"></div>
-			<p class="muted" id="icloud-status" hidden></p>
-		</details>
-
 		<div class="edit-foot">
 			<p class="muted">Endringer vises her når siden er bygd om (~et par minutter etter innsending). Vil du endre alt for hånd (aliaser, varsel-tid m.m.)? <a href="https://github.dev/CHaerem/sportivista/blob/main/scripts/config/interests.json" target="_blank" rel="noopener">Rediger fila direkte</a>.</p>
 		</div>
 	</main>
 
+	<!-- Whole-web-behind-login: CloudKit JS + the gate. gate-boot.js hides the page
+	     until Sign in with Apple. (The QR-import + manual "Synk med iCloud" panels
+	     were removed — redundant now that the whole site requires iCloud and the
+	     profile syncs automatically.) -->
+	<script src="js/icloud-config.js"></script>
+	<script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" async></script>
 	<script src="js/shared-constants.js"></script>
 	<script src="js/lens.js"></script>
 	<script src="js/profile-sync.js"></script>
+	<script src="js/icloud-sync.js"></script>
+	<script src="js/gate-boot.js"></script>
 	<script src="js/theme.js"></script>
 	<script src="js/edit.js"></script>
-	<!-- iCloud sync (optional): CloudKit JS from Apple's CDN + the public token.
-	     Both are inert until icloud-config.js carries a token — no dead network. -->
-	<script src="js/icloud-config.js"></script>
-	<script src="https://cdn.apple-cloudkit.com/ck/2/cloudkit.js" async></script>
-	<script src="js/icloud-sync.js"></script>
-	<script>
-		// Personal-profile import: paste an app QR/link (or arrive with a
-		// #profile=… / ?d=… fast-path from the phone's share sheet) and MERGE it
-		// into this device's local profile. No login, no server — the same codec
-		// the app uses. Calm status line, no spinner (DESIGN.md).
-		(function () {
-			const box = document.getElementById('import-box');
-			if (!box || typeof ssProfileImport !== 'function') return;
-			const field = document.getElementById('import-payload');
-			const btn = document.getElementById('import-run');
-			const status = document.getElementById('import-status');
-			const say = (msg) => { status.textContent = msg; status.hidden = false; };
-			async function run(payload) {
-				try {
-					const res = await ssProfileImport(payload);
-					say(`Lagt til: ${res.added} · fjernet: ${res.removed}. Åpne oversikten for å se dem.`);
-					field.value = '';
-				} catch (e) {
-					say(e && e.message === 'empty' ? 'Fant ingenting å importere i den lenken.'
-						: 'Kunne ikke lese lenken — sjekk at du limte inn hele.');
-				}
-			}
-			btn?.addEventListener('click', () => { if (field.value.trim()) run(field.value.trim()); });
-			// Fast-path: a share link like https://sportivista.com/rediger.html#profile=<payload>.
-			try {
-				const hash = (location.hash || '').replace(/^#/, '');
-				const q = new URLSearchParams(hash || location.search.replace(/^\?/, ''));
-				const payload = q.get('profile') || q.get('d');
-				if (payload) { box.open = true; field.value = payload; run(payload); }
-			} catch { /* ignore */ }
-		})();
-
-		// iCloud sync init — only when a token is configured (icloud-config.js).
-		// CloudKit JS loads async, so wait for it briefly; give up quietly after ~10s.
-		(function () {
-			if (!window.ssICloud || !window.SPORTIVISTA_ICLOUD || !window.SPORTIVISTA_ICLOUD.apiToken) return;
-			let tries = 0;
-			const t = setInterval(() => {
-				if (typeof CloudKit !== 'undefined') { clearInterval(t); window.ssICloud.init({ onSynced: () => {} }); }
-				else if (++tries > 40) clearInterval(t);
-			}, 250);
-		})();
-	</script>
 </body>
 </html>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Sportivista v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-8';
+const CACHE_NAME = 'sportivista-v1-9';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [
@@ -29,6 +29,7 @@ const SHELL_FILES = [
     '/js/edit.js',
     '/js/icloud-config.js',
     '/js/icloud-sync.js',
+    '/js/gate-boot.js',
     '/activity.html',
     '/styleguide.html'
 ];


### PR DESCRIPTION
Lukker direkte-URL-bypass: alle web-sider krever nå Sign in with Apple. Delt gate-boot.js for sekundærsidene; index beholder sin egen wiring. Fjernet den nå-overflødige QR-import + Synk-disclosuren på rediger (hele siden krever iCloud + synker automatisk). Suite 820 grønn. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)