### PR TITLE
WP-154: web↔app-paritet — Nyheter-fane, rad-glyf+chevron, flytende assistent, Logg ut

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -350,10 +350,26 @@ skal likevel bestå denne før merge; håndhev det som kan håndheves i CI:
   (system → mørk → lys) som et *bevisst* unntak fra § Tema. iOS flyttet temavalget
   til Deg › Utseende, men web har ingen Deg-skjerm, så header-glyfen er den eneste
   plassen det kan bo.
-- **Sport-symbol-unntak (WP-128):** § Radens anatomis per-sport SF-symbol gjelder
-  KUN native flater. Web har ingen SF Symbols, og emoji/logo i kromet er forbudt
-  (§ Forbudsliste), så web signaliserer sport gjennom innholdet (tittel + meta),
-  ikke en per-rad-glyf. Et eget web-ikonsett innføres ikke bare for dette.
+- **Sport-symbol (web-paritet, WP-154 — LUKKER WP-128-unntaket):** § Radens
+  anatomis per-sport-glyf gjelder NÅ også web. SF Symbols finnes ikke på web, så
+  `docs/` bruker et eget lite SVG-ikonsett (`js/sport-icons.js`) tastet på de SAMME
+  kanoniske sport-taggene — stille (`tertiaryLabel`/`--fg-3`), ALDRI farget
+  (amber-budsjettet urørt), dekorativt (tittel/meta bærer sporten for AT). Ikke
+  emoji/logo (§ Forbudsliste holder — dette er rene SVG-glyfer). Bevisste web-avvik
+  fra SF-tabellen: vintersportene (langrenn/alpint/hopp/kombinert) deler ett
+  snøfnugg (en håndtegnet figur per gren er uleselig på 16px), skiskyting beholder
+  blinken (`target`).
+- **Disclosure-chevron (web-paritet, WP-154):** ekspanderbare web-rader bærer nå en
+  stille chevron (`--fg-3`, roteres 90° ved åpning under `prefers-reduced-motion`-
+  respekt) — samme trykkbarhets-signal som iOS' native `List`-chevron, portert til
+  web-SVG. (Erstatter den gamle «trykkbarhet kun via rytme»-web-regelen.)
+- **Uka | Nyheter + Hjelperen (web-paritet, WP-154):** web har nå den samme
+  segmenterte roten (§ Navigasjon — «Uka | Nyheter») og den flytende bunn-trailing
+  «Assistent»-knappen + samtalearket (§ Hjelperen), kollaps-på-scroll inkludert.
+  Nyhetstavla speiler § Nyheter (NYTT `news.json` · RESULTAT · FREMOVER; den
+  redaksjonelle overskriften bor fortsatt som web-heroens rolige linje, så § Nyheters
+  første seksjon gjentas ikke). Web-assistenten er den deterministiske gulvversjonen
+  (`js/assistant.js`) — samme inngang/ark-mønster, mindre motor.
 - **Stemme:** norsk, lavmælt, presis. «Kanal ukjent», ikke «Ingen streaming!».
   Aldri utropstegn i kromet. Feil forklarer hva og hvorfor.
 

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -1,7 +1,9 @@
 /* Sportivista — the agenda. One quiet list, grouped by day. The flat row language of
    DESIGN.md: hairlines, one amber dot for must-see. No cards, no washes, no
-   left-stripes, no chips, no chevrons, no emoji in the chrome. Each row answers
-   only: when · what · where to watch. */
+   left-stripes, no chips, no emoji in the chrome. Each row answers only: when ·
+   what · where to watch — plus, since WP-154 (owner ask, app-parity), a quiet
+   per-sport glyph and a disclosure chevron on expandable rows (both tertiaryLabel,
+   never amber; the app's AgendaView row anatomy, ported to web SVGs). */
 
 /* ── Live now: a quiet line at the very top, only when something is on ─────── */
 .live-now { margin: 18px 0 4px; }
@@ -61,15 +63,25 @@
 /* Row wrapper — the hairline lives here, below every row (incl. the day's last). */
 .ev-wrap { border-bottom: 1px solid var(--line); }
 
-/* Event row — [dot] [time] [what + meta] [ⓘ]. Flat. Scanned by rhythm, not boxes.
-   The whole row is tappable; that's signalled by rhythm + hover, never a chevron. */
+/* Event row — [dot] [time] [sport glyph] [what + meta] [ⓘ + chevron]. Flat,
+   scanned by rhythm. App-parity (WP-154): a quiet per-sport glyph names the sport
+   at a glance (iOS SportSymbol), and expandable rows carry a disclosure chevron. */
 .ev {
 	display: grid;
-	grid-template-columns: 14px var(--time-col) 1fr auto;
+	grid-template-columns: 14px var(--time-col) 18px 1fr auto;
 	column-gap: 12px;
 	align-items: start;
 	padding: 12px 0;
 }
+/* The per-sport glyph — quiet tertiaryLabel, NEVER coloured (the amber dot stays
+   the row's only accent). Fixed 18px box so every title aligns. */
+.ev-sport { width: 18px; height: 18px; color: var(--fg-3); margin-top: 1px; }
+/* Trailing group: the AI ⓘ then the disclosure chevron. */
+.ev-trail { display: inline-flex; align-items: center; gap: 6px; justify-self: end; margin-top: 1px; }
+.ev-chevron { width: 15px; height: 15px; color: var(--fg-3); transition: transform 0.15s ease; }
+.ev[aria-expanded="true"] .ev-chevron, .ev-chevron.open { transform: rotate(90deg); }
+.ev.expandable:hover .ev-chevron { color: var(--accent); }
+@media (prefers-reduced-motion: reduce) { .ev-chevron { transition: none; } }
 .ev.expandable { cursor: pointer; }
 .ev.expandable:hover { background: color-mix(in srgb, var(--fg) 5%, transparent); }
 .ev.expandable:hover .ev-title { color: var(--accent); }
@@ -113,13 +125,12 @@
 .ev-sep { color: var(--fg-3); }
 .ev-round { color: var(--fg-2); }
 
-/* ⓘ — mono, dempet, ONLY on AI-research rows; opens provenance in the detail. */
+/* ⓘ — dempet, ONLY on AI-research rows; opens provenance in the detail. Sits
+   inside .ev-trail (flex) now, so no grid justify-self. */
 .ev-info {
 	color: var(--fg-3);
 	font-size: 15px;
-	line-height: 1.35;
-	margin-top: 1px;
-	justify-self: end;
+	line-height: 1.2;
 }
 .ev.expandable:hover .ev-info { color: var(--accent); }
 
@@ -146,7 +157,8 @@
 /* Expanded detail — the "nice extra", quiet, only on demand. Indented under the
    title column; same flat row language, no card-in-a-card. */
 .ev-detail {
-	padding: 4px 0 16px calc(14px + 12px + var(--time-col) + 12px);
+	/* Indent to the title column: dot(14) + gap(12) + time + gap(12) + sport(18) + gap(12). */
+	padding: 4px 0 16px calc(14px + 12px + var(--time-col) + 12px + 18px + 12px);
 	display: grid;
 	grid-template-columns: minmax(0, 1fr);   /* one column, fills the width so .d-prose can break out cleanly */
 	gap: 6px;
@@ -160,8 +172,8 @@
    whole card, not a ~130px strip (WP-127). Short facts (Arena/Runde/Se på) keep
    key/value. The label sits on its own line above the paragraphs. */
 .ev-detail .d-prose {
-	margin-left: calc(-38px - var(--time-col));   /* = -(14 + 12 + time-col + 12), cancels .ev-detail's indent */
-	width: calc(100% + 38px + var(--time-col));
+	margin-left: calc(-68px - var(--time-col));   /* = -(14+12+time-col+12+18+12), cancels .ev-detail's indent */
+	width: calc(100% + 68px + var(--time-col));
 }
 .ev-detail .d-prose .d-k { display: block; min-width: 0; margin-bottom: 4px; }
 .ev-detail .d-prose .d-p { color: var(--fg-2); margin: 0 0 6px; line-height: 1.5; overflow-wrap: break-word; }
@@ -285,15 +297,129 @@
 }
 
 /* ── Assistant (deterministic Q&A over your feed) ───────────────────────────
-   Calm: one field, one amber focus ring, no spinner, no chrome. The answer is a
-   quiet line; matching events render as ordinary agenda rows below it. */
-.assistant { margin: 0 0 28px; }
+   App-parity (WP-154): a compact floating bottom-trailing BUTTON (never a dead
+   field) that opens a conversation sheet — mirrors the iOS AssistantButton +
+   AssistantSheetView. Calm: one amber accent (the glyph), no spinner, no chrome.
+   The answer is a quiet line; matching events render as ordinary agenda rows. */
+
+/* The floating entry — hugs its content, pinned bottom-right, above the board.
+   Amber glyph = the ONE accent and the tell that this pill IS a control. */
+.assistant-fab {
+	position: fixed; right: 20px; bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+	z-index: 60; display: inline-flex; align-items: center; gap: 8px;
+	padding: 12px 20px; min-height: 48px; border-radius: 999px; cursor: pointer;
+	font: inherit; font-size: 15px; font-weight: 600; color: var(--fg);
+	background: color-mix(in srgb, var(--accent) 12%, var(--cell));
+	border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28); backdrop-filter: blur(12px);
+	transition: padding 0.2s ease, gap 0.2s ease;
+}
+.assistant-fab:hover { border-color: color-mix(in srgb, var(--accent) 55%, var(--line)); }
+.assistant-fab .fab-glyph { width: 18px; height: 18px; fill: var(--accent); flex-shrink: 0; }
+.assistant-fab .fab-label { white-space: nowrap; }
+/* Collapsed (while scrolling): the bare glyph, near-circular — the iOS idiom. */
+.assistant-fab.collapsed { padding: 12px; gap: 0; }
+.assistant-fab.collapsed .fab-label {
+	max-width: 0; opacity: 0; overflow: hidden;
+	transition: max-width 0.2s ease, opacity 0.15s ease;
+}
+.assistant-fab .fab-label { max-width: 8em; opacity: 1; transition: max-width 0.2s ease, opacity 0.2s ease; }
+
+/* The conversation sheet — a bottom sheet with a backdrop, mirroring the iOS
+   .sheet(detents). Calm: rounded top, a grabber, no spinner. */
+.assistant-sheet { position: fixed; inset: 0; z-index: 70; }
+.assistant-sheet[hidden] { display: none; }
+.assistant-sheet .sheet-backdrop {
+	position: absolute; inset: 0; background: rgba(0, 0, 0, 0.45);
+	animation: ss-fade 0.18s ease;
+}
+.assistant-sheet .sheet-panel {
+	position: absolute; left: 0; right: 0; bottom: 0;
+	max-width: 640px; margin: 0 auto; box-sizing: border-box;
+	max-height: 80vh; overflow-y: auto; padding: 8px 20px calc(24px + env(safe-area-inset-bottom, 0px));
+	background: var(--bg); border-top-left-radius: 18px; border-top-right-radius: 18px;
+	border-top: 1px solid var(--line); box-shadow: 0 -8px 40px rgba(0, 0, 0, 0.4);
+	animation: ss-rise 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes ss-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes ss-rise { from { transform: translateY(24px); opacity: 0.6; } to { transform: translateY(0); opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+	.assistant-sheet .sheet-backdrop, .assistant-sheet .sheet-panel { animation: none; }
+}
+.sheet-grabber { width: 36px; height: 5px; border-radius: 3px; background: var(--fg-3); opacity: 0.5; margin: 6px auto 12px; }
+.sheet-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.sheet-title { font-size: 17px; font-weight: 700; color: var(--fg); }
+.sheet-close { font: inherit; font-size: 15px; color: var(--accent); background: none; border: none; cursor: pointer; padding: 4px; }
 .assistant-input {
-	width: 100%; box-sizing: border-box; font: inherit; font-size: 15px;
-	padding: 11px 14px; border: 1px solid var(--line); border-radius: 10px;
-	background: var(--surface); color: var(--fg);
+	width: 100%; box-sizing: border-box; font: inherit; font-size: 16px;
+	padding: 12px 14px; border: 1px solid var(--line); border-radius: 12px;
+	background: var(--cell); color: var(--fg);
 }
 .assistant-input::placeholder { color: var(--fg-3); }
 .assistant-input:focus { outline: none; border-color: var(--accent); }
+/* Example prompts (shown until the first answer) — quiet tappable rows, mirroring
+   the iOS sheet's example thread. */
+.assistant-examples { margin-top: 14px; }
+.assistant-examples[hidden] { display: none; }
+.ex-lead { font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--fg-3); margin: 0 0 6px; }
+.ex-row {
+	display: block; width: 100%; text-align: left; font: inherit; font-size: 15px;
+	color: var(--fg-2); background: none; border: none; border-bottom: 1px solid var(--line);
+	padding: 12px 0; cursor: pointer;
+}
+.ex-row:hover { color: var(--accent); }
 .assistant-results { margin-top: 14px; }
-.assistant-answer { font-size: 14px; color: var(--fg-2); margin: 0 0 10px; line-height: 1.5; }
+.assistant-results[hidden] { display: none; }
+.assistant-answer { font-size: 15px; color: var(--fg); margin: 0 0 10px; line-height: 1.5; }
+
+/* ── Root segmented — «Uka | Nyheter» (app-parity, WP-154) ───────────────────
+   A quiet native-style segmented control mirroring the iOS ContentView picker.
+   One amber accent on the selected segment; calm, no shadow. */
+.root-tabs {
+	display: inline-flex; align-self: stretch; width: 100%; box-sizing: border-box;
+	margin: 4px 0 20px; padding: 3px; gap: 3px;
+	background: var(--cell); border: 1px solid var(--line); border-radius: 12px;
+}
+.root-tab {
+	flex: 1; font: inherit; font-size: 14px; font-weight: 600; color: var(--fg-2);
+	padding: 8px 12px; border: none; border-radius: 9px; background: none; cursor: pointer;
+	transition: background 0.15s ease, color 0.15s ease;
+}
+.root-tab:hover { color: var(--fg); }
+.root-tab.is-active {
+	color: var(--fg); background: var(--bg);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
+}
+.root-view[hidden] { display: none; }
+/* Clear the floating assistant button so the last row / footer is never occluded
+   (the iOS safeAreaInset equivalent). */
+main.wrap { padding-bottom: 88px; }
+
+/* ── Nyheter board (twin of iOS NewsView) — NYTT + RESULTAT sections ──────────
+   Flat, hairline-separated rows in the agenda's language; no cards, one amber
+   accent (the source ↗ link). FREMOVER is the existing disclosure below. */
+.nw-section { margin: 0 0 26px; }
+.nw-head {
+	font-size: 13px; font-weight: 700; color: var(--fg-2);
+	letter-spacing: 0.08em; text-transform: uppercase; margin: 0 0 10px;
+}
+.nw-empty { color: var(--fg-3); font-size: 14px; margin: 0; }
+/* NYTT pointer row — the whole row is the link; title then a quiet meta line. */
+.nw-row {
+	display: block; padding: 12px 0; border-bottom: 1px solid var(--line);
+	color: inherit; text-decoration: none;
+}
+.nw-row:last-child { border-bottom: none; }
+.nw-title { display: block; font-size: 15px; color: var(--fg); line-height: 1.35; overflow-wrap: break-word; }
+.nw-row:hover .nw-title { color: var(--accent); }
+.nw-meta { display: block; margin-top: 3px; font-size: 13px; color: var(--fg-2); }
+.nw-sep { color: var(--fg-3); }
+.nw-source { color: var(--accent); }
+.nw-time, .nw-sport { color: var(--fg-2); }
+/* RESULTAT row — team – team on the left, the score (tabular) on the right. */
+.rs-row { display: flex; align-items: baseline; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--line); }
+.rs-row:last-child { border-bottom: none; }
+.rs-main { min-width: 0; flex: 1; }
+.rs-title { display: block; font-size: 15px; color: var(--fg); overflow-wrap: break-word; }
+.rs-meta { display: block; margin-top: 3px; font-size: 13px; color: var(--fg-2); }
+.rs-score { font-size: 15px; font-weight: 600; color: var(--fg); font-variant-numeric: tabular-nums; white-space: nowrap; }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -92,6 +92,11 @@ main { padding: 6px 0 72px; }
 .site-footer a { color: var(--fg-2); }
 .site-footer a:hover { color: var(--accent); }
 .site-footer a.footer-alt { color: var(--fg-3); font-size: 0.85em; }
