### PR TITLE
parity: single-source assistent-vokabularet (delt JSON)

### DIFF
--- a/docs/config/assistant-vocab.json
+++ b/docs/config/assistant-vocab.json
@@ -1,0 +1,40 @@
+{
+	"_readme": "SHARED assistant vocabulary — the single source read by BOTH the web (docs/js/assistant.js) and iOS (Assistant/AssistantVocab.swift, bundled via project.yml into the app + test targets, mirroring LensConfig). Change a keyword HERE and both platforms follow. This closes a real drift: iOS SportVocabulary was richer than the web's inline table. Values are the reconciled SUPERSET; keep them identical to what SportVocabulary (EntityIndex.swift) + AgendaFilterParser (AgendaFilter.swift) pinned. NOTE: the iOS AgendaFilterWindow enum has NO 'tonight' window, so iOS reads only today/tomorrow/this-week/this-weekend from windowTokens; 'tonight' is web-only (its answer path). Follow/question parsing stays per-platform (structurally different) and is NOT here.",
+	"version": 1,
+	"sportKeywords": {
+		"fotball": "football", "football": "football", "soccer": "football",
+		"golf": "golf",
+		"tennis": "tennis",
+		"sjakk": "chess", "chess": "chess",
+		"sykkel": "cycling", "sykling": "cycling", "landeveissykling": "cycling", "cycling": "cycling",
+		"friidrett": "athletics", "athletics": "athletics", "løping": "athletics",
+		"f1": "f1", "formel1": "f1", "formel": "f1", "formula1": "f1", "formula": "f1",
+		"esport": "esports", "esports": "esports", "cs2": "esports", "cs": "esports", "counterstrike": "esports",
+		"skiskyting": "biathlon", "biathlon": "biathlon",
+		"langrenn": "cross-country", "crosscountry": "cross-country",
+		"alpint": "alpine", "alpine": "alpine", "slalam": "alpine", "utfor": "alpine",
+		"hopp": "ski jumping", "skihopp": "ski jumping", "hopprenn": "ski jumping",
+		"kombinert": "nordic", "nordic": "nordic"
+	},
+	"categories": {
+		"keywords": {
+			"vintersport": "winter-sports", "vintersporter": "winter-sports",
+			"vinteridrett": "winter-sports", "vinteridretter": "winter-sports"
+		},
+		"members": {
+			"winter-sports": ["biathlon", "cross-country", "nordic", "alpine", "ski jumping"]
+		},
+		"display": {
+			"winter-sports": "vintersport"
+		}
+	},
+	"presentCues": ["vis", "filtrer", "fremhev"],
+	"resetWords": ["alt", "alle", "igjen", "allt"],
+	"windowTokens": {
+		"this-week": ["uka", "uken", "uke"],
+		"this-weekend": ["helga", "helgen", "helg"],
+		"tomorrow": ["morgen", "imorgen"],
+		"today": ["dag", "idag"],
+		"tonight": ["kveld", "ikveld"]
+	}
+}

--- a/docs/js/assistant.js
+++ b/docs/js/assistant.js
@@ -15,8 +15,8 @@
 // Depends on shared-constants.js + lens.js. Pure `ssAssistant(query, ctx)` is
 // unit-tested; the DOM wiring (bindAssistant) is a thin Dashboard extension.
 
-const SS_A_PRESENT_CUES = new Set(['vis', 'filtrer', 'fremhev']);
-const SS_A_RESET_WORDS = new Set(['alt', 'alle', 'igjen', 'allt']);
+// presentCues + resetWords now come from the shared assistant-vocab.json (below);
+// questionWords/followCues/unfollowPhrases stay web-only (iOS parses these differently).
 const SS_A_QUESTION_WORDS = new Set(['når', 'nar', 'hva', 'hvem', 'hvor', 'hvilke', 'hvilken', 'hvorfor', 'skjer']);
 const SS_A_FOLLOW_CUES = new Set(['følg', 'folg', 'følge', 'folge']);
 // Natural-form phrases; compared against ssNormalize(raw) via ssNormalize(phrase)
@@ -31,29 +31,59 @@ function ssATokens(s) {
 	return ssNormalize(s).replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean);
 }
 
