### PR TITLE
web: egen Apple-HIG login-knapp

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -100,5 +100,21 @@ body.gated .auth-gate {
 .auth-gate .wordmark { font-size: 30px; font-weight: 700; letter-spacing: -0.02em; }
 .auth-gate .wordmark-colon { color: var(--accent); }
 .auth-gate-lead { color: var(--fg-2); font-size: 15px; line-height: 1.55; margin: 0; }
-.auth-signin { min-height: 44px; display: flex; justify-content: center; }
+/* CloudKit renders its own (inconsistent) sign-in button into #apple-sign-in-button;
+   we hide it off-screen (kept renderable + clickable) and drive it from our own
+   Apple-HIG button below, so the design is fully ours. */
+#apple-sign-in-button { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); pointer-events: none; }
+.signin-apple {
+	display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+	min-width: 240px; height: 50px; padding: 0 22px; border: none; border-radius: 12px;
+	font-size: 17px; font-weight: 500; letter-spacing: -0.01em; cursor: pointer;
+	background: #000; color: #fff; -webkit-font-smoothing: antialiased; transition: opacity 0.12s;
+}
+.signin-apple:hover { opacity: 0.85; }
+.signin-apple:active { opacity: 0.7; }
+.signin-apple .apple-logo { width: 17px; height: 17px; fill: currentColor; margin-top: -2px; }
+/* Apple HIG: on dark backgrounds use a WHITE button, on light a BLACK one. */
+@media (prefers-color-scheme: dark) { .signin-apple { background: #fff; color: #000; } }
+:root[data-theme="light"] .signin-apple { background: #000; color: #fff; }
+:root[data-theme="dark"] .signin-apple { background: #fff; color: #000; }
 .auth-error { color: #FF453A; font-size: 13.5px; line-height: 1.5; margin: 0; max-width: 32ch; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,11 @@
 		<div class="auth-gate-inner">
 			<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
 			<p class="auth-gate-lead">Din personlige sportsoversikt. Logg inn med Apple for å se det du følger — synket med iPhone-appen via din egen iCloud.</p>
-			<div id="apple-sign-in-button" class="auth-signin"></div>
+			<button type="button" id="signin-apple" class="signin-apple">
+				<svg class="apple-logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
+				<span>Logg på med Apple</span>
+			</button>
+			<div id="apple-sign-in-button"></div>
 			<p class="auth-error" id="auth-error" hidden></p>
 		</div>
 	</div>

--- a/docs/js/gate-boot.js
+++ b/docs/js/gate-boot.js
@@ -21,8 +21,11 @@
 		g.className = 'auth-gate';
 		g.innerHTML = '<div class="auth-gate-inner">'
 			+ '<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>'
-			+ '<p class="auth-gate-lead">Logg inn med Apple for å fortsette.</p>'
-			+ '<div id="apple-sign-in-button" class="auth-signin"></div>'
+			+ '<p class="auth-gate-lead">Logg på med Apple for å fortsette.</p>'
+			+ '<button type="button" id="signin-apple" class="signin-apple">'
+			+ '<svg class="apple-logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>'
+			+ '<span>Logg på med Apple</span></button>'
+			+ '<div id="apple-sign-in-button"></div>'
 			+ '<p class="auth-error" id="auth-error" hidden></p></div>';
 		document.body.appendChild(g);
 	}

--- a/docs/js/icloud-sync.js
+++ b/docs/js/icloud-sync.js
@@ -201,6 +201,20 @@ window.ssICloud = (function () {
 		if (!cfg.apiToken) { showError('iCloud-innlogging er ikke konfigurert.'); return; }
 		if (!configure()) { showError('iCloud-innlogging er utilgjengelig akkurat nå.'); return; }
 		showGate();
+		// Drive our own Apple-HIG button (#signin-apple) by forwarding its click to
+		// CloudKit's hidden button — the click is a user gesture, so the auth popup
+		// is allowed. Falls back to un-hiding CloudKit's own button if ours is absent.
+		const custom = document.getElementById('signin-apple');
+		if (custom) {
+			custom.addEventListener('click', () => {
+				const el = document.querySelector('#apple-sign-in-button a, #apple-sign-in-button button, #apple-sign-in-button [role="button"], #apple-sign-in-button [tabindex]');
+				if (el && typeof el.click === 'function') { el.click(); return; }
+				// Safety net: our forward target isn't there → un-hide CloudKit's own
+				// button so the user is never stuck with a dead custom button.
+				const ck = document.getElementById('apple-sign-in-button');
+				if (ck) { ck.style.cssText = 'position:static;width:auto;height:auto;clip:auto;pointer-events:auto;margin-top:8px;'; custom.style.display = 'none'; }
+			});
+		}
 		container.setUpAuth().then((userIdentity) => { if (userIdentity) reveal(); }).catch((err) => {
 			try { console.error('[Sportivista] CloudKit setUpAuth failed:', err && (err.ckErrorCode || err.reason || err.message) || err, err); } catch (e) {}
 			const code = (err && (err.ckErrorCode || err.reason)) || '';

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Sportivista v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-9';
+const CACHE_NAME = 'sportivista-v1-10';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [


### PR DESCRIPTION
Erstattet CloudKits inkonsistente default-knapp med en egen «Logg på med Apple»-knapp (Apple-logo SVG + HIG-farger, tema-bevisst). CloudKits knapp skjules off-screen og driver av vår via klikk-videresending; sikkerhetsnett avslører den native om videresendingen svikter. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)