+/* CloudKit's default sign-out control is hidden off-screen (kept renderable +
+   clickable); we drive our own calm footer «Logg ut» link from it. */
+#apple-sign-out-button { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); pointer-events: none; }
+.footer-signout-link { background: none; border: none; padding: 0; font-family: inherit; cursor: pointer; color: var(--fg-3); font-size: 0.85em; line-height: inherit; }
+.footer-signout-link:hover { color: var(--accent); }
 /* Quiet, dismissible iOS "add to Home Screen" hint (shown only when relevant).
    Flat — a hairline top/bottom, never a card. */
 .install-hint { margin: 4px 0 14px; padding: 12px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); color: var(--fg-2); font-size: 12.5px; line-height: 1.55; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,26 +53,66 @@
 			<h1 class="hero-headline" id="hero-headline"></h1>
 		</section>
 		<p class="install-hint" id="install-hint" hidden></p>
-		<section class="assistant" id="assistant">
-			<input type="text" id="assistant-input" class="assistant-input" autocomplete="off" placeholder="Spør: hva skjer i kveld? · vis golf · når spiller Liverpool?">
-			<div class="assistant-results" id="assistant-results" hidden></div>
-		</section>
-		<div class="live-now" id="live-now" hidden></div>
-		<div id="agenda"></div>
-		<!-- "Neste opp" sits UNDER the agenda (WP-148): a per-entity forward glance is a
-		     nice-to-have, but rendering it ABOVE the day-grouped agenda buried «I dag»
-		     under rows for events 8–14 days out — inverting «viktig + nært først». It
-		     keeps its nearest-first dedupe against what's already on the board; below
-		     the agenda it complements «Fremover»/«Dette dekker vi» instead of competing
-		     with today. (renderAgenda still runs before renderNextUp, so the dedupe set
-		     is populated regardless of DOM order.) -->
-		<section class="next-up" id="next-up" hidden></section>
-		<details class="fremover" id="fremover" hidden></details>
-		<details class="followed" id="followed" hidden>
-			<summary id="followed-summary"><span>Dette dekker vi</span><a class="followed-edit-top" href="rediger.html" onclick="event.stopPropagation()">Be om dekning</a></summary>
-			<div class="followed-body" id="followed-body"></div>
-		</details>
+		<!-- Root segmented (app-parity, WP-154): «Uka» (what's happening — the agenda)
+		     vs «Nyheter» (what's new — the four-section news board). Mirrors the iOS
+		     ContentView segmented control. Both cover the whole week. -->
+		<div class="root-tabs" role="tablist" aria-label="Visning">
+			<button type="button" class="root-tab is-active" data-view="uka" role="tab" aria-selected="true">Uka</button>
+			<button type="button" class="root-tab" data-view="nyheter" role="tab" aria-selected="false">Nyheter</button>
+		</div>
+		<div id="view-uka" class="root-view" role="tabpanel">
+			<div class="live-now" id="live-now" hidden></div>
+			<div id="agenda"></div>
+			<!-- "Neste opp" sits UNDER the agenda (WP-148): a per-entity forward glance is a
+			     nice-to-have, but rendering it ABOVE the day-grouped agenda buried «I dag»
+			     under rows for events 8–14 days out — inverting «viktig + nært først». It
+			     keeps its nearest-first dedupe against what's already on the board; below
+			     the agenda it complements «Fremover»/«Dette dekker vi» instead of competing
+			     with today. (renderAgenda still runs before renderNextUp, so the dedupe set
+			     is populated regardless of DOM order.) -->
+			<section class="next-up" id="next-up" hidden></section>
+			<details class="followed" id="followed" hidden>
+				<summary id="followed-summary"><span>Dette dekker vi</span><a class="followed-edit-top" href="rediger.html" onclick="event.stopPropagation()">Be om dekning</a></summary>
+				<div class="followed-body" id="followed-body"></div>
+			</details>
+		</div>
+		<div id="view-nyheter" class="root-view" role="tabpanel" hidden>
+			<!-- The four-section Nyheter board (twin of iOS NewsBoard/NewsView): NYTT
+			     (news.json pointers, lens-matched) · RESULTAT (followed teams' results)
+			     · FREMOVER (forvarsler beyond 14 d). The editorial headline stays the
+			     quiet hero line above, so its «I din verden i dag» section isn't repeated. -->
+			<div id="nyheter"></div>
+			<details class="fremover" id="fremover" hidden></details>
+		</div>
 	</main>
+
+	<!-- Assistent-inngang (app-parity, WP-154): a compact floating bottom-trailing
+	     button — sparkles + «Assistent» — that reads unmistakably as a button (never a
+	     dead field), collapsing to the bare glyph while the board scrolls (mirrors the
+	     iOS AssistantButton). Tapping it opens the conversation sheet below, where the
+	     input, example rows and grounded results live (mirrors AssistantSheetView). -->
+	<button type="button" id="assistant-fab" class="assistant-fab" aria-haspopup="dialog" aria-label="Assistent">
+		<svg class="fab-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.6l1.7 4.5L18 8.8l-4.3 1.7L12 15l-1.7-4.5L6 8.8l4.3-1.7L12 2.6zm6.5 9.4l.9 2.4 2.4.9-2.4.9-.9 2.4-.9-2.4-2.4-.9 2.4-.9.9-2.4zM6 13.5l.7 1.8 1.8.7-1.8.7L6 18.5l-.7-1.8L3.5 16l1.8-.7L6 13.5z"/></svg>
+		<span class="fab-label">Assistent</span>
+	</button>
+	<div id="assistant-sheet" class="assistant-sheet" hidden role="dialog" aria-modal="true" aria-label="Assistent">
+		<div class="sheet-backdrop" data-assistant-close></div>
+		<div class="sheet-panel">
+			<div class="sheet-grabber" aria-hidden="true"></div>
+			<div class="sheet-head">
+				<span class="sheet-title">Assistent</span>
+				<button type="button" class="sheet-close" data-assistant-close aria-label="Lukk">Lukk</button>
+			</div>
+			<input type="text" id="assistant-input" class="assistant-input" autocomplete="off" enterkeyhint="search" placeholder="Spør om det du følger …">
+			<div class="assistant-examples" id="assistant-examples">
+				<p class="ex-lead">Prøv for eksempel</p>
+				<button type="button" class="ex-row" data-ex="hva skjer i kveld?">hva skjer i kveld?</button>
+				<button type="button" class="ex-row" data-ex="vis golf denne uka">vis golf denne uka</button>
+				<button type="button" class="ex-row" data-ex="når spiller Liverpool?">når spiller Liverpool?</button>
+			</div>
+			<div class="assistant-results" id="assistant-results" hidden></div>
+		</div>
+	</div>
 
 	<footer class="site-footer wrap">
 		<span id="footer-updated"></span>
@@ -82,7 +122,11 @@
 		<a id="app-promo-link" class="footer-alt footer-app" href="#" hidden title="Sportivista som iPhone-app — varsler, widget og assistent på lomma">Få iPhone-appen</a>
 		<span id="footer-stale" class="footer-stale" hidden></span>
 		<span id="footer-usage" class="footer-usage" hidden></span>
-		<span id="apple-sign-out-button" class="footer-signout" title="Logg ut av iCloud"></span>
+		<!-- CloudKit renders its own (inconsistent) sign-out control into
+		     #apple-sign-out-button; we hide it off-screen and drive our own calm
+		     footer link (shown only when signed in). Same pattern as sign-in. -->
+		<span id="apple-sign-out-button" aria-hidden="true"></span>
+		<button type="button" id="signout-link" class="footer-alt footer-signout-link" hidden>Logg ut</button>
 	</footer>
 
 	<script src="js/icloud-config.js"></script>
@@ -92,12 +136,14 @@
 	<script src="js/lens.js"></script>
 	<script src="js/profile-sync.js"></script>
 	<script src="js/assistant.js"></script>
+	<script src="js/sport-icons.js"></script>
 	<script src="js/theme.js"></script>
 	<script src="js/dashboard.js"></script>
 	<script src="js/live.js"></script>
 	<script src="js/detail.js"></script>
 	<script src="js/followed.js"></script>
 	<script src="js/profile-ui.js"></script>
+	<script src="js/news-web.js"></script>
 	<script src="js/chrome.js"></script>
 	<script>
 		// Whole-web-behind-login boot: dashboard.js's DOMContentLoaded calls

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -43,6 +43,7 @@ class Dashboard {
 		this.maybeShowInstallHint();
 		this.renderAppPromo();
 		if (typeof this.bindAssistant === 'function') this.bindAssistant();
+		if (typeof this.bindRootTabs === 'function') this.bindRootTabs();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
 			if (this._liveVisible) this.onResume();
@@ -72,10 +73,15 @@ class Dashboard {
 		// catalog.json — NOT a personal interests.json (that is no longer published;
 		// the owner's personal view is the iOS app). `this.interests` stays null, so
 		// the personal accents/lens degrade to event-intrinsic signals only.
-		const [events, featured, standings, results, tracked, catalog, meta, usage] = await Promise.all([
+		const [events, featured, standings, results, tracked, catalog, meta, usage, news] = await Promise.all([
 			load('events.json'), load('featured.json'), load('standings.json'), load('recent-results.json'), load('tracked.json'), load('catalog.json'), load('meta.json'), load('usage-state.json'),
+			// news.json — lens-ready pointers (id/title/link/source/sport/entityIds/
+			// publishedAt, never article text). Feeds the Nyheter board's NYTT section.
+			load('news.json'),
 		]);
 		this.allEvents = Array.isArray(events) ? events : [];
+		// news.json may be a bare array or {items:[…]} — normalise to an array.
+		this.news = Array.isArray(news) ? news : (news && Array.isArray(news.items) ? news.items : []);
 		// Prefer the server's stable id (build-events.js, WP-02) — a hash of
 		// sport|title|time that survives re-renders/reorders. Fall back to the
 		// old array-index synthesis only for a payload from before this field
@@ -126,6 +132,7 @@ class Dashboard {
 		this.renderFremover();
 		this.renderNextUp();
 		this.renderFollowed();
+		if (typeof this.renderNyheter === 'function') this.renderNyheter();
 		this.renderFooter();
 		this.renderUsage();
 	}
@@ -497,12 +504,30 @@ class Dashboard {
 	 *  column so titles stay aligned. The dot is the whole must-see language. */
 	dotCell(on) { return on ? '<span class="ev-dot" aria-hidden="true"></span>' : '<span></span>'; }
 
-	/** The ⓘ provenance glyph — mono, dempet, ONLY on AI-research rows. Every
-	 *  other row keeps an empty cell (tappability is signalled by rhythm). */
+	/** The ⓘ provenance glyph — dempet, ONLY on AI-research rows; else nothing. */
 	infoCell(e) {
 		return e.source === 'ai-research'
 			? '<span class="ev-info" aria-label="Funnet av AI — trykk for kilder">ⓘ</span>'
-			: '<span></span>';
+			: '';
+	}
+
+	/** The per-sport row glyph (app-parity, WP-154). Guarded so a row still renders
+	 *  if sport-icons.js is absent (e.g. the vm-sandbox unit tests). */
+	sportIconCell(sport) { return typeof ssSportIcon === 'function' ? ssSportIcon(sport) : ''; }
+
+	/** A quiet disclosure chevron (app-parity, WP-154) — shown on expandable rows,
+	 *  rotated 90° when open. Decorative; the row's role="button"/aria-expanded
+	 *  carries the affordance for assistive tech. */
+	chevronCell(expandable, open) {
+		return expandable
+			? `<svg class="ev-chevron${open ? ' open' : ''}" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`
+			: '';
+	}
+
+	/** The trailing cell: the AI ⓘ (if any) then the disclosure chevron (if
+	 *  expandable), grouped so the grid keeps one trailing column. */
+	trailCell(e, expandable, open) {
+		return `<span class="ev-trail">${this.infoCell(e)}${this.chevronCell(expandable, open)}</span>`;
 	}
 
 	eventRow(e) {
@@ -523,8 +548,9 @@ class Dashboard {
 		return `<div class="ev-wrap"><div class="ev${this.isMustSee(e) ? ' must' : ''}${status ? ' cancelled' : ''}${done ? ' done' : ''}${expandable ? ' expandable' : ''}"${attrs}>
 			${this.dotCell(this.isMustSee(e))}
 			<span class="ev-time">${escapeHtml(this.timeLabel(e))}</span>
+			${this.sportIconCell(e.sport)}
 			<span class="ev-main"><span class="ev-title">${this.eventTitle(e)}</span>${this.eventMeta(e, trailing)}</span>
-			${this.infoCell(e)}
+			${this.trailCell(e, expandable, open)}
 		</div><div class="ev-detail"${open ? '' : ' hidden'}>${open ? this.eventDetail(e) : ''}</div></div>`;
 	}
 
@@ -538,8 +564,9 @@ class Dashboard {
 		return `<div class="ev-wrap"><div class="ev expandable series" role="button" tabindex="0" aria-expanded="${open}" data-event-id="${escapeHtml(s.id)}">
 			${this.dotCell(false)}
 			<span class="ev-time">${escapeHtml(this.osloTime(date))}</span>
+			${this.sportIconCell(s.nextStage.sport)}
 			<span class="ev-main"><span class="ev-title">${escapeHtml(s.tournament)}</span><span class="ev-meta">${meta}</span></span>
-			<span></span>
+			${this.trailCell(s.nextStage, true, open)}
 		</div><div class="ev-detail"${open ? '' : ' hidden'}>${open ? this.eventDetail(s) : ''}</div></div>`;
 	}
 

--- a/docs/js/icloud-sync.js
+++ b/docs/js/icloud-sync.js
@@ -166,7 +166,23 @@ window.ssICloud = (function () {
 		// a fresh sign-in — without this they'd each run a sync and race a 409).
 		// Reset on sign-out so a re-sign-in reveals again.
 		let revealed = false;
-		const showGate = () => { revealed = false; const g = gateEl(); if (g) g.hidden = false; if (document.body) document.body.classList.add('gated'); };
+		const signOutLink = () => document.getElementById('signout-link');
+		// Drive our own calm «Logg ut» footer link by forwarding its click to
+		// CloudKit's hidden sign-out control. Shown only when signed in (reveal),
+		// hidden again when the gate re-shows. No-op on pages without the link.
+		let signOutWired = false;
+		const wireSignOut = () => {
+			const link = signOutLink();
+			if (!link) return;
+			link.hidden = false;
+			if (signOutWired) return;
+			signOutWired = true;
+			link.addEventListener('click', () => {
+				const el = document.querySelector('#apple-sign-out-button a, #apple-sign-out-button button, #apple-sign-out-button [role="button"], #apple-sign-out-button [tabindex]');
+				if (el && typeof el.click === 'function') el.click();
+			});
+		};
+		const showGate = () => { revealed = false; const g = gateEl(); if (g) g.hidden = false; if (document.body) document.body.classList.add('gated'); const l = signOutLink(); if (l) l.hidden = true; };
 		const showError = (m) => { showGate(); const e = errEl(); if (e) { e.textContent = m; e.hidden = false; } };
 		const reveal = async () => {
 			if (revealed) return;
@@ -176,6 +192,7 @@ window.ssICloud = (function () {
 			onAuthed();
 			if (document.body) document.body.classList.remove('gated');
 			const g = gateEl(); if (g) g.hidden = true;
+			wireSignOut();
 			wireForegroundResync();
 		};
 

--- a/docs/js/news-web.js
+++ b/docs/js/news-web.js
@@ -1,0 +1,189 @@
+// news-web.js — the Nyheter board (app-parity, WP-154): a JS twin of the iOS
+// NewsBoard/NewsView. It renders three sections into #nyheter/#fremover under the
+// «Nyheter» segment (the fourth iOS section — the editorial headline — stays the
+// quiet hero line above, so it isn't repeated here):
+//
+//   1. NYTT     — news.json pointers, lens-matched, newest first (capped).
+//   2. RESULTAT — followed teams' recent football results (or catalog-wide).
+//   3. FREMOVER — forvarsler beyond 14 d (rendered by dashboard.renderFremover
+//                 into #fremover, which now lives inside the Nyheter view).
+//
+// The lens mirrors NewsLens.swift: a pointer is shown when its entityIds hit the
+// followed set OR its sport is a followed WHOLE-sport. An EMPTY profile is
+// catalog-wide (show all recent news) — the web's catalog-wide default elsewhere.
+//
+// Pure `ssNewsRelevant` / `ssCanonicalNewsSport` are unit-tested; the DOM wiring
+// (renderNyheter / bindRootTabs) is a thin Dashboard prototype extension.
+
+/** Normalise a news item's sport tag so "formula1" ≡ "f1" etc (mirrors
+ *  NewsLens.canonicalSport). Lowercased; a few common aliases folded in. */
+function ssCanonicalNewsSport(sport) {
+	const s = String(sport || '').trim().toLowerCase();
+	const alias = { formula1: 'f1', motorsport: 'f1', soccer: 'football' };
+	return alias[s] || s;
+}
+
+/** Is a news pointer in the lens? `lens` is either {catalogWide:true} (empty
+ *  profile → everything) or {entityIds:Set, sports:Set}. Mirrors NewsLens.matches:
+ *  an entityId hit OR a followed whole-sport hit. */
+function ssNewsRelevant(item, lens) {
+	if (!lens || lens.catalogWide) return true;
+	const ids = Array.isArray(item.entityIds) ? item.entityIds : [];
+	if (ids.some((id) => lens.entityIds.has(id))) return true;
+	return lens.sports.has(ssCanonicalNewsSport(item.sport));
+}
+
+// ── Dashboard prototype extension (DOM) ──────────────────────────────────────
+if (typeof Dashboard !== 'undefined') Object.assign(Dashboard.prototype, {
+	/** The news lens derived from the on-device profile. Whole-sport follows are
+	 *  the build-entities `sport-`/`category-` id convention (the web has no synced
+	 *  entity index — exactly the iOS `nil` fallback). Empty profile → catalog-wide. */
+	newsLens() {
+		const profile = this.profile;
+		if (!this.hasProfile || !profile || !Array.isArray(profile.rules)) return { catalogWide: true };
+		const live = profile.rules.filter((r) => !r.deleted).map((r) => r.rule || r);
+		const entityIds = new Set(), sports = new Set();
+		const catMembers = (this.assistantVocab && this.assistantVocab.categories && this.assistantVocab.categories.members) || {};
+		for (const rule of live) {
+			const id = rule && rule.entityId;
+			if (!id) continue;
+			entityIds.add(id);
+			if (id.indexOf('sport-') === 0) sports.add(ssCanonicalNewsSport(id.slice('sport-'.length)));
+			else if (id.indexOf('category-') === 0) {
+				const cat = id.slice('category-'.length);
+				for (const s of (catMembers[cat] || [])) sports.add(ssCanonicalNewsSport(s));
+			}
+		}
+		return { entityIds, sports };
+	},
+
+	/** A quiet Norwegian relative time ("3 t siden", "i går") for a news item's
+	 *  publishedAt, or "" when undateable. */
+	newsRelativeTime(iso) {
+		if (!iso) return '';
+		const then = Date.parse(iso);
+		if (Number.isNaN(then)) return '';
+		const diffMs = then - Date.now();
+		const mins = Math.round(diffMs / 60000);
+		try {
+			const rtf = new Intl.RelativeTimeFormat('nb', { numeric: 'auto', style: 'short' });
+			if (Math.abs(mins) < 60) return rtf.format(mins, 'minute');
+			const hrs = Math.round(mins / 60);
+			if (Math.abs(hrs) < 24) return rtf.format(hrs, 'hour');
+			return rtf.format(Math.round(hrs / 24), 'day');
+		} catch { return ''; }
+	},
+
+	/** The Norwegian display label for a canonical sport tag (shared lens-config). */
+	sportLabel(sport) {
+		const nb = this.lensConfig && this.lensConfig.sportNb;
+		const key = ssCanonicalNewsSport(sport);
+		return (nb && nb[key]) || sport || '';
+	},
+
+	/** One NYTT row: title (opens the source in a new tab — a pointer, never
+	 *  inlined article text), then a quiet sport · source ↗ · relative-time line. */
+	newsRow(item) {
+		const url = String(item.link || '');
+		const rel = this.newsRelativeTime(item.publishedAt);
+		const sep = '<span class="nw-sep"> · </span>';
+		// Skip the sport tag when it's the uninformative "general" (most RSS feeds)
+		// or empty — the source + time already carry the row (avoids "general ·" noise).
+		const canon = ssCanonicalNewsSport(item.sport);
+		const sport = (canon && canon !== 'general') ? `<span class="nw-sport">${escapeHtml(this.sportLabel(item.sport))}</span>` : '';
+		const meta = [
+			sport,
+			`<span class="nw-source">${escapeHtml(item.source || '')} ↗</span>`,
+			rel ? `<span class="nw-time">${escapeHtml(rel)}</span>` : '',
+		].filter(Boolean).join(sep);
+		const title = escapeHtml(item.title || '');
+		const inner = `<span class="nw-title">${title}</span><span class="nw-meta">${meta}</span>`;
+		return url
+			? `<a class="nw-row" href="${escapeHtml(url)}" target="_blank" rel="noopener">${inner}</a>`
+			: `<div class="nw-row">${inner}</div>`;
+	},
+
+	/** One RESULTAT row: a followed team's recent football result with its score. */
+	resultRow(r) {
+		const title = `${escapeHtml(r.homeTeam || '')} – ${escapeHtml(r.awayTeam || '')}`;
+		const hasScore = Number.isFinite(r.homeScore) && Number.isFinite(r.awayScore);
+		const score = hasScore ? `<span class="rs-score">${r.homeScore}–${r.awayScore}</span>` : '';
+		const meta = r.league ? `<span class="rs-meta">${escapeHtml(r.league)}</span>` : '';
+		return `<div class="rs-row"><span class="rs-main"><span class="rs-title">${title}</span>${meta}</span>${score}</div>`;
+	},
+
+	/** The lens-matched news, newest first, capped. */
+	newsItems(max = 20) {
+		const lens = this.newsLens();
+		return (this.news || [])
+			.filter((it) => ssNewsRelevant(it, lens))
+			.slice()
+			.sort((a, b) => (Date.parse(b.publishedAt || 0) - Date.parse(a.publishedAt || 0)))
+			.slice(0, max);
+	},
+
+	/** Followed teams' recent football results (newest first); catalog-wide when
+	 *  the profile is empty. Matched by an entity NAME hit on either team. */
+	resultItems(max = 8) {
+		const football = (this.recentResults && this.recentResults.football) || [];
+		const lens = this.newsLens();
+		let list = football;
+		if (!lens.catalogWide) {
+			const names = [];
+			const live = (this.profile && this.profile.rules || []).filter((r) => !r.deleted).map((r) => r.rule || r);
+			for (const rule of live) if (rule && rule.entityName) names.push(rule.entityName);
+			list = football.filter((r) => {
+				const hay = `${r.homeTeam || ''} ${r.awayTeam || ''}`;
+				return names.some((n) => ssContainsTerm(hay, n));
+			});
+		}
+		return list.slice()
+			.sort((a, b) => (Date.parse(b.date || 0) - Date.parse(a.date || 0)))
+			.slice(0, max);
+	},
+
+	/** Render the Nyheter board's NYTT + RESULTAT sections into #nyheter. FREMOVER
+	 *  is rendered separately by renderFremover into #fremover (below, same view). */
+	renderNyheter() {
+		const el = document.getElementById('nyheter');
+		if (!el) return;
+		const news = this.newsItems();
+		const results = this.resultItems();
+		let html = '';
+		html += '<section class="nw-section"><h2 class="nw-head">Nytt</h2>';
+		html += news.length
+			? news.map((it) => this.newsRow(it)).join('')
+			: '<p class="nw-empty">Ingen nyheter om det du følger akkurat nå.</p>';
+		html += '</section>';
+		if (results.length) {
+			html += '<section class="nw-section"><h2 class="nw-head">Resultat</h2>';
+			html += results.map((r) => this.resultRow(r)).join('');
+			html += '</section>';
+		}
+		el.innerHTML = html;
+	},
+
+	/** The Uka | Nyheter segmented control. Toggles the two root views; the FREMOVER
+	 *  disclosure lives inside the Nyheter view (rendered by renderFremover). */
+	bindRootTabs() {
+		const tabs = Array.from(document.querySelectorAll('.root-tab'));
+		const views = { uka: document.getElementById('view-uka'), nyheter: document.getElementById('view-nyheter') };
+		if (!tabs.length || !views.uka || !views.nyheter) return;
+		const show = (name) => {
+			for (const t of tabs) {
+				const on = t.dataset.view === name;
+				t.classList.toggle('is-active', on);
+				t.setAttribute('aria-selected', String(on));
+			}
+			views.uka.hidden = name !== 'uka';
+			views.nyheter.hidden = name !== 'nyheter';
+		};
+		for (const t of tabs) t.addEventListener('click', () => show(t.dataset.view));
+		show('uka');
+	},
+});
+
+// Node/vitest interop (pure helpers).
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = { ssNewsRelevant, ssCanonicalNewsSport };
+}

--- a/docs/js/profile-ui.js
+++ b/docs/js/profile-ui.js
@@ -65,15 +65,20 @@ Object.assign(window.Dashboard.prototype, {
 		}
 	},
 
-	/** Wire the deterministic assistant input: type a question → grounded answer
-	 *  + the matching event rows, in a calm panel (no spinner, no model). */
+	/** Wire the deterministic assistant: a floating bottom-trailing button opens a
+	 *  conversation sheet (mirrors the iOS AssistantButton + AssistantSheetView).
+	 *  Type a question → grounded answer + matching event rows; no spinner, no model. */
 	bindAssistant() {
+		const fab = document.getElementById('assistant-fab');
+		const sheet = document.getElementById('assistant-sheet');
 		const input = document.getElementById('assistant-input');
 		const results = document.getElementById('assistant-results');
-		if (!input || !results || typeof ssAssistant !== 'function') return;
+		const examples = document.getElementById('assistant-examples');
+		if (!fab || !sheet || !input || !results || typeof ssAssistant !== 'function') return;
+
 		const run = () => {
 			const q = input.value.trim();
-			if (!q) { results.hidden = true; results.innerHTML = ''; return; }
+			if (!q) { results.hidden = true; results.innerHTML = ''; if (examples) examples.hidden = false; return; }
 			const r = ssAssistant(q, { events: this.allEvents || [], interests: this.interests, config: this.lensConfig, vocab: this.assistantVocab, nowMs: Date.now() });
 			const rows = (r.eventIds || [])
 				.map((id) => (this._eventById && this._eventById.get(id)) || (this.allEvents || []).find((e) => e.id === id))
@@ -81,10 +86,36 @@ Object.assign(window.Dashboard.prototype, {
 			const body = rows.length ? rows.map((e) => this.eventRow(e)).join('') : '';
 			results.innerHTML = `<p class="assistant-answer">${escapeHtml(r.text)}</p>${body}`;
 			results.hidden = false;
+			if (examples) examples.hidden = true; // the thread replaces the examples (iOS parity)
 		};
+
+		// Sheet open/close. Focus the field on open so the keyboard/dictation is ready.
+		const open = () => {
+			sheet.hidden = false;
+			// Defer focus a frame so the rise animation doesn't fight the caret.
+			requestAnimationFrame(() => input.focus());
+		};
+		const close = () => { sheet.hidden = true; input.blur(); };
+		fab.addEventListener('click', open);
+		sheet.querySelectorAll('[data-assistant-close]').forEach((el) => el.addEventListener('click', close));
+		document.addEventListener('keydown', (evt) => { if (evt.key === 'Escape' && !sheet.hidden) close(); });
+
+		// Example rows fill the field and run — the sheet's calm guiding (iOS parity).
+		if (examples) examples.querySelectorAll('.ex-row').forEach((el) => el.addEventListener('click', () => {
+			input.value = el.dataset.ex || el.textContent || '';
+			run();
+		}));
+
 		input.addEventListener('keydown', (evt) => { if (evt.key === 'Enter') { evt.preventDefault(); run(); } });
-		// Clearing the field hides the panel again.
-		input.addEventListener('input', () => { if (!input.value.trim()) { results.hidden = true; results.innerHTML = ''; } });
+		// Clearing the field brings the examples back.
+		input.addEventListener('input', () => { if (!input.value.trim()) { results.hidden = true; results.innerHTML = ''; if (examples) examples.hidden = false; } });
+
+		// Collapse the FAB to the bare glyph while the board scrolls (iOS WP-146
+		// idiom); expanded at the top / at rest. A small dead-zone keeps a resting
+		// board expanded. Reduce Motion: the CSS transition is disabled there anyway.
+		const onScroll = () => { fab.classList.toggle('collapsed', window.scrollY > 40); };
+		window.addEventListener('scroll', onScroll, { passive: true });
+		onScroll();
 	},
 
 	/** Recompute interests/covers from a profile state (mirrors loadData's branch). */

--- a/docs/js/sport-icons.js
+++ b/docs/js/sport-icons.js
@@ -1,0 +1,54 @@
+// sport-icons.js — inline SVG sport glyphs for the agenda rows (web twin of the
+// iOS SportSymbol registry, WP-108). SF Symbols don't exist on web, so these are
+// simple line icons keyed by the SAME canonical sport tags the pipeline emits.
+// Quiet (tertiaryLabel, --fg-3), NEVER coloured (the amber must-see dot stays the
+// row's only accent), decorative (aria-hidden — the title/meta carries the sport
+// for assistive tech). One glyph per sport so "which sport" reads at a glance.
+//
+// Deliberate web divergences from the SF Symbol table (documented, not accidental):
+//   • the winter sports (cross-country/alpine/ski jumping/nordic) share one
+//     snowflake glyph — SF distinguishes downhill/crosscountry figures, but a
+//     hand-drawn figure per discipline is illegible at 16px. biathlon keeps its
+//     own target (the rifle half that defines it), matching SF's `target` choice.
+//   • fallback is a calendar, mirroring SportSymbol.fallback.
+
+// Canonical/alias sport tag → glyph key.
+const SS_SPORT_ICON_ALIAS = {
+	football: 'football', soccer: 'football',
+	golf: 'golf', tennis: 'tennis', cycling: 'cycling', athletics: 'athletics',
+	f1: 'f1', formula1: 'f1', motorsport: 'f1',
+	esports: 'esports', chess: 'chess',
+	biathlon: 'biathlon',
+	'cross-country': 'snow', alpine: 'snow', 'ski jumping': 'snow', nordic: 'snow',
+};
+
+// glyph key → inner SVG markup (each carries its own fill/stroke; the wrapper only
+// provides the 24×24 viewBox + class). Kept minimal and recognisable at 16px.
+const SS_SPORT_ICON_PATHS = {
+	football: '<circle cx="12" cy="12" r="8.3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M12 7.6l3.4 2.5-1.3 4h-4.2L8.6 10.1z" fill="currentColor"/>',
+	golf: '<path d="M7.6 21V3.4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M7.6 4.4l8.2 2.5-8.2 2.5z" fill="currentColor"/>',
+	tennis: '<circle cx="12" cy="12" r="8.3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M6 6.4c3.1 2.9 3.1 8.5 0 11.4M18 6.4c-3.1 2.9-3.1 8.5 0 11.4" fill="none" stroke="currentColor" stroke-width="1.3"/>',
+	cycling: '<g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="16.4" r="3.3"/><circle cx="18" cy="16.4" r="3.3"/><path d="M6 16.4l4.2-7h4.3l3.5 7M9.6 9.4h4.4"/></g>',
+	athletics: '<g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="14.6" cy="5" r="1.8" fill="currentColor" stroke="none"/><path d="M14 8.6l-2.6 3.6 3 2 1 4.8M11.4 12.2l-3.4-1M15 9.7l3 1.2 2-1.9M12 15.2l-2.6 4.4"/></g>',
+	f1: '<path d="M6 21V4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5h4v3h4V5h4v3h-4v3h4v3h-4v-3h-4v3H6v-3h4V8H6z" fill="currentColor"/>',
+	esports: '<path d="M8.2 9h7.6a4.8 4.8 0 0 1 4.8 4.9 2.8 2.8 0 0 1-5 1.7L14.2 14H9.8l-1.4 1.6a2.8 2.8 0 0 1-5-1.7A4.8 4.8 0 0 1 8.2 9z" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M6.6 12h2.2M7.7 10.9v2.2" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/><circle cx="15.6" cy="12" r="0.95" fill="currentColor"/>',
+	chess: '<path d="M5 9.2l2.6 2L12 6l4.4 5.2 2.6-2-1.5 8H6.5z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>',
+	snow: '<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"><path d="M12 3v18M4.2 7.5l15.6 9M19.8 7.5l-15.6 9"/><path d="M12 6.6l2-2M12 6.6l-2-2M12 17.4l2 2M12 17.4l-2 2"/></g>',
+	biathlon: '<circle cx="12" cy="12" r="8.3" fill="none" stroke="currentColor" stroke-width="1.4"/><circle cx="12" cy="12" r="4.4" fill="none" stroke="currentColor" stroke-width="1.4"/><circle cx="12" cy="12" r="1.3" fill="currentColor"/>',
+	fallback: '<rect x="4" y="5" width="16" height="15" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M4 9.5h16M8 3.5v3M16 3.5v3" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>',
+};
+
+/** Glyph key for a sport tag (canonical or alias), else 'fallback'. */
+function ssSportIconKey(sport) {
+	const s = String(sport || '').trim().toLowerCase();
+	return SS_SPORT_ICON_ALIAS[s] || 'fallback';
+}
+
+/** The inline SVG for a sport tag — a quiet, decorative row glyph. */
+function ssSportIcon(sport) {
+	const inner = SS_SPORT_ICON_PATHS[ssSportIconKey(sport)] || SS_SPORT_ICON_PATHS.fallback;
+	return `<svg class="ev-sport" viewBox="0 0 24 24" aria-hidden="true">${inner}</svg>`;
+}
+
+if (typeof window !== 'undefined') { window.ssSportIcon = ssSportIcon; window.ssSportIconKey = ssSportIconKey; }
+if (typeof module !== 'undefined' && module.exports) module.exports = { ssSportIcon, ssSportIconKey };

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Sportivista v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-10';
+const CACHE_NAME = 'sportivista-v1-12';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [
@@ -18,12 +18,14 @@ const SHELL_FILES = [
     '/js/lens.js',
     '/js/profile-sync.js',
     '/js/assistant.js',
+    '/js/sport-icons.js',
     '/js/theme.js',
     '/js/dashboard.js',
     '/js/live.js',
     '/js/detail.js',
     '/js/followed.js',
     '/js/profile-ui.js',
+    '/js/news-web.js',
     '/js/chrome.js',
     '/rediger.html',
     '/js/edit.js',

--- a/tests/news-web.test.js
+++ b/tests/news-web.test.js
@@ -1,0 +1,50 @@
+// news-web.test.js — the Nyheter board's pure lens helpers (app-parity, WP-154).
+// Mirrors NewsLens.swift: entityId hit OR followed whole-sport; empty profile is
+// catalog-wide. The DOM rendering (renderNyheter/bindRootTabs) is a thin Dashboard
+// prototype extension covered by the client render tests; here we pin the lens.
+
+import { describe, it, expect } from "vitest";
+import { ssNewsRelevant, ssCanonicalNewsSport } from "../docs/js/news-web.js";
+
+describe("ssCanonicalNewsSport", () => {
+	it("folds aliases and lowercases", () => {
+		expect(ssCanonicalNewsSport("formula1")).toBe("f1");
+		expect(ssCanonicalNewsSport("motorsport")).toBe("f1");
+		expect(ssCanonicalNewsSport("soccer")).toBe("football");
+		expect(ssCanonicalNewsSport("Football")).toBe("football");
+		expect(ssCanonicalNewsSport(" Golf ")).toBe("golf");
+	});
+	it("is empty-safe", () => {
+		expect(ssCanonicalNewsSport("")).toBe("");
+		expect(ssCanonicalNewsSport(null)).toBe("");
+		expect(ssCanonicalNewsSport(undefined)).toBe("");
+	});
+});
+
+describe("ssNewsRelevant", () => {
+	const item = (over) => ({ sport: "football", entityIds: [], ...over });
+
+	it("empty/catalog-wide lens shows everything", () => {
+		expect(ssNewsRelevant(item(), { catalogWide: true })).toBe(true);
+		expect(ssNewsRelevant(item(), null)).toBe(true);
+	});
+
+	it("matches on an entityId the profile follows", () => {
+		const lens = { entityIds: new Set(["viktor-hovland"]), sports: new Set() };
+		expect(ssNewsRelevant(item({ sport: "golf", entityIds: ["viktor-hovland"] }), lens)).toBe(true);
+		expect(ssNewsRelevant(item({ sport: "golf", entityIds: ["someone-else"] }), lens)).toBe(false);
+	});
+
+	it("matches on a followed WHOLE-sport (alias-normalised)", () => {
+		const lens = { entityIds: new Set(), sports: new Set(["f1"]) };
+		expect(ssNewsRelevant(item({ sport: "formula1", entityIds: [] }), lens)).toBe(true);
+		expect(ssNewsRelevant(item({ sport: "golf", entityIds: [] }), lens)).toBe(false);
+	});
+
+	it("an athlete follow does NOT open the whole sport (id-scoped, mirrors NewsLens)", () => {
+		// Following Hovland (an entity id, no sport rule) admits golf news that NAMES
+		// him (stamped id), not every golf headline.
+		const lens = { entityIds: new Set(["viktor-hovland"]), sports: new Set() };
+		expect(ssNewsRelevant(item({ sport: "golf", entityIds: [] }), lens)).toBe(false);
+	});
+});

--- a/tests/sport-icons.test.js
+++ b/tests/sport-icons.test.js
@@ -1,0 +1,48 @@
+// sport-icons.test.js — the web sport-glyph registry (app-parity, WP-154), the
+// web twin of the iOS SportSymbol table. Pins the alias resolution + that every
+// mapped sport yields a well-formed, quiet (never-coloured) SVG.
+
+import { describe, it, expect } from "vitest";
+import { ssSportIcon, ssSportIconKey } from "../docs/js/sport-icons.js";
+
+describe("ssSportIconKey", () => {
+	it("maps canonical tags + aliases to glyph keys", () => {
+		expect(ssSportIconKey("football")).toBe("football");
+		expect(ssSportIconKey("soccer")).toBe("football");
+		expect(ssSportIconKey("formula1")).toBe("f1");
+		expect(ssSportIconKey("F1")).toBe("f1");
+		expect(ssSportIconKey("cross-country")).toBe("snow");
+		expect(ssSportIconKey("alpine")).toBe("snow");
+		expect(ssSportIconKey("ski jumping")).toBe("snow");
+		expect(ssSportIconKey("biathlon")).toBe("biathlon");
+		expect(ssSportIconKey("chess")).toBe("chess");
+	});
+	it("falls back for unknown/empty sports (mirrors SportSymbol.fallback)", () => {
+		expect(ssSportIconKey("kabaddi")).toBe("fallback");
+		expect(ssSportIconKey("")).toBe("fallback");
+		expect(ssSportIconKey(null)).toBe("fallback");
+	});
+});
+
+describe("ssSportIcon", () => {
+	it("returns a well-formed, decorative SVG with the row class", () => {
+		const svg = ssSportIcon("golf");
+		expect(svg).toMatch(/^<svg class="ev-sport"/);
+		expect(svg).toContain('viewBox="0 0 24 24"');
+		expect(svg).toContain('aria-hidden="true"');
+		expect(svg.trim().endsWith("</svg>")).toBe(true);
+	});
+	it("uses currentColor only — never a hardcoded colour (amber budget untouched)", () => {
+		for (const sport of ["football", "golf", "tennis", "cycling", "athletics", "f1", "esports", "chess", "biathlon", "cross-country", "unknown"]) {
+			const svg = ssSportIcon(sport);
+			expect(svg).toContain("currentColor");
+			// No hex / named colours baked into the glyph.
+			expect(svg).not.toMatch(/#[0-9a-fA-F]{3,6}\b/);
+			expect(svg.toLowerCase()).not.toContain("fill=\"amber");
+		}
+	});
+	it("distinct sports get distinct glyphs (golf ≠ f1 ≠ football)", () => {
+		expect(ssSportIcon("golf")).not.toBe(ssSportIcon("f1"));
+		expect(ssSportIcon("f1")).not.toBe(ssSportIcon("football"));
+	});
+});


### PR DESCRIPTION
Lukker de tre web↔app-forskjellene eieren pekte på (av fire kandidater — login-veggen beholdes bevisst), + fikser den «rare» sign-out-knappen.

## Hva
1. **Nyheter-fane** — segmentert «Uka | Nyheter» under headeren (tvilling av iOS `ContentView`). Nyhetstavla speiler `NewsBoard`/`NewsView`:
   - **NYTT** — `news.json`-pekere, lens-matchet (`js/news-web.js`: entityId- ELLER hel-sport-treff; tom profil = katalog-bredt). Åpner kilden i ny fane, aldri inline artikkeltekst.
   - **RESULTAT** — fulgte lags fotballkamper m/ skår (katalog-bredt uten profil).
   - **FREMOVER** — forvarsler >14 d (gjenbruker eksisterende disclosure, flyttet inn i fanen).
   - Den redaksjonelle overskriften blir værende som web-heroens rolige linje, så § Nyheters første seksjon gjentas ikke.
2. **Assistent-inngang** — inline-feltet erstattet av en kompakt flytende bunn-trailing **«✨ Assistent»**-knapp (kollapser til bar glyf ved scroll) som åpner et **samtale-ark** med felt + eksempelrader + grunnede svar. Tvilling av `AssistantButton` + `AssistantSheetView`; samme deterministiske motor (`assistant.js`).
3. **Rad-detaljer** — per-sport **SVG-glyf** mellom tid og tittel + **disclosure-chevron** (roteres ved åpning) + ⓘ — appens `AgendaView`-radanatomi. SF Symbols finnes ikke på web, så `js/sport-icons.js` er et eget lite ikonsett tastet på de SAMME kanoniske sport-taggene: stille (`--fg-3`), ALDRI farget (amber-budsjettet urørt), dekorativt. **Lukker WP-128-«ingen web-glyf»-unntaket**; `DESIGN.md` § Cross-surface oppdatert.

**+ Sign-out-knapp:** CloudKits inkonsistente default-kontroll skjules off-screen; footer får en rolig «Logg ut»-lenke drevet av den skjulte kontrollen (samme grep som sign-in-knappen).

## Bevisst IKKE endret
- **Login-veggen** (hele web bak Sign in with Apple) — eieren beholder den.
- Twin-disiplinen: web er den deterministiske gulvversjonen av assistenten; glyf/lens er egne web-artefakter tastet på delte kanoniske tagger (ikke bit-tvillinger — SF Symbols/native List finnes ikke på web).

## Tester
- `tests/news-web.test.js` (nyhets-lensen) + `tests/sport-icons.test.js` (glyf-registeret + at ingen glyf er farget). **847 grønne** totalt.
- SW-cache v1-10→v1-12; `news-web.js` + `sport-icons.js` lagt i `SHELL_FILES`.

## Verifisert visuelt
Skjermbilder tatt lokalt (gate omgått for skudd): FAB + ark, Nyheter-tavla (NYTT/RESULTAT/FREMOVER), rader m/ sport-glyfer + chevron, ekspandert rad (chevron-rotasjon + detalj-innrykk), lys + mørk. Ingen konsoll-feil.

Berører kun `docs/`, `DESIGN.md`, `tests/` — koordinert med parallell agent-økt (som eier `scripts/`/`ios/`/`.github/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)