-/** Invert lens-config.sportNb (+ common aliases) → norwegian keyword → canonical. */
-function ssASportKeywords(config) {
-	const cfg = (typeof ssLensConfig === 'function') ? ssLensConfig(config) : { sportNb: {} };
-	const map = {};
-	for (const [canon, nb] of Object.entries(cfg.sportNb || {})) map[ssNormalize(nb)] = canon;
-	Object.assign(map, {
-		fotball: 'football', sykkel: 'cycling', sykling: 'cycling', sjakk: 'chess',
-		esport: 'esports', cs2: 'esports', cs: 'esports', friidrett: 'athletics',
-		skiskyting: 'biathlon', langrenn: 'cross-country', alpint: 'alpine',
-		formel: 'f1', f1: 'f1', golf: 'golf', tennis: 'tennis',
-	});
-	return map;
+// Baked-in fallback identical to docs/config/assistant-vocab.json — the SHARED
+// vocabulary iOS bundles too (AssistantVocab.swift). Used when the fetch fails so
+// the assistant degrades to today's behaviour, never breaks.
+const SS_A_VOCAB_DEFAULTS = Object.freeze({
+	sportKeywords: {
+		fotball: 'football', football: 'football', soccer: 'football', golf: 'golf', tennis: 'tennis',
+		sjakk: 'chess', chess: 'chess', sykkel: 'cycling', sykling: 'cycling', landeveissykling: 'cycling', cycling: 'cycling',
+		friidrett: 'athletics', athletics: 'athletics', 'løping': 'athletics',
+		f1: 'f1', formel1: 'f1', formel: 'f1', formula1: 'f1', formula: 'f1',
+		esport: 'esports', esports: 'esports', cs2: 'esports', cs: 'esports', counterstrike: 'esports',
+		skiskyting: 'biathlon', biathlon: 'biathlon', langrenn: 'cross-country', crosscountry: 'cross-country',
+		alpint: 'alpine', alpine: 'alpine', slalam: 'alpine', utfor: 'alpine',
+		hopp: 'ski jumping', skihopp: 'ski jumping', hopprenn: 'ski jumping', kombinert: 'nordic', nordic: 'nordic',
+	},
+	categories: {
+		keywords: { vintersport: 'winter-sports', vintersporter: 'winter-sports', vinteridrett: 'winter-sports', vinteridretter: 'winter-sports' },
+		members: { 'winter-sports': ['biathlon', 'cross-country', 'nordic', 'alpine', 'ski jumping'] },
+		display: { 'winter-sports': 'vintersport' },
+	},
+	presentCues: ['vis', 'filtrer', 'fremhev'],
+	resetWords: ['alt', 'alle', 'igjen', 'allt'],
+	windowTokens: {
+		'this-week': ['uka', 'uken', 'uke'], 'this-weekend': ['helga', 'helgen', 'helg'],
+		tomorrow: ['morgen', 'imorgen'], today: ['dag', 'idag'], tonight: ['kveld', 'ikveld'],
+	},
+});
+
+/** Coalesce a possibly-partial assistant-vocab.json with the baked-in defaults. */
+function ssAssistantVocab(v) {
+	if (!v) return SS_A_VOCAB_DEFAULTS;
+	const d = SS_A_VOCAB_DEFAULTS;
+	return {
+		sportKeywords: v.sportKeywords || d.sportKeywords,
+		categories: v.categories || d.categories,
+		presentCues: v.presentCues || d.presentCues,
+		resetWords: v.resetWords || d.resetWords,
+		windowTokens: v.windowTokens || d.windowTokens,
+	};
 }
 
-/** The [start,end) window for a keyword — today/tomorrow/this-week/this-weekend,
- *  Oslo day-key bounds (mirror AgendaFilterWindow.range). Returns null if none. */
-function ssADetectWindow(tokenSet) {
-	const has = (w) => tokenSet.has(w);
-	if (has('uka') || has('uken') || has('uke')) return 'this-week';
-	if (has('helga') || has('helgen') || has('helg')) return 'this-weekend';
-	if (has('morgen') || has('imorgen')) return 'tomorrow';
-	if (has('dag') || has('idag')) return 'today';
-	if (has('kveld') || has('ikveld')) return 'tonight';
+/** Norwegian keyword → canonical sport tag, from the shared vocabulary. */
+function ssASportKeywords(vocab) {
+	return ssAssistantVocab(vocab).sportKeywords;
+}
+
+/** The named window for a token set — from windowTokens. Returns null if none.
+ *  Order (this-week → tonight) mirrors the web's answer/filter precedence. */
+function ssADetectWindow(tokenSet, vocab) {
+	const wt = ssAssistantVocab(vocab).windowTokens;
+	const hasAny = (list) => (list || []).some((w) => tokenSet.has(w));
+	for (const win of ['this-week', 'this-weekend', 'tomorrow', 'today', 'tonight']) {
+		if (hasAny(wt[win])) return win;
+	}
 	return null;
 }
 
@@ -102,6 +132,9 @@ function ssAssistant(query, ctx) {
 	const events = (ctx && ctx.events) || [];
 	const interests = ctx && ctx.interests;
 	const config = ctx && ctx.config;
+	const vocab = ssAssistantVocab(ctx && ctx.vocab); // shared assistant-vocab.json
+	const presentCues = new Set(vocab.presentCues);
+	const resetWords = new Set(vocab.resetWords);
 	const nowMs = (ctx && ctx.nowMs) || Date.now();
 	const raw = String(query || '').trim();
 	if (!raw) return { kind: 'help', text: 'Spør f.eks. «hva skjer i kveld?» eller «vis golf denne uka».', eventIds: [] };
@@ -122,13 +155,19 @@ function ssAssistant(query, ctx) {
 	}
 
 	// 2. Filter utterance (starts with a present cue).
-	if (tokens[0] && SS_A_PRESENT_CUES.has(tokens[0])) {
-		const sportMap = ssASportKeywords(config);
+	if (tokens[0] && presentCues.has(tokens[0])) {
+		const sportMap = ssASportKeywords(vocab);
+		const catKeywords = vocab.categories.keywords || {};
+		const catMembers = vocab.categories.members || {};
 		const sports = new Set();
-		for (const t of tokens) if (sportMap[t]) sports.add(sportMap[t]);
-		const window = ssADetectWindow(tokenSet);
+		for (const t of tokens) {
+			if (sportMap[t]) sports.add(sportMap[t]);
+			// Umbrella category ("vintersport") → its member sports (WP-64 parity).
+			if (catKeywords[t]) for (const s of catMembers[catKeywords[t]] || []) sports.add(s);
+		}
+		const window = ssADetectWindow(tokenSet, vocab);
 		if (!sports.size && !window) {
-			if (tokens.some((t) => SS_A_RESET_WORDS.has(t))) return { kind: 'reset', text: 'Viser alt igjen.', eventIds: [] };
+			if (tokens.some((t) => resetWords.has(t))) return { kind: 'reset', text: 'Viser alt igjen.', eventIds: [] };
 			return { kind: 'help', text: 'Hva vil du se? Prøv «vis golf» eller «vis i helga».', eventIds: [] };
 		}
 		let list = relevant.filter((e) => (!sports.size || sports.has((e.sport || '').toLowerCase()))
@@ -142,7 +181,7 @@ function ssAssistant(query, ctx) {
 
 	// 3. Question — window or entity.
 	const isQuestion = raw.includes('?') || (tokens[0] && SS_A_QUESTION_WORDS.has(tokens[0])) || tokenSet.has('skjer');
-	const window = ssADetectWindow(tokenSet);
+	const window = ssADetectWindow(tokenSet, vocab);
 	if (window) {
 		const list = relevant.filter((e) => ssAInWindow(e, window, nowMs)).sort(sortByTime);
 		const when = { today: 'I dag', tomorrow: 'I morgen', tonight: 'I kveld', 'this-week': 'Denne uka', 'this-weekend': 'I helga' }[window];

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -92,6 +92,9 @@ class Dashboard {
 		// iOS bundles. Passed to lens.js; a fetch failure → lens.js's baked-in
 		// defaults (byte-identical), so the board never breaks on a missing config.
 		this.lensConfig = await fetch('config/lens-config.json').then((r) => (r.ok ? r.json() : null)).catch(() => null);
+		// Shared assistant vocabulary (docs/config/assistant-vocab.json) — the SAME
+		// file iOS bundles. A fetch failure → assistant.js's baked-in defaults.
+		this.assistantVocab = await fetch('config/assistant-vocab.json').then((r) => (r.ok ? r.json() : null)).catch(() => null);
 		// The personal profile makes the board YOURS: a stored follow list
 		// (localStorage, synced via QR/iCloud) drives the accents, "dine lag og
 		// utøvere", and why-shown. An EMPTY profile == today's catalog-wide board,

--- a/docs/js/profile-ui.js
+++ b/docs/js/profile-ui.js
@@ -74,7 +74,7 @@ Object.assign(window.Dashboard.prototype, {
 		const run = () => {
 			const q = input.value.trim();
 			if (!q) { results.hidden = true; results.innerHTML = ''; return; }
-			const r = ssAssistant(q, { events: this.allEvents || [], interests: this.interests, config: this.lensConfig, nowMs: Date.now() });
+			const r = ssAssistant(q, { events: this.allEvents || [], interests: this.interests, config: this.lensConfig, vocab: this.assistantVocab, nowMs: Date.now() });
 			const rows = (r.eventIds || [])
 				.map((id) => (this._eventById && this._eventById.get(id)) || (this.allEvents || []).find((e) => e.id === id))
 				.filter(Boolean);

--- a/ios/Sportivista/Assistant/AgendaFilter.swift
+++ b/ios/Sportivista/Assistant/AgendaFilter.swift
@@ -149,11 +149,11 @@ struct AgendaFilter: Equatable, Sendable {
 /// has no present cue, so this returns nil for it).
 enum AgendaFilterParser {
 
-    /// The words that open a presentation utterance.
-    private static let presentCues: Set<String> = ["vis", "filtrer", "fremhev"]
+    /// The words that open a presentation utterance (shared assistant-vocab.json).
+    private static let presentCues: Set<String> = Set(AssistantVocab.shared.presentCues)
 
     /// Words that mean "clear the filter" (reset to show everything).
-    private static let resetWords: Set<String> = ["alt", "alle", "igjen", "allt"]
+    private static let resetWords: Set<String> = Set(AssistantVocab.shared.resetWords)
 
     static func parse(_ utterance: String, index: EntityIndex) -> AgendaFilter? {
         let tokens = EntityIndex.tokens(utterance)
@@ -201,10 +201,11 @@ enum AgendaFilterParser {
     /// The date window named in the utterance, if any. Reads normalised tokens
     /// («på»→"pa", «uka»→"uka"), so "denne uka"/"i dag"/"i morgen"/"i helga" land.
     static func detectWindow(set: Set<String>) -> AgendaFilterWindow? {
-        if set.contains("uka") || set.contains("uken") || set.contains("uke") { return .thisWeek }
-        if set.contains("helga") || set.contains("helgen") || set.contains("helg") { return .thisWeekend }
-        if set.contains("morgen") || set.contains("imorgen") { return .tomorrow }
-        if set.contains("dag") || set.contains("idag") { return .today }
+        let v = AssistantVocab.shared // shared window tokens (iOS ignores web's 'tonight')
+        if !set.isDisjoint(with: v.tokens(for: "this-week")) { return .thisWeek }
+        if !set.isDisjoint(with: v.tokens(for: "this-weekend")) { return .thisWeekend }
+        if !set.isDisjoint(with: v.tokens(for: "tomorrow")) { return .tomorrow }
+        if !set.isDisjoint(with: v.tokens(for: "today")) { return .today }
         return nil
     }
 }

--- a/ios/Sportivista/Assistant/AssistantVocab.swift
+++ b/ios/Sportivista/Assistant/AssistantVocab.swift
@@ -1,0 +1,82 @@
+//
+//  AssistantVocab.swift
+//  Sportivista
+//
+//  The SHARED assistant vocabulary, decoded once from the bundled
+//  `assistant-vocab.json` — the SAME file the web reads (docs/js/assistant.js) and
+//  iOS bundles (project.yml references ../docs/config/assistant-vocab.json into the
+//  app + test targets; NOT the widget — the widget runs no assistant). Change a
+//  keyword in that one file and both platforms follow. Mirrors LensConfig.
+//
+//  Fail-safe: a missing/unparseable resource returns `fallback`, whose values are
+//  byte-identical to the literals SportVocabulary/AgendaFilterParser pinned before
+//  the extraction — so a bad bundle degrades to today's behaviour, never a crash.
+//
+
+import Foundation
+
+struct AssistantVocab: Decodable, Sendable {
+    var sportKeywords: [String: String]
+    var categories: Categories
+    var presentCues: [String]
+    var resetWords: [String]
+    var windowTokens: [String: [String]]
+
+    struct Categories: Decodable, Sendable {
+        var keywords: [String: String]
+        var members: [String: [String]]
+        var display: [String: String]
+    }
+
+    /// Values identical to the pre-extraction literals — the safety net.
+    static let fallback = AssistantVocab(
+        sportKeywords: [
+            "fotball": "football", "football": "football", "soccer": "football",
+            "golf": "golf", "tennis": "tennis",
+            "sjakk": "chess", "chess": "chess",
+            "sykkel": "cycling", "sykling": "cycling", "landeveissykling": "cycling", "cycling": "cycling",
+            "friidrett": "athletics", "athletics": "athletics", "løping": "athletics",
+            "f1": "f1", "formel1": "f1", "formel": "f1", "formula1": "f1", "formula": "f1",
+            "esport": "esports", "esports": "esports", "cs2": "esports", "cs": "esports", "counterstrike": "esports",
+            "skiskyting": "biathlon", "biathlon": "biathlon",
+            "langrenn": "cross-country", "crosscountry": "cross-country",
+            "alpint": "alpine", "alpine": "alpine", "slalam": "alpine", "utfor": "alpine",
+            "hopp": "ski jumping", "skihopp": "ski jumping", "hopprenn": "ski jumping",
+            "kombinert": "nordic", "nordic": "nordic",
+        ],
+        categories: Categories(
+            keywords: [
+                "vintersport": "winter-sports", "vintersporter": "winter-sports",
+                "vinteridrett": "winter-sports", "vinteridretter": "winter-sports",
+            ],
+            members: ["winter-sports": ["biathlon", "cross-country", "nordic", "alpine", "ski jumping"]],
+            display: ["winter-sports": "vintersport"]
+        ),
+        presentCues: ["vis", "filtrer", "fremhev"],
+        resetWords: ["alt", "alle", "igjen", "allt"],
+        windowTokens: [
+            "this-week": ["uka", "uken", "uke"], "this-weekend": ["helga", "helgen", "helg"],
+            "tomorrow": ["morgen", "imorgen"], "today": ["dag", "idag"], "tonight": ["kveld", "ikveld"],
+        ]
+    )
+
+    static let shared: AssistantVocab = load()
+
+    static func load() -> AssistantVocab {
+        let bundle = Bundle(for: AssistantVocabBundleMarker.self)
+        guard
+            let url = bundle.url(forResource: "assistant-vocab", withExtension: "json"),
+            let data = try? Data(contentsOf: url),
+            let decoded = try? JSONDecoder().decode(AssistantVocab.self, from: data)
+        else {
+            return fallback
+        }
+        return decoded
+    }
+
+    /// The tokens for a window iOS supports (the AgendaFilterWindow cases). The web
+    /// also carries a `tonight` window; iOS's filter has none, so it's ignored here.
+    func tokens(for window: String) -> Set<String> { Set(windowTokens[window] ?? []) }
+}
+
+private final class AssistantVocabBundleMarker {}

--- a/ios/Sportivista/Assistant/EntityIndex.swift
+++ b/ios/Sportivista/Assistant/EntityIndex.swift
@@ -520,24 +520,9 @@ extension Entity {
 /// canonical English sport tag entities carry, and back to a Norwegian display
 /// word for the assistant's reasons.
 enum SportVocabulary {
-    static let keywordToSport: [String: String] = [
-        "fotball": "football", "football": "football", "soccer": "football",
-        "golf": "golf",
-        "tennis": "tennis",
-        "sjakk": "chess", "chess": "chess",
-        "sykkel": "cycling", "sykling": "cycling", "landeveissykling": "cycling", "cycling": "cycling",
-        "friidrett": "athletics", "athletics": "athletics", "løping": "athletics",
-        "f1": "f1", "formel1": "f1", "formel": "f1", "formula1": "f1", "formula": "f1",
-        "esport": "esports", "esports": "esports", "cs2": "esports", "cs": "esports", "counterstrike": "esports",
-        // WP-64: winter sports — the datahull that made "all vintersport"
-        // ungroundable. Each maps to the canonical tag build-entities.js
-        // publishes a sport entity under (sport-biathlon, sport-cross-country …).
-        "skiskyting": "biathlon", "biathlon": "biathlon",
-        "langrenn": "cross-country", "crosscountry": "cross-country",
-        "alpint": "alpine", "alpine": "alpine", "slalam": "alpine", "utfor": "alpine",
-        "hopp": "ski jumping", "skihopp": "ski jumping", "hopprenn": "ski jumping",
-        "kombinert": "nordic", "nordic": "nordic"
-    ]
+    // WP-XX: now sourced from the SHARED assistant-vocab.json (AssistantVocab) so
+    // keywords stay identical to the web. Same type/API — no consumer changes.
+    static let keywordToSport: [String: String] = AssistantVocab.shared.sportKeywords
 
     static let sportDisplay: [String: String] = [
         "football": "fotball", "golf": "golf", "tennis": "tennis", "chess": "sjakk",
@@ -552,20 +537,13 @@ enum SportVocabulary {
 
     /// A free-text umbrella keyword ("vintersport") → the canonical category key
     /// build-entities.js publishes a category entity under (category-<key>).
-    static let keywordToCategory: [String: String] = [
-        "vintersport": "winter-sports", "vintersporter": "winter-sports",
-        "vinteridrett": "winter-sports", "vinteridretter": "winter-sports"
-    ]
+    static let keywordToCategory: [String: String] = AssistantVocab.shared.categories.keywords
 
     /// A category key → the member sports it expands to («vintersport» → settet).
     /// This is the app-side expansion the server's category entity stands in for.
-    static let categoryToSports: [String: [String]] = [
-        "winter-sports": ["biathlon", "cross-country", "nordic", "alpine", "ski jumping"]
-    ]
+    static let categoryToSports: [String: [String]] = AssistantVocab.shared.categories.members
 
-    static let categoryDisplayNames: [String: String] = [
-        "winter-sports": "vintersport"
-    ]
+    static let categoryDisplayNames: [String: String] = AssistantVocab.shared.categories.display
 
     static func categoryDisplay(for category: String) -> String { categoryDisplayNames[category] ?? category }
 }

--- a/ios/SportivistaTests/AssistantVocabTests.swift
+++ b/ios/SportivistaTests/AssistantVocabTests.swift
@@ -1,0 +1,32 @@
+//
+//  AssistantVocabTests.swift
+//  SportivistaTests
+//
+//  Coherence gate mirroring tests/assistant-vocab.test.js: the BUNDLED
+//  assistant-vocab.json (AssistantVocab.shared) must equal the Swift `fallback`,
+//  so the fallback can't silently drift from the shared file. If this fails, the
+//  .json and AssistantVocab.fallback diverged — reconcile them.
+//
+
+import XCTest
+
+final class AssistantVocabTests: XCTestCase {
+    func test_bundledMatchesFallback() {
+        let shared = AssistantVocab.shared
+        let fb = AssistantVocab.fallback
+        XCTAssertEqual(shared.sportKeywords, fb.sportKeywords, "sportKeywords drifted from the fallback")
+        XCTAssertEqual(shared.categories.keywords, fb.categories.keywords)
+        XCTAssertEqual(shared.categories.members, fb.categories.members)
+        XCTAssertEqual(shared.categories.display, fb.categories.display)
+        XCTAssertEqual(shared.presentCues, fb.presentCues)
+        XCTAssertEqual(shared.resetWords, fb.resetWords)
+        XCTAssertEqual(shared.windowTokens, fb.windowTokens)
+    }
+
+    func test_categoryExpansionAndWindowsResolve() {
+        // A couple of sanity anchors that the vocab drives real behaviour.
+        XCTAssertEqual(SportVocabulary.keywordToSport["counterstrike"], "esports")
+        XCTAssertEqual(SportVocabulary.categoryToSports["winter-sports"]?.sorted(),
+                       ["alpine", "biathlon", "cross-country", "nordic", "ski jumping"])
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -66,6 +66,10 @@ targets:
       # (Feed/); change a value in that one file and both platforms follow.
       - path: ../docs/config/lens-config.json
         buildPhase: resources
+      # The SHARED assistant vocabulary (docs/config/assistant-vocab.json) —
+      # AssistantVocab.swift decodes it. NOT in the widget (no assistant there).
+      - path: ../docs/config/assistant-vocab.json
+        buildPhase: resources
     info:
       path: Sportivista/Info.plist
       properties:
@@ -293,6 +297,10 @@ targets:
       # and FeedVectorTests prove the extraction is byte-identical to the old
       # hard-coded constants.
       - path: ../docs/config/lens-config.json
+        buildPhase: resources
+      # Shared assistant vocabulary — AssistantVocab resolves it in the test bundle;
+      # AgendaFilterTests/EvalCorpusTests prove the extraction changed nothing.
+      - path: ../docs/config/assistant-vocab.json
         buildPhase: resources
     resources:
       - path: SportivistaTests/Fixtures

--- a/tests/PARITY.md
+++ b/tests/PARITY.md
@@ -1,0 +1,58 @@
+# Web ↔ app parity — how the two stay in sync
+
+The personalization domain is implemented on both platforms: **iOS Swift** (native,
+the primary) and **web JS** (a calm secondary surface). A native SwiftUI app and an
+HTML/DOM web app cannot share one runtime — and the WidgetKit extension (30MB, no
+JSCore) forces a native Swift lens to exist regardless — so a small algorithm
+surface is deliberately **twinned**. The discipline: **single-source the DATA,
+twin the ALGORITHMS, machine-guard the drift.**
+
+## Single-sourced (edit ONE file, both platforms follow)
+
+| Data | File | iOS reads via | Web reads via |
+|---|---|---|---|
+| Lens tunables | `docs/config/lens-config.json` | `Feed/LensConfig.swift` (bundled, incl. widget) | `docs/js/lens.js` (fetch + baked-in fallback) |
+| Assistant vocabulary | `docs/config/assistant-vocab.json` | `Assistant/AssistantVocab.swift` (bundled, app+tests, NOT widget) | `docs/js/assistant.js` (fetch + baked-in fallback) |
+| Golden feed vectors | `tests/fixtures/feed-vectors/*.json` | `FeedVectorTests` | `tests/feed-vectors.test.js` |
+| Profile CRDT vectors | `tests/fixtures/profile-payloads/*` + `tests/profile-vectors.test.js` | `ProfileCodecGoldenTests` | `tests/profile-codec-golden.test.js` |
+
+Both platforms carry a **baked-in fallback** identical to the JSON (so a missing
+bundle degrades, never crashes) — pinned by coherence tests
+(`tests/assistant-vocab.test.js` + `AssistantVocabTests.swift`).
+
+## Twinned + pinned (edit TWO files, CI catches a forgotten side)
+
+- **Lens predicates** — `docs/js/lens.js` ↔ `ios/Sportivista/Feed/FeedCompiler.swift`.
+  Pinned bit-for-bit by the 14 feed-vectors replayed on both sides. Deliberate
+  divergences live in `tests/fixtures/feed-vectors/DIVERGENCES.md` (e.g. must-see
+  naive-substring vs word-boundary — do NOT "unify").
+- **Profile CRDT + codec** — `docs/js/profile-sync.js` ↔ `ProfileMerge.swift` /
+  `ProfileSyncModel.swift` / `ProfileShareCodec.swift`. Pinned by the cross-platform
+  codec golden. Contract is **decode-compatibility, not byte-identity** (Apple `.zlib`
+  and Node `deflate-raw` emit different valid bytes).
+- **Deterministic assistant** — `docs/js/assistant.js` ↔ `Assistant/AgendaFilter.swift`
+  + `FeedQuery.swift` + parsers. The web is a deliberate SUBSET (a calm floor); iOS is
+  the superset (EntityIndex fuzzy resolution, the Foundation-Models path, memory).
+
+## The maintenance rules
+
+- **Tunable / vocabulary change** → edit ONE json in `docs/config/`. Both follow. No
+  code. (Update the baked-in fallback + the coherence test if you add a field.)
+- **Lens algorithm change** → edit `lens.js` **and** `FeedCompiler.swift` in the same
+  commit; add/update a feed-vector. Either suite alone failing = a forgotten side.
+- **Assistant semantic change** → edit `assistant.js` **and** the Swift parser; add a
+  case to `eval-corpus.json` first (corpus-driven).
+- **Codec change** → regenerate the Swift golden (`TEST_RUNNER_DUMP_GOLDEN=1`, see
+  `profile-codec-golden.test.js`) + both fixtures. Decode-compat is the contract.
+
+## The tripwire (when to reconsider a shared runtime)
+
+Consolidation to a single runtime was evaluated (SwiftWasm, JavaScriptCore) and
+rejected: the widget keeps a native Swift lens forever, the web has no build step,
+and "same semantics, mechanically pinned" is already the real invariant. BUT — **if
+the web assistant is ever promoted to a first-class, feature-parity surface** (full
+FeedQuery search + entity resolution + memory), the duplicated deterministic surface
+would grow from ~180 to ~1500+ lines and churn per feature. At that point, revisit a
+single JS deterministic-assistant core run via `JSContext` in the **main app only**
+(widget + Foundation-Models path untouched; lens/CRDT stay twinned). The shared
+`eval-corpus.json` gate is the safety net that migration would need.

--- a/tests/assistant-vocab.test.js
+++ b/tests/assistant-vocab.test.js
@@ -1,0 +1,40 @@
+// assistant-vocab.test.js — coherence gate for the SHARED assistant vocabulary.
+// docs/config/assistant-vocab.json is read by the web (assistant.js) AND bundled
+// into iOS (AssistantVocab.swift). This pins the web's baked-in fallback to the
+// shared file, so a keyword added to the JSON without updating the fallback (or
+// vice versa) fails CI. The iOS side is pinned by AgendaFilterTests running the
+// BUNDLED file; a Swift assertion (AssistantVocabTests) pins its fallback too.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import { createClientSandbox, loadClientScript } from "./helpers/load-client.js";
+
+const vocab = JSON.parse(fs.readFileSync(
+	path.resolve(process.cwd(), "docs", "config", "assistant-vocab.json"), "utf-8"));
+
+let W;
+beforeAll(() => {
+	const sandbox = createClientSandbox();
+	loadClientScript(sandbox, "shared-constants.js");
+	loadClientScript(sandbox, "lens.js");
+	loadClientScript(sandbox, "assistant.js");
+	W = sandbox.window;
+});
+
+describe("assistant-vocab.json ↔ web baked-in fallback", () => {
+	it("the web fallback matches the shared JSON field-for-field", () => {
+		const d = W.ssAssistantVocab(null); // → SS_A_VOCAB_DEFAULTS
+		expect(d.sportKeywords).toEqual(vocab.sportKeywords);
+		expect(d.categories).toEqual(vocab.categories);
+		expect(d.presentCues).toEqual(vocab.presentCues);
+		expect(d.resetWords).toEqual(vocab.resetWords);
+		expect(d.windowTokens).toEqual(vocab.windowTokens);
+	});
+
+	it("the assistant consumes a passed-in vocab (proves the wiring, not just the fallback)", () => {
+		expect(W.ssASportKeywords({ sportKeywords: { pingpong: "tabletennis" } })).toEqual({ pingpong: "tabletennis" });
+		const tokenSet = new Set(["søndag", "helga"]);
+		expect(W.ssADetectWindow(tokenSet, { windowTokens: { "this-weekend": ["helga"] } })).toBe("this-weekend");
+	});
+});

--- a/tests/assistant.test.js
+++ b/tests/assistant.test.js
@@ -52,6 +52,16 @@ describe("filter utterances", () => {
 	it("«vis alt» → reset", () => {
 		expect(ask("vis alt").kind).toBe("reset");
 	});
+	it("«vis vintersport» expands the umbrella category to its member sports (shared vocab)", () => {
+		const r = ask("vis vintersport");
+		expect(r.kind).toBe("filter");
+		expect(r.filter.sports.sort()).toEqual(["alpine", "biathlon", "cross-country", "nordic", "ski jumping"]);
+	});
+	it("recognises a keyword the old web table lacked (soccer → football)", () => {
+		const r = ask("vis soccer");
+		expect(r.kind).toBe("filter");
+		expect(r.filter.sports).toEqual(["football"]);
+	});
 });
 
 describe("entity next-event", () => {


### PR DESCRIPTION
Fable-spikens A+-steg — single-source dataen, twin algoritmene. Assistent-vokabularet var duplisert data som allerede hadde drevet (iOS var rikere).

- `docs/config/assistant-vocab.json`: én kilde (sport-nøkkelord, kategori-paraplyer, cues, reset, vindus-tokens). Reconciliert til iOS-supersettet → web vant nøkkelord + kategori-ekspansjon («vis vintersport»). Ingen regresjon.
- Web (assistant.js/dashboard.js/profile-ui) + iOS (AssistantVocab.swift + SportVocabulary + AgendaFilterParser) leser fra samme fil.
- Coherence-gater begge sider (bundlet == fallback). `tests/PARITY.md` dokumenterer vedlikeholds-reglene + tripwiren.

JS 824 grønn; iOS grønn; widget urørt. Utløser TestFlight (ios/-endring).