### PR TITLE
icloud: snappy synk (forgrunn-resync + umiddelbar push)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,17 @@
 				const ready = typeof CloudKit !== 'undefined';
 				if (ready || ++tries > 40) { // ~10s, then gate shows the CloudKit-missing error
 					clearInterval(t);
-					ssICloud.gate({ onAuthed: () => dashboard.init() });
+					ssICloud.gate({
+						onAuthed: () => dashboard.init(),
+						// A foreground re-sync may have merged a phone change → re-render
+						// the board from the freshly-synced local profile.
+						onResync: () => {
+							if (typeof dashboard.applyProfile === 'function' && typeof ssProfileLoad === 'function') {
+								dashboard.applyProfile(ssProfileLoad());
+								dashboard.render();
+							}
+						},
+					});
 				}
 			}, 250);
 		};

--- a/docs/js/icloud-sync.js
+++ b/docs/js/icloud-sync.js
@@ -157,6 +157,9 @@ window.ssICloud = (function () {
 	 *  populates it), #auth-error (message), and body.gated (CSS hides the content). */
 	function gate(opts) {
 		const onAuthed = (opts && opts.onAuthed) || (() => {});
+		// Called after a FOREGROUND re-sync with the sync result, so the caller can
+		// re-render the board when returning to the tab picks up a phone change.
+		const onResync = (opts && opts.onResync) || (() => {});
 		const gateEl = () => document.getElementById('auth-gate');
 		const errEl = () => document.getElementById('auth-error');
 		// Reveal AT MOST ONCE per auth (setUpAuth AND whenUserSignsIn can both fire on
@@ -173,7 +176,27 @@ window.ssICloud = (function () {
 			onAuthed();
 			if (document.body) document.body.classList.remove('gated');
 			const g = gateEl(); if (g) g.hidden = true;
+			wireForegroundResync();
 		};
+
+		// Re-sync when the tab returns to the foreground, so a change made on the
+		// phone shows up without a manual refresh. Throttled (min 8s between rounds)
+		// and skipped while gated/offline; sync() is itself re-entrant-safe.
+		let lastResync = 0, foregroundWired = false;
+		function wireForegroundResync() {
+			if (foregroundWired) return;
+			foregroundWired = true;
+			const maybe = async () => {
+				if (!revealed || document.hidden) return;
+				const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+				if (now - lastResync < 8000) return;
+				lastResync = now;
+				const res = await sync();
+				if (res) onResync(res);
+			};
+			document.addEventListener('visibilitychange', maybe);
+			if (typeof window !== 'undefined') window.addEventListener('focus', maybe);
+		}
 		if (typeof CloudKit === 'undefined') { showError('Kunne ikke laste iCloud-innlogging. Sjekk nettforbindelsen og last siden på nytt.'); return; }
 		if (!cfg.apiToken) { showError('iCloud-innlogging er ikke konfigurert.'); return; }
 		if (!configure()) { showError('iCloud-innlogging er utilgjengelig akkurat nå.'); return; }

--- a/docs/js/profile-ui.js
+++ b/docs/js/profile-ui.js
@@ -57,6 +57,12 @@ Object.assign(window.Dashboard.prototype, {
 		else ssProfileFollow({ entityId: d.entityId, entityName: d.entityName, sport: d.entitySport, kind: d.kind });
 		this.applyProfile(ssProfileLoad());
 		this.render();
+		// Push the change to iCloud right away (fire-and-forget) so the phone picks
+		// it up on its next sync — no waiting for a later web sync round. No-op when
+		// iCloud isn't wired (dev/test) or the user isn't signed in.
+		if (window.ssICloud && typeof ssICloud.enabled === 'function' && ssICloud.enabled()) {
+			try { Promise.resolve(ssICloud.sync()).catch(() => {}); } catch { /* ignore */ }
+		}
 	},
 
 	/** Wire the deterministic assistant input: type a question → grounded answer


### PR DESCRIPTION
Gjør to-veis-synken live: (1) web re-synker når fanen kommer i forgrunn (throttlet 8s) → telefon-endringer vises uten manuell refresh; (2) følg/slutt på web pusher til iCloud med én gang. Begge guardet. Suite 820 grønn. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)