### PR TITLE
WP-163: web søk-og-følg + assistenten UTFØRER følging + katalog lagdelt

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1833,7 +1833,7 @@ Bølge 2: WP-161 (register) ∥ WP-165 (signal). Bølge 3: WP-162 (id-varighet).
 | WP-160 | Strakstiltak: catalog.tier2 → entities.json + håndball-label + alias-datafil | 0J | — | planlagt |
 | WP-161 | Verdensregisteret: seedet entitetsregister (~1 500–5 000 entiteter) | 0J | WP-160 | planlagt |
 | WP-162 | Sesongløse id-er + re-grounding: follows overlever sesonger | 0J | WP-161 | planlagt |
-| WP-163 | Web: søk-og-følg-flate + assistent-mutasjon wiret + katalog-kollaps-fella | 0J | WP-160 | planlagt |
+| WP-163 | Web: søk-og-følg-flate + assistent-mutasjon wiret + katalog-kollaps-fella | 0J | WP-160 | 🔬 branch wp-163-web-sok-og-folg — søk-og-følg mot entities.json i «Dette dekker vi» (treff → ssProfileFollow); assistenten UTFØRER «følg X» (kind:'mutation' konsumert i bindAssistant); followTargets slår opp ekte entityId før syntetisk fallback (ingen CRDT-dubletter); katalogen lagdelt under «Det du følger» (aldri kollapset); rediger.html omprofilert til «Be om dekning». 26 nye tester, 877/877 grønt, E2E i browser (dark/light) |
 | WP-164 | iOS: soft-follow («følg likevel») + ærlig off-season-svar | 0J | WP-160 | planlagt |
 | WP-165 | Etterspørselssignal v0: utenfor-katalog-follow → anonymt, offentlig signal | 0J | WP-163, WP-164 | planlagt |
 

--- a/docs/css/cards.css
+++ b/docs/css/cards.css
@@ -278,6 +278,37 @@
 .followed[open] summary::before { content: "▾ "; }
 .followed-body { margin-top: 14px; }
 .followed-layer { margin-bottom: 22px; }
+/* WP-163: the two-layer heading — "Det du følger" (your list) above "Dette dekker
+   vi" (the catalog). Quiet, secondaryLabel, not amber (DESIGN § Gruppeoverskrift). */
+.followed-layer-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-3); margin: 0 0 8px; }
+.followed-mine { padding-bottom: 4px; }
+
+/* ── Søk-og-følg (WP-163) — a calm search box + hairline result rows ─────────
+   Mirrors rediger.html's .add-search. One amber accent (the name on hover / the
+   Følg label when following); flat rows, no chips, no boxes (DESIGN § Forbud). */
+.follow-search { margin-bottom: 18px; }
+.follow-search-input {
+	width: 100%; box-sizing: border-box; font: inherit; font-size: 15px;
+	padding: 10px 13px; border: 1px solid var(--line); border-radius: 10px;
+	background: var(--cell); color: var(--fg);
+}
+.follow-search-input::placeholder { color: var(--fg-3); }
+.follow-search-input:focus { outline: none; border-color: var(--accent); }
+.follow-search-results { margin-top: 6px; }
+.follow-search-results[hidden] { display: none; }
+.fs-result {
+	display: flex; align-items: baseline; gap: 10px; width: 100%; text-align: left;
+	font: inherit; font-size: 15px; color: var(--fg); background: none; border: none;
+	border-bottom: 1px solid var(--line); padding: 11px 0; cursor: pointer;
+}
+.fs-result:hover .fs-name { color: var(--accent); }
+.fs-name { min-width: 0; overflow-wrap: break-word; }
+.fs-sport { font-size: 11.5px; color: var(--fg-3); }
+.fs-follow { margin-left: auto; font-size: 12.5px; color: var(--accent); white-space: nowrap; flex-shrink: 0; }
+/* Once following: the whole row goes quiet, the label reads "Følger" in fg-3. */
+.fs-result.is-following .fs-follow { color: var(--fg-3); }
+.fs-empty { font-size: 13px; color: var(--fg-3); font-style: italic; padding: 10px 0 2px; }
+.fs-empty a { color: var(--accent); font-style: normal; }
 .chip-group { margin-bottom: 14px; }
 .chip-group-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-3); margin-bottom: 6px; }
 /* Tournaments read as a quiet dot-separated line, not pills. */

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,6 +74,14 @@
 			<section class="next-up" id="next-up" hidden></section>
 			<details class="followed" id="followed" hidden>
 				<summary id="followed-summary"><span>Dette dekker vi</span><a class="followed-edit-top" href="rediger.html" onclick="event.stopPropagation()">Be om dekning</a></summary>
+				<!-- Søk-og-følg (WP-163): the vanilla-user path to follow something that
+				     isn't on the board. Searches entities.json (name + aliases); a tap
+				     follows directly (ssProfileFollow) with a calm confirmation. Wired
+				     once by profile-ui.js bindFollowSearch (survives re-render). -->
+				<div class="follow-search" id="follow-search">
+					<input type="search" id="follow-search-input" class="follow-search-input" placeholder="Søk og følg et lag eller en utøver…" autocomplete="off" autocapitalize="off">
+					<div class="follow-search-results" id="follow-search-results" hidden></div>
+				</div>
 				<div class="followed-body" id="followed-body"></div>
 			</details>
 		</div>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -43,6 +43,7 @@ class Dashboard {
 		this.maybeShowInstallHint();
 		this.renderAppPromo();
 		if (typeof this.bindAssistant === 'function') this.bindAssistant();
+		if (typeof this.bindFollowSearch === 'function') this.bindFollowSearch();
 		if (typeof this.bindRootTabs === 'function') this.bindRootTabs();
 		document.addEventListener('visibilitychange', () => {
 			this._liveVisible = !document.hidden;
@@ -73,13 +74,20 @@ class Dashboard {
 		// catalog.json — NOT a personal interests.json (that is no longer published;
 		// the owner's personal view is the iOS app). `this.interests` stays null, so
 		// the personal accents/lens degrade to event-intrinsic signals only.
-		const [events, featured, standings, results, tracked, catalog, meta, usage, news] = await Promise.all([
+		const [events, featured, standings, results, tracked, catalog, meta, usage, news, entities] = await Promise.all([
 			load('events.json'), load('featured.json'), load('standings.json'), load('recent-results.json'), load('tracked.json'), load('catalog.json'), load('meta.json'), load('usage-state.json'),
 			// news.json — lens-ready pointers (id/title/link/source/sport/entityIds/
 			// publishedAt, never article text). Feeds the Nyheter board's NYTT section.
 			load('news.json'),
+			// entities.json — the stable-id index of athletes/teams/tournaments/leagues
+			// (WP-05, folded from the catalog long-tail by WP-160). WP-163 uses it for
+			// the search-and-follow flate AND to resolve an event's REAL entityId so a
+			// web follow key-matches the iOS id across devices (no CRDT dupes).
+			load('entities.json'),
 		]);
 		this.allEvents = Array.isArray(events) ? events : [];
+		// The followable entity index — a bare array of {id,name,aliases,sport,type}.
+		this.entities = Array.isArray(entities) ? entities : (entities && Array.isArray(entities.entities) ? entities.entities : []);
 		// news.json may be a bare array or {items:[…]} — normalise to an array.
 		this.news = Array.isArray(news) ? news : (news && Array.isArray(news.items) ? news.items : []);
 		// Prefer the server's stable id (build-events.js, WP-02) — a hash of
@@ -109,14 +117,19 @@ class Dashboard {
 		const profile = (typeof ssProfileLoad === 'function') ? ssProfileLoad() : null;
 		this.profile = profile;
 		this.hasProfile = !!(profile && typeof ssStateIsEmpty === 'function' && !ssStateIsEmpty(profile));
+		// WP-163 layering: the CATALOG (what we cover, ~130 names) is ALWAYS the base
+		// layer — following something must never collapse "Dette dekker vi"/"Neste opp"
+		// down to only your own list. `this.covers` = the catalog; `this.followed` =
+		// your personal follows (shown as a "Det du følger" layer ABOVE the catalog).
+		this.covers = catalog && catalog.tier2 ? { alwaysTrack: catalog.tier2 } : null;
 		if (this.hasProfile) {
+			// interests drives the LENS (isMustSee/whyShown/relevance) — unchanged.
 			this.interests = ssProfileToInterests(profile);
-			this.covers = { alwaysTrack: this.interests.alwaysTrack };
+			this.followed = { alwaysTrack: this.interests.alwaysTrack };
 		} else {
-			// WP-96 fallback: catalog-wide "Dette dekker vi" from what we COVER;
 			// interests null → isMustSee/emphasize use only event-intrinsic signals.
-			this.covers = catalog && catalog.tier2 ? { alwaysTrack: catalog.tier2 } : null;
 			this.interests = null;
+			this.followed = null;
 		}
 		this.meta = meta;
 		this.usage = usage;

--- a/docs/js/followed.js
+++ b/docs/js/followed.js
@@ -8,18 +8,33 @@ Object.assign(window.Dashboard.prototype, {
 	// upcoming-only. Kept deliberately small so it tops the agenda without
 	// burying it; the full list (incl. "ikke satt opp ennå" + tournaments +
 	// editing) stays in the "Hva vi følger" disclosure at the bottom.
+	/** The athletes+teams behind "Neste opp": YOUR follows first, then the catalog
+	 *  (what we cover), de-duplicated by name. WP-163: following must not collapse
+	 *  the glance to only your list — it LAYERS your follows on top of the catalog. */
+	nextUpCandidates() {
+		const bucket = (c) => (c && c.alwaysTrack) ? [...(c.alwaysTrack.athletes || []), ...(c.alwaysTrack.teams || [])] : [];
+		const out = [];
+		const seen = new Set();
+		for (const entry of [...bucket(this.followed), ...bucket(this.covers)]) {
+			const key = ssNormalize(ssEntityName(entry));
+			if (!key || seen.has(key)) continue;
+			seen.add(key);
+			out.push(entry);
+		}
+		return out;
+	},
+
 	/** Followed athletes/teams that have an upcoming event, nearest first. The
-	 *  pure selection behind "Dine neste" (upcoming-only; gaps live at the bottom). */
+	 *  pure selection behind "Neste opp" (upcoming-only; gaps live at the bottom). */
 	nextUpEntries() {
-		// WP-96: sourced from the catalog (what we cover), not a personal profile.
-		const at = this.covers && this.covers.alwaysTrack;
-		if (!at) return [];
+		const candidates = this.nextUpCandidates();
+		if (!candidates.length) return [];
 		// WP-128: don't repeat an entity's next event in the glance when that same
 		// event already has its own visible agenda row in the window (renderAgenda
 		// records the shown ids). Absent the set (e.g. before first agenda render),
 		// no dedupe — the glance still shows everything.
 		const shown = this._agendaShownIds;
-		return [...(at.athletes || []), ...(at.teams || [])]
+		return candidates
 			.map((entry) => ({ entry, next: this.nextEventForEntity(entry) }))
 			.filter((x) => x.next)
 			.filter((x) => !(shown && shown.has(x.next.id)))
@@ -51,19 +66,38 @@ Object.assign(window.Dashboard.prototype, {
 		const wrap = document.getElementById('followed');
 		const body = document.getElementById('followed-body');
 		if (!wrap || !body) return;
-		// WP-96: "Dette dekker vi" renders the catalog (tier2), not a personal profile.
+		// WP-163: TWO layers, one disclosure — "Det du følger" (your personal list)
+		// on top, then "Dette dekker vi" (the catalog, tier2). Following something
+		// never collapses the catalog away (the old bug where covers became your
+		// list only). Both may be present; the catalog is always the base.
 		const at = this.covers && this.covers.alwaysTrack;
-		if (!at) { wrap.hidden = true; return; }
+		const mine = this.followed && this.followed.alwaysTrack;
+		if (!at && !mine) { wrap.hidden = true; return; }
 
 		const nextGroup = (label, items, notifyDefault) => (items || []).length
 			? `<div class="chip-group"><div class="chip-group-label">${label}</div><ul class="follow-next">${items.map((x) => this.followRow(x, notifyDefault)).join('')}</ul></div>`
 			: '';
-		body.innerHTML = '<div class="followed-layer">'
-			+ nextGroup('Utøvere', at.athletes, true)
-			+ nextGroup('Lag', at.teams, true)
-			+ nextGroup('Turneringer', at.tournaments, false)
-			+ `<div class="followed-hint">Dette er sportene og navnene Sportivista dekker · trykk en rad for detaljer. <a class="followed-edit" href="rediger.html">Savner du noe? Be om dekning →</a></div>`
-			+ '</div>';
+		// "Det du følger" — a flat, nearest-first list of everything you follow.
+		let yours = '';
+		if (mine) {
+			const followedEntries = [...(mine.athletes || []), ...(mine.teams || []), ...(mine.tournaments || [])];
+			if (followedEntries.length) {
+				yours = '<div class="followed-layer followed-mine">'
+					+ '<div class="followed-layer-label">Det du følger</div>'
+					+ `<ul class="follow-next">${followedEntries.map((x) => this.followRow(x, true)).join('')}</ul>`
+					+ '</div>';
+			}
+		}
+		const catalog = at
+			? '<div class="followed-layer followed-catalog">'
+				+ (yours ? '<div class="followed-layer-label">Dette dekker vi</div>' : '')
+				+ nextGroup('Utøvere', at.athletes, true)
+				+ nextGroup('Lag', at.teams, true)
+				+ nextGroup('Turneringer', at.tournaments, false)
+				+ '</div>'
+			: '';
+		body.innerHTML = yours + catalog
+			+ `<div class="followed-hint">Søk over for å følge et lag eller en utøver · trykk en rad for detaljer. <a class="followed-edit" href="rediger.html">Savner du en hel sport? Be om dekning →</a></div>`;
 		wrap.hidden = false;
 	},
 

--- a/docs/js/profile-ui.js
+++ b/docs/js/profile-ui.js
@@ -13,9 +13,66 @@ Object.assign(window.Dashboard.prototype, {
 		return typeof ssProfileFollows === 'function' && typeof ssProfileFollow === 'function';
 	},
 
+	// ── Entity index (docs/data/entities.json) ───────────────────────────────
+	/** The followable named long-tail — teams, athletes, tournaments, leagues.
+	 *  Excludes the server-inert `sport`/`category` meta entities (those drive the
+	 *  assistant's sport filter, not a personal follow). Empty until loadData runs
+	 *  (so the pure helpers degrade gracefully in a stripped/test context). */
+	followableEntities() {
+		const FOLLOWABLE = new Set(['team', 'league', 'tournament', 'athlete']);
+		return (this.entities || []).filter((e) => e && e.type && FOLLOWABLE.has(e.type));
+	},
+
+	/** The follow `kind` for an entities.json `type` — the bucket ssProfileToInterests
+	 *  files it under. Mirrors the iOS mapping; league counts as a team. */
+	entityFollowKind(type) {
+		if (type === 'team' || type === 'league') return 'team';
+		if (type === 'tournament') return 'tournament';
+		return 'athlete'; // athlete + anything unexpected
+	},
+
+	/** Resolve a name (+ optional sport) to its REAL entities.json entity via a
+	 *  word-boundary term match (name/alias, either direction — never naive substring,
+	 *  so "Brooklyn" never resolves to "Lyn"). Sport-scoped when both carry a sport.
+	 *  Returns the entity object or null. This is what lets a web follow reuse the
+	 *  stable iOS id instead of a synthetic one. */
+	resolveEntity(name, sport) {
+		const q = (name || '').trim();
+		if (!q) return null;
+		const sp = sport ? ssNormalize(sport) : null;
+		for (const ent of this.followableEntities()) {
+			if (sp && ent.sport && ssNormalize(ent.sport) !== sp) continue;
+			const terms = [ent.name, ...(ent.aliases || [])].filter(Boolean);
+			if (terms.some((t) => ssContainsTerm(q, t) || ssContainsTerm(t, q))) return ent;
+		}
+		return null;
+	},
+
+	/** Substring search over the entity index (name + aliases, normalised), ranked
+	 *  exact → prefix → substring, capped. Powers the search-and-follow box. */
+	searchEntities(query, limit = 8) {
+		const q = ssNormalize((query || '').trim());
+		if (q.length < 2) return [];
+		const scored = [];
+		for (const ent of this.followableEntities()) {
+			const names = [ent.name, ...(ent.aliases || [])].filter(Boolean);
+			let best = Infinity;
+			for (const n of names) {
+				const nn = ssNormalize(n);
+				const idx = nn.indexOf(q);
+				if (idx < 0) continue;
+				best = Math.min(best, idx === 0 ? (nn.length === q.length ? 0 : 1) : 2);
+			}
+			if (best < Infinity) scored.push({ ent, rank: best });
+		}
+		scored.sort((a, b) => a.rank - b.rank || a.ent.name.localeCompare(b.ent.name, 'nb', { sensitivity: 'accent' }));
+		return scored.slice(0, limit).map((x) => x.ent);
+	},
+
 	/** The followable entities on an event: each team (with its id) and each
-	 *  Norwegian player. Prefers the event's real entityId so a web follow
-	 *  key-matches the iOS WP-05 id across devices; falls back to a synthesized
+	 *  Norwegian player. Prefers the event's server-stamped entityId; else looks up
+	 *  the REAL entities.json id (so a web follow key-matches the iOS WP-05 id across
+	 *  devices — no CRDT dupes); only then falls back to a synthesized
 	 *  `normalize(name)|sport` id (best-effort, documented divergence). */
 	followTargets(e) {
 		const out = [];
@@ -23,10 +80,16 @@ Object.assign(window.Dashboard.prototype, {
 		const push = (name, id, kind) => {
 			const nm = (name || '').trim();
 			if (!nm) return;
-			const entityId = id || `${ssNormalize(nm)}|${e.sport || ''}`;
+			let entityId = id;
+			let ekind = kind;
+			if (!entityId) {
+				const ent = this.resolveEntity(nm, e.sport);
+				if (ent) { entityId = ent.id; ekind = this.entityFollowKind(ent.type); }
+			}
+			if (!entityId) entityId = `${ssNormalize(nm)}|${e.sport || ''}`;
 			if (seen.has(entityId)) return;
 			seen.add(entityId);
-			out.push({ entityId, entityName: nm, sport: e.sport || '', kind });
+			out.push({ entityId, entityName: nm, sport: e.sport || '', kind: ekind });
 		};
 		push(e.homeTeam, e.homeTeamEntityId, 'team');
 		push(e.awayTeam, e.awayTeamEntityId, 'team');
@@ -48,21 +111,65 @@ Object.assign(window.Dashboard.prototype, {
 		}).join('');
 	},
 
-	/** Toggle a follow from a button's data-* attrs, then re-render locally (no
-	 *  network refetch) so the accents/sections update immediately. */
-	toggleFollow(btn) {
-		if (!this.profileAvailable()) return;
-		const d = btn.dataset;
-		if (d.followState === 'on') ssProfileUnfollow(d.entityId);
-		else ssProfileFollow({ entityId: d.entityId, entityName: d.entityName, sport: d.entitySport, kind: d.kind });
-		this.applyProfile(ssProfileLoad());
-		this.render();
-		// Push the change to iCloud right away (fire-and-forget) so the phone picks
-		// it up on its next sync — no waiting for a later web sync round. No-op when
-		// iCloud isn't wired (dev/test) or the user isn't signed in.
+	/** Push the local profile change to iCloud right away (fire-and-forget) so the
+	 *  phone picks it up on its next sync — no waiting for a later web sync round.
+	 *  No-op when iCloud isn't wired (dev/test) or the user isn't signed in. */
+	pushProfileToICloud() {
 		if (window.ssICloud && typeof ssICloud.enabled === 'function' && ssICloud.enabled()) {
 			try { Promise.resolve(ssICloud.sync()).catch(() => {}); } catch { /* ignore */ }
 		}
+	},
+
+	/** Commit a follow: persist the rule, re-personalise the board locally (no
+	 *  network refetch), and push to iCloud. The ONE write path shared by the detail
+	 *  sheet, the search-and-follow box, and the assistant. Returns true on success. */
+	commitFollow(entity) {
+		if (!this.profileAvailable()) return false;
+		ssProfileFollow({ entityId: entity.entityId, entityName: entity.entityName, sport: entity.sport, kind: entity.kind });
+		this.applyProfile(ssProfileLoad());
+		this.render();
+		this.pushProfileToICloud();
+		return true;
+	},
+
+	/** Commit an unfollow (tombstone the rule), then re-personalise + push. */
+	commitUnfollow(entityId) {
+		if (!this.profileAvailable()) return false;
+		ssProfileUnfollow(entityId);
+		this.applyProfile(ssProfileLoad());
+		this.render();
+		this.pushProfileToICloud();
+		return true;
+	},
+
+	/** Toggle a follow from a button's data-* attrs (the detail-sheet buttons and
+	 *  the search results). */
+	toggleFollow(btn) {
+		if (!this.profileAvailable()) return;
+		const d = btn.dataset;
+		if (d.followState === 'on') this.commitUnfollow(d.entityId);
+		else this.commitFollow({ entityId: d.entityId, entityName: d.entityName, sport: d.entitySport, kind: d.kind });
+	},
+
+	/** Execute an assistant follow/unfollow intent ("følg Liverpool"). Resolves the
+	 *  subject against entities.json and commits it — never invents an entity, never
+	 *  claims a follow it can't ground. Returns { ok, text } for a calm confirmation
+	 *  line (the DOM wiring in bindAssistant renders it). */
+	handleFollowIntent(subject, unfollow) {
+		const q = (subject || '').trim();
+		if (!q) return { ok: false, text: 'Hvem vil du følge? Prøv «følg Hovland».' };
+		if (!this.profileAvailable()) return { ok: false, text: 'Følging er ikke tilgjengelig akkurat nå.' };
+		const ent = this.resolveEntity(q);
+		if (!ent) return { ok: false, text: `Fant ikke «${q}». Søk i «Dette dekker vi» for å følge.` };
+		const isOn = ssProfileFollows(ent.id);
+		if (unfollow) {
+			if (!isOn) return { ok: false, text: `Du følger ikke ${ent.name}.` };
+			this.commitUnfollow(ent.id);
+			return { ok: true, text: `Sluttet å følge ${ent.name}.` };
+		}
+		if (isOn) return { ok: true, text: `Du følger allerede ${ent.name}.` };
+		this.commitFollow({ entityId: ent.id, entityName: ent.name, sport: ent.sport || '', kind: this.entityFollowKind(ent.type) });
+		return { ok: true, text: `Følger ${ent.name} nå.` };
 	},
 
 	/** Wire the deterministic assistant: a floating bottom-trailing button opens a
@@ -80,6 +187,16 @@ Object.assign(window.Dashboard.prototype, {
 			const q = input.value.trim();
 			if (!q) { results.hidden = true; results.innerHTML = ''; if (examples) examples.hidden = false; return; }
 			const r = ssAssistant(q, { events: this.allEvents || [], interests: this.interests, config: this.lensConfig, vocab: this.assistantVocab, nowMs: Date.now() });
+			// A follow/unfollow intent is EXECUTED here (WP-163) — the assistant used to
+			// return kind:'mutation' that nothing consumed. Resolve + commit the follow,
+			// then show a calm confirmation instead of the dead "trykk raden" hint.
+			if (r.kind === 'mutation') {
+				const res = this.handleFollowIntent(r.subject, r.unfollow);
+				results.innerHTML = `<p class="assistant-answer">${escapeHtml(res.text)}</p>`;
+				results.hidden = false;
+				if (examples) examples.hidden = true;
+				return;
+			}
 			const rows = (r.eventIds || [])
 				.map((id) => (this._eventById && this._eventById.get(id)) || (this.allEvents || []).find((e) => e.id === id))
 				.filter(Boolean);
@@ -118,16 +235,68 @@ Object.assign(window.Dashboard.prototype, {
 		onScroll();
 	},
 
-	/** Recompute interests/covers from a profile state (mirrors loadData's branch). */
+	/** Recompute interests/covers from a profile state (mirrors loadData's branch).
+	 *  WP-163: the catalog stays the base `covers` layer; `followed` is your personal
+	 *  list, shown ABOVE the catalog — following never collapses the catalog away. */
 	applyProfile(profile) {
 		this.profile = profile;
 		this.hasProfile = !!(profile && typeof ssStateIsEmpty === 'function' && !ssStateIsEmpty(profile));
+		this.covers = this.catalog && this.catalog.tier2 ? { alwaysTrack: this.catalog.tier2 } : null;
 		if (this.hasProfile) {
 			this.interests = ssProfileToInterests(profile);
-			this.covers = { alwaysTrack: this.interests.alwaysTrack };
+			this.followed = { alwaysTrack: this.interests.alwaysTrack };
 		} else {
-			this.covers = this.catalog && this.catalog.tier2 ? { alwaysTrack: this.catalog.tier2 } : null;
 			this.interests = null;
+			this.followed = null;
 		}
+	},
+
+	// ── Search-and-follow (WP-163) ───────────────────────────────────────────
+	/** Wire the search box inside the "Dette dekker vi" disclosure: type a name →
+	 *  matching entities from entities.json → tap to follow directly (ssProfileFollow)
+	 *  with a calm inline confirmation. This is the vanilla-user path to follow
+	 *  something that isn't on the board (the detail-sheet buttons only cover rows).
+	 *  Calm by DESIGN.md: hairline rows, one amber accent, no toast/spinner. */
+	bindFollowSearch() {
+		const input = document.getElementById('follow-search-input');
+		const results = document.getElementById('follow-search-results');
+		if (!input || !results || !this.profileAvailable()) return;
+
+		const render = () => {
+			const q = input.value.trim();
+			if (q.length < 2) { results.hidden = true; results.innerHTML = ''; return; }
+			const hits = this.searchEntities(q);
+			if (!hits.length) {
+				results.innerHTML = `<p class="fs-empty">Ingen treff på «${escapeHtml(q)}».`
+					+ ` <a href="rediger.html">Be om dekning →</a></p>`;
+				results.hidden = false;
+				return;
+			}
+			results.innerHTML = hits.map((ent) => this.followSearchRow(ent)).join('');
+			results.hidden = false;
+		};
+
+		input.addEventListener('input', render);
+		results.addEventListener('click', (evt) => {
+			const row = evt.target.closest('.fs-result');
+			if (!row) return;
+			const d = row.dataset;
+			const on = ssProfileFollows(d.entityId);
+			if (on) this.commitUnfollow(d.entityId);
+			else this.commitFollow({ entityId: d.entityId, entityName: d.entityName, sport: d.entitySport, kind: d.kind });
+			render(); // reflect the new follow state on the row (Følg ⇄ Følger)
+		});
+	},
+
+	/** One search result row: name · sport · a Følg/Følger toggle. */
+	followSearchRow(ent) {
+		const on = ssProfileFollows(ent.id);
+		const kind = this.entityFollowKind(ent.type);
+		const sport = ent.sport ? `<span class="fs-sport">${escapeHtml((typeof ssLensConfig === 'function' && ssLensConfig(this.lensConfig).sportNb[ent.sport]) || ent.sport)}</span>` : '';
+		return `<button type="button" class="fs-result${on ? ' is-following' : ''}"`
+			+ ` data-entity-id="${escapeHtml(ent.id)}" data-entity-name="${escapeHtml(ent.name)}"`
+			+ ` data-entity-sport="${escapeHtml(ent.sport || '')}" data-kind="${escapeHtml(kind)}"`
+			+ ` aria-pressed="${on}"><span class="fs-name">${escapeHtml(ent.name)}</span>${sport}`
+			+ `<span class="fs-follow">${on ? 'Følger' : 'Følg'}</span></button>`;
 	},
 });

--- a/docs/rediger.html
+++ b/docs/rediger.html
@@ -3,11 +3,11 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
-	<meta name="description" content="Rediger det du følger i Sportivista.">
+	<meta name="description" content="Be Sportivista om å dekke en ny sport eller turnering.">
 	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
 	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
 	<link rel="icon" type="image/png" href="favicon.png">
-	<title>Rediger · Sportivista</title>
+	<title>Be om dekning · Sportivista</title>
 	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
 	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
 	<link rel="stylesheet" href="css/base.css">
@@ -75,16 +75,18 @@
 
 	<main class="wrap">
 		<a class="edit-back" href="index.html">‹ Tilbake til oversikten</a>
-		<h1>Rediger det du følger</h1>
-		<p class="edit-lead">Trykk en rad for å se neste hendelse og endre den — ingen skriving, ingen JSON. Send inn skjemaet, så <strong>oppdateres lista automatisk</strong> og siden bygges om (~et par minutter).</p>
-
-		<div id="edit-root"><p class="muted">Laster …</p></div>
+		<h1>Be om dekning</h1>
+		<p class="edit-lead"><strong>Vil du bare følge et lag eller en utøver?</strong> Det gjør du direkte på forsiden — søk i «Dette dekker vi» og trykk <em>Følg</em>. <a href="index.html">Gå til forsiden →</a></p>
+		<p class="edit-lead">Denne siden er for å be Sportivista om å <strong>dekke noe nytt</strong> — en sport eller turnering vi ikke henter ennå. Det sendes som et forslag til vedlikeholderen; når det tas inn, dukker det opp for alle.</p>
 
 		<section class="add-box">
-			<h2>Legg til noe nytt</h2>
-			<input type="search" id="add-search" class="add-search" placeholder="Søk etter lag, utøver eller turnering…" autocomplete="off" autocapitalize="off">
+			<h2>Be om ny dekning</h2>
+			<input type="search" id="add-search" class="add-search" placeholder="Søk etter en sport, turnering eller et lag…" autocomplete="off" autocapitalize="off">
 			<div id="add-suggestions" class="add-suggestions"></div>
 		</section>
+
+		<h2 class="edit-subhead">Dette dekker vi allerede</h2>
+		<div id="edit-root"><p class="muted">Laster …</p></div>
 
 		<div class="edit-foot">
 			<p class="muted">Endringer vises her når siden er bygd om (~et par minutter etter innsending). Vil du endre alt for hånd (aliaser, varsel-tid m.m.)? <a href="https://github.dev/CHaerem/sportivista/blob/main/scripts/config/interests.json" target="_blank" rel="noopener">Rediger fila direkte</a>.</p>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Sportivista v2 Service Worker — fresh data always, network-first shell
-const CACHE_NAME = 'sportivista-v1-12';
+const CACHE_NAME = 'sportivista-v1-13';
 const DATA_PATH_FRAGMENT = '/data/';
 
 const SHELL_FILES = [

--- a/tests/web-follow-anything.test.js
+++ b/tests/web-follow-anything.test.js
@@ -1,0 +1,202 @@
+// web-follow-anything.test.js (WP-163) — the vanilla-user "follow anything" path
+// on the web: search entities.json → follow directly, the assistant EXECUTES a
+// follow, followTargets reuses the real entities.json id (no CRDT dupes), and the
+// catalog is LAYERED under your follows (never collapsed away).
+//
+// All pure/DOM-free methods on the Dashboard prototype (bindFollowSearch/bindAssistant
+// need real DOM and are exercised in the browser E2E instead).
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createClientSandbox, loadClientScript } from "./helpers/load-client.js";
+
+let W;
+beforeEach(() => {
+	const sandbox = createClientSandbox();
+	Object.assign(sandbox, { TextEncoder, TextDecoder, btoa, atob, Uint8Array, crypto: globalThis.crypto });
+	loadClientScript(sandbox, "shared-constants.js");
+	loadClientScript(sandbox, "lens.js");
+	loadClientScript(sandbox, "profile-sync.js");
+	loadClientScript(sandbox, "assistant.js");
+	loadClientScript(sandbox, "dashboard.js");
+	loadClientScript(sandbox, "detail.js");
+	loadClientScript(sandbox, "followed.js");
+	loadClientScript(sandbox, "profile-ui.js");
+	W = sandbox.window;
+	// A small entities.json fixture shaped like the real one (WP-160 folds tier2 in;
+	// Liverpool stands in for that long-tail team that isn't on the board today).
+	W.dashboard.entities = [
+		{ id: "liverpool", name: "Liverpool", aliases: ["Liverpool FC", "LFC"], sport: "football", type: "team" },
+		{ id: "arsenal", name: "Arsenal", aliases: ["Arsenal FC"], sport: "football", type: "team" },
+		{ id: "lyn", name: "Lyn", aliases: ["FK Lyn Oslo"], sport: "football", type: "team" },
+		{ id: "premier-league-2026-27", name: "Premier League 2026/27", aliases: ["Premier League"], sport: "football", type: "league" },
+		{ id: "the-open-2026", name: "The Open 2026", aliases: ["The Open"], sport: "golf", type: "tournament" },
+		{ id: "viktor-hovland", name: "Viktor Hovland", aliases: ["Hovland"], sport: "golf", type: "athlete" },
+		// server-inert meta entity — must be EXCLUDED from the follow search
+		{ id: "sport-football", name: "Fotball", aliases: ["football", "soccer"], sport: "football", type: "sport" },
+	];
+	W.dashboard.catalog = { tier2: { teams: [], athletes: [], tournaments: [] } };
+	W.dashboard.render = () => {}; // DOM-free: neutralise the local re-render
+	W.dashboard.applyProfile(W.ssProfileLoad());
+});
+
+describe("followableEntities — the long-tail, meta entities excluded", () => {
+	it("keeps team/league/tournament/athlete, drops sport/category", () => {
+		const types = W.dashboard.followableEntities().map((e) => e.type);
+		expect(types).toContain("team");
+		expect(types).toContain("league");
+		expect(types).toContain("tournament");
+		expect(types).toContain("athlete");
+		expect(types).not.toContain("sport");
+	});
+});
+
+describe("entityFollowKind — the profile bucket", () => {
+	it("maps type → follow kind (league counts as team)", () => {
+		expect(W.dashboard.entityFollowKind("team")).toBe("team");
+		expect(W.dashboard.entityFollowKind("league")).toBe("team");
+		expect(W.dashboard.entityFollowKind("tournament")).toBe("tournament");
+		expect(W.dashboard.entityFollowKind("athlete")).toBe("athlete");
+	});
+});
+
+describe("resolveEntity — real entities.json id via word-boundary match", () => {
+	it("resolves a team name to its entity", () => {
+		expect(W.dashboard.resolveEntity("Liverpool", "football").id).toBe("liverpool");
+	});
+	it("resolves via an alias", () => {
+		expect(W.dashboard.resolveEntity("LFC", "football").id).toBe("liverpool");
+	});
+	it("is sport-scoped (no cross-sport collision)", () => {
+		expect(W.dashboard.resolveEntity("Liverpool", "golf")).toBe(null);
+	});
+	it("never naive-substring matches (Brooklyn ≠ Lyn)", () => {
+		expect(W.dashboard.resolveEntity("Brooklyn", "football")).toBe(null);
+	});
+	it("returns null with no entity index loaded", () => {
+		W.dashboard.entities = [];
+		expect(W.dashboard.resolveEntity("Liverpool", "football")).toBe(null);
+	});
+});
+
+describe("searchEntities — the search box source", () => {
+	it("matches on a name substring, ranked exact→prefix→substring", () => {
+		const hits = W.dashboard.searchEntities("liver");
+		expect(hits[0].id).toBe("liverpool");
+	});
+	it("matches on an alias", () => {
+		expect(W.dashboard.searchEntities("hovland").map((e) => e.id)).toContain("viktor-hovland");
+	});
+	it("ignores queries under 2 chars", () => {
+		expect(W.dashboard.searchEntities("l")).toEqual([]);
+	});
+	it("excludes the server-inert sport entity", () => {
+		expect(W.dashboard.searchEntities("fotball").map((e) => e.id)).not.toContain("sport-football");
+	});
+});
+
+describe("followTargets — reuses the REAL entities.json id (no CRDT dupes)", () => {
+	it("looks up the real id when the event carries none", () => {
+		const t = W.dashboard.followTargets({ sport: "football", homeTeam: "Liverpool", awayTeam: "Arsenal" });
+		expect(t.map((x) => x.entityId)).toEqual(["liverpool", "arsenal"]);
+		expect(t[0].kind).toBe("team");
+	});
+	it("prefers the event's server-stamped id over a lookup", () => {
+		const t = W.dashboard.followTargets({ sport: "football", homeTeam: "Liverpool", homeTeamEntityId: "team-liverpool" });
+		expect(t[0].entityId).toBe("team-liverpool");
+	});
+	it("falls back to the synthetic id when nothing resolves", () => {
+		const t = W.dashboard.followTargets({ sport: "golf", norwegianPlayers: [{ name: "Ukjent Spiller" }] });
+		expect(t[0].entityId).toBe("ukjent spiller|golf");
+	});
+});
+
+describe("followSearchRow — calm, escaped, follow-state aware", () => {
+	it("labels 'Følg' when not followed, 'Følger' after", () => {
+		const before = W.dashboard.followSearchRow(W.dashboard.entities[0]);
+		expect(before).toContain("Følg");
+		expect(before).not.toContain("is-following");
+		W.dashboard.commitFollow({ entityId: "liverpool", entityName: "Liverpool", sport: "football", kind: "team" });
+		const after = W.dashboard.followSearchRow(W.dashboard.entities[0]);
+		expect(after).toContain("Følger");
+		expect(after).toContain("is-following");
+	});
+	it("escapes the entity name", () => {
+		const html = W.dashboard.followSearchRow({ id: "x", name: "<script>alert(1)</script>", sport: "football", type: "team" });
+		expect(html).not.toContain("<script>alert");
+	});
+});
+
+describe("commitFollow / commitUnfollow — the shared write path", () => {
+	it("following fills interests and flips hasProfile", () => {
+		W.dashboard.commitFollow({ entityId: "liverpool", entityName: "Liverpool", sport: "football", kind: "team" });
+		expect(W.ssProfileFollows("liverpool")).toBe(true);
+		expect(W.dashboard.hasProfile).toBe(true);
+		expect(W.dashboard.followed.alwaysTrack.teams.map((e) => e.name)).toContain("Liverpool");
+	});
+	it("unfollowing the last entity returns to the catalog-only fallback", () => {
+		W.dashboard.commitFollow({ entityId: "liverpool", entityName: "Liverpool", sport: "football", kind: "team" });
+		W.dashboard.commitUnfollow("liverpool");
+		expect(W.ssProfileFollows("liverpool")).toBe(false);
+		expect(W.dashboard.hasProfile).toBe(false);
+		expect(W.dashboard.followed).toBe(null);
+	});
+});
+
+describe("handleFollowIntent — the assistant EXECUTES the follow (WP-163)", () => {
+	it("«følg Liverpool» resolves + commits, with a calm confirmation", () => {
+		const res = W.dashboard.handleFollowIntent("Liverpool", false);
+		expect(res.ok).toBe(true);
+		expect(res.text).toContain("Følger Liverpool");
+		expect(W.ssProfileFollows("liverpool")).toBe(true);
+	});
+	it("the assistant router → mutation → handled end-to-end", () => {
+		const r = W.ssAssistant("følg Hovland", { events: [], interests: null, config: null, nowMs: Date.now() });
+		expect(r.kind).toBe("mutation");
+		const res = W.dashboard.handleFollowIntent(r.subject, r.unfollow);
+		expect(res.ok).toBe(true);
+		expect(W.ssProfileFollows("viktor-hovland")).toBe(true);
+	});
+	it("«slutt å følge Liverpool» tombstones the rule", () => {
+		W.dashboard.handleFollowIntent("Liverpool", false);
+		const res = W.dashboard.handleFollowIntent("Liverpool", true);
+		expect(res.ok).toBe(true);
+		expect(W.ssProfileFollows("liverpool")).toBe(false);
+	});
+	it("an unknown subject is an honest miss (never invents)", () => {
+		const res = W.dashboard.handleFollowIntent("Klingon FC", false);
+		expect(res.ok).toBe(false);
+		expect(res.text).toContain("Fant ikke");
+		expect(W.dashboard.hasProfile).toBe(false);
+	});
+	it("an empty subject asks who", () => {
+		expect(W.dashboard.handleFollowIntent("", false).ok).toBe(false);
+	});
+});
+
+describe("layered covers — following never collapses the catalog (WP-163)", () => {
+	beforeEach(() => {
+		W.dashboard.catalog = { tier2: {
+			teams: [{ name: "Rosenborg", sport: "football" }],
+			athletes: [{ name: "Casper Ruud", sport: "tennis" }],
+			tournaments: [],
+		} };
+		W.dashboard.applyProfile(W.ssProfileLoad());
+	});
+	it("catalog stays the base covers layer after a follow", () => {
+		W.dashboard.commitFollow({ entityId: "liverpool", entityName: "Liverpool", sport: "football", kind: "team" });
+		// covers = catalog (unchanged); followed = your list (new)
+		expect(W.dashboard.covers.alwaysTrack.teams.map((e) => e.name)).toContain("Rosenborg");
+		expect(W.dashboard.followed.alwaysTrack.teams.map((e) => e.name)).toContain("Liverpool");
+	});
+	it("nextUpCandidates unions your follows + the catalog, de-duped by name", () => {
+		W.dashboard.commitFollow({ entityId: "liverpool", entityName: "Liverpool", sport: "football", kind: "team" });
+		const names = W.dashboard.nextUpCandidates().map((e) => W.ssEntityName(e));
+		expect(names).toContain("Liverpool"); // your follow
+		expect(names).toContain("Rosenborg"); // the catalog, still present
+	});
+	it("a name in both layers appears once", () => {
+		W.dashboard.commitFollow({ entityId: "rosenborg", entityName: "Rosenborg", sport: "football", kind: "team" });
+		const names = W.dashboard.nextUpCandidates().map((e) => W.ssEntityName(e));
+		expect(names.filter((n) => n === "Rosenborg").length).toBe(1);
+	});
+});


### PR DESCRIPTION
## WP-163 · «Følg hva som helst» på web (FASE 0J, bølge 1)

**Mål:** en vanlig web-bruker kan følge noe som ikke står på tavla. I dag var eneste følge-vei detaljark-knappene (universet = tavlas rader), assistentens «følg X» var en død stub (`kind:'mutation'` ble aldri konsumert), og `rediger.html` skrev kun eierens `interests.json` via OWNER-gatede issues (no-op for alle andre).

### De 5 innholdspunktene

1. **Søk-og-følg-flate** i «Dette dekker vi»-disclosuren (`index.html` + `profile-ui.js` `bindFollowSearch`): søk mot `entities.json` (navn+aliaser, samme `ssNormalize` som `lens.js`), rangert eksakt→prefiks→delstreng. Treff → `ssProfileFollow` direkte med rolig inline-kvittering (Følg ⇄ Følger). Hårlinje-rader, én amber-aksent, ingen toast/spinner (DESIGN § Forbudsliste). Meta-entitetene `sport`/`category` ekskluderes.
2. **Assistent-mutasjonen wiret:** `bindAssistant` konsumerer nå `kind:'mutation'` → `handleFollowIntent`, som slår opp subjektet i `entities.json` og **utfører** følgingen med rolig kvittering («Følger Liverpool nå.»). Ærlig miss når navnet ikke groundes — aldri oppfunnet.
3. **Syntetisk id-divergens fjernet:** `followTargets` slår opp **ekte** `entityId` fra `entities.json` (word-boundary navn/alias-match, sport-scoped, aldri naiv delstreng → Brooklyn≠Lyn) FØR fallback til `normalize(name)|sport`. En web-følging nøkkel-matcher nå iOS-id-en → ingen CRDT-dubletter på tvers av enheter.
4. **Katalog-kollaps-fella lukket:** første følging kollapser ikke lenger «Dette dekker vi»/«Neste opp» til kun profilens liste. Katalogen er alltid base-laget (`this.covers`); dine follows vises **lagdelt over** som «Det du følger» (`this.followed`). `nextUpEntries` unionerer begge (deduped på navn). LENSEN (`this.interests`) er urørt → **ingen feed-vektor-endring**.
5. **`rediger.html` omprofilert ærlig til «Be om dekning»** (WP-96-intensjonen): ber om ny *dekning* (sport/turnering) via den uendrede OWNER-gatede issue-flyten, og lenker til forsidens søk-og-følg for selve *følgingen*.

### Ikke-mål (holdt)
Ingen endring i follow-request-flyten/`interests.json`, ingen ny backend, ingen endring i `scripts/` (pipeline) eller `ios/`. Delte skrivehjelpere (`commitFollow`/`commitUnfollow`/`pushProfileToICloud`) gjenbrukt av detaljark, søk OG assistent (én iCloud-push-sti). sw-cache → `v1-13`.

### Endrede filer
`docs/index.html`, `docs/js/profile-ui.js`, `docs/js/dashboard.js`, `docs/js/followed.js`, `docs/css/cards.css`, `docs/rediger.html`, `docs/sw.js`, `PLAN.md`, `tests/web-follow-anything.test.js` (ny).

### Verifisering (aksept-bevis)
- **Vitest:** 877/877 grønt serielt (`npx vitest run --maxWorkers=1`), inkl. 26 nye tester i `tests/web-follow-anything.test.js` (resolveEntity/searchEntities/entityFollowKind/followTargets-med-ekte-id/handleFollowIntent/lagdelte covers) + eksisterende `dashboard-cards`/`profile-ui`/`assistant`/`edit`/`feed-vectors` uendret. Lens-vektorene er bit-like (rørte ikke `lens.js`).
- **E2E i browser (dark + light), mot en lokal `entities.json` med en tier2-lignende Liverpool-entitet (WP-160 bygges parallelt; ikke committet):**
  - *Søk «Liverpool» → Følg* → `ssProfileFollows('liverpool') === true` (ekte id, ikke syntetisk), raden vises i **«Det du følger»**, «Dette dekker vi»-katalogen fortsatt synlig under (lagdelt), søkeraden bytter til «Følger». iCloud-push kalles via `toggleFollow`-mønsteret (`pushProfileToICloud`).
  - *Assistent «følg Manchester City»* → «Følger Manchester City nå.», `ssProfileFollows('manchester-city') === true`, raden i «Det du følger».
  - *`rediger.html`* viser «Be om dekning» med lenke til forsidens følg-flate + «Dette dekker vi allerede».
  - Ingen konsoll-feil; begge temaer verifisert (true-black mørk / grouped-light). Skjermbildene ble tatt interaktivt under verifiseringen (dark/light × søk-og-følg + assistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)