### PR TITLE
WP-164: iOS soft-follow («Følg likevel») + ærlig off-season-svar

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1834,7 +1834,7 @@ Bølge 2: WP-161 (register) ∥ WP-165 (signal). Bølge 3: WP-162 (id-varighet).
 | WP-161 | Verdensregisteret: seedet entitetsregister (~1 500–5 000 entiteter) | 0J | WP-160 | planlagt |
 | WP-162 | Sesongløse id-er + re-grounding: follows overlever sesonger | 0J | WP-161 | planlagt |
 | WP-163 | Web: søk-og-følg-flate + assistent-mutasjon wiret + katalog-kollaps-fella | 0J | WP-160 | 🔬 branch wp-163-web-sok-og-folg — søk-og-følg mot entities.json i «Dette dekker vi» (treff → ssProfileFollow); assistenten UTFØRER «følg X» (kind:'mutation' konsumert i bindAssistant); followTargets slår opp ekte entityId før syntetisk fallback (ingen CRDT-dubletter); katalogen lagdelt under «Det du følger» (aldri kollapset); rediger.html omprofilert til «Be om dekning». 26 nye tester, 877/877 grønt, E2E i browser (dark/light) |
-| WP-164 | iOS: soft-follow («følg likevel») + ærlig off-season-svar | 0J | WP-160 | planlagt |
+| WP-164 | iOS: soft-follow («følg likevel») + ærlig off-season-svar | 0J | WP-160 | 🔬 branch wp-164-ios-soft-follow — «Følg likevel» ved søke-miss + grounder-avvisning (navnebasert regel, nøytral notify-default), ærlig «Fulgt — …»-status m/sesonglinje fra tracked.json, onboarding-CI-vakt (Liverpool-assert: TODO(WP-160)) |
 | WP-165 | Etterspørselssignal v0: utenfor-katalog-follow → anonymt, offentlig signal | 0J | WP-163, WP-164 | planlagt |
 
 ### WP-160 · Strakstiltak: fold catalog.tier2 inn i entities.json (bølge 1)

--- a/ios/Sportivista/Assistant/AssistantResultThread.swift
+++ b/ios/Sportivista/Assistant/AssistantResultThread.swift
@@ -302,6 +302,31 @@ struct AssistantResultThread: View {
                             }
                         }
                     }
+                    // WP-164: the rejection is honest, not a dead-end — the USER
+                    // may choose to follow the bare name anyway (a soft-follow;
+                    // the model's anti-hallucination gate is untouched). Only a
+                    // rejected FOLLOW offers it — «slutt å følge X» does not.
+                    if rejection.proposal.kind == .add, !rejection.query.isEmpty {
+                        Button {
+                            viewModel.softFollow(from: rejection)
+                            dismissIfDone()
+                        } label: {
+                            HStack(spacing: 8) {
+                                Text("Følg «\(rejection.query)» likevel")
+                                    .font(.sportivista(.subheadline, weight: .semibold))
+                                    .foregroundStyle(SportivistaTokens.label)
+                                    .multilineTextAlignment(.leading)
+                                Spacer(minLength: 8)
+                                Image(systemName: "plus")
+                                    .font(.sportivista(.footnote, weight: .semibold))
+                                    .foregroundStyle(SportivistaTokens.tertiaryLabel)
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("assistant.softfollow")
+                    }
                     Button("OK") { viewModel.dismissRejection(rejection); dismissIfDone() }
                         .font(.sportivista(.caption))
                         .foregroundStyle(SportivistaTokens.label.opacity(0.6))

--- a/ios/Sportivista/Assistant/AssistantViewModel.swift
+++ b/ios/Sportivista/Assistant/AssistantViewModel.swift
@@ -164,6 +164,11 @@ final class AssistantViewModel {
     /// app to the same DataStore the feed reads. Read-only: no write path here.
     private let eventsProvider: () -> [Event]
     private let newsProvider: () -> [NewsItem]
+    /// WP-164 — the synced tracked.json (read-only), so «Det du følger» can show
+    /// an honest season line («Fulgt — sesongstart medio august …») for a
+    /// followed entity with nothing on the board yet. Defaults to nil (the
+    /// mutation-only tests); wired in the app to the same DataStore cache.
+    private let trackedProvider: () -> TrackedConfig?
     /// WP-16.4 — the in-flight interpret task, so the command line can cancel it.
     private var currentTask: Task<Void, Never>?
 
@@ -185,6 +190,7 @@ final class AssistantViewModel {
         feedProvider: @escaping () -> FeedQuery = { FeedQuery(now: Date()) },
         eventsProvider: @escaping () -> [Event] = { [] },
         newsProvider: @escaping () -> [NewsItem] = { [] },
+        trackedProvider: @escaping () -> TrackedConfig? = { nil },
         deferAvailabilityCheck: Bool = false
     ) {
         self.assistant = assistant
@@ -193,6 +199,7 @@ final class AssistantViewModel {
         self.misunderstoodLog = misunderstoodLog
         self.eventsProvider = eventsProvider
         self.newsProvider = newsProvider
+        self.trackedProvider = trackedProvider
         // Default the memory store over the SAME profile file, so memory and the
         // profile share one on-disk `ProfileSyncState`.
         self.memoryStore = memoryStore ?? MemoryStore(profileStore: profileStore)
@@ -255,6 +262,8 @@ final class AssistantViewModel {
             // events + news the agenda/Nyheter boards read (no new source).
             eventsProvider: { dataStore.loadEvents() },
             newsProvider: { dataStore.loadNews() },
+            // WP-164 — the honest season line's source (read-only, same cache).
+            trackedProvider: { dataStore.loadTracked() },
             deferAvailabilityCheck: true
         )
         // Den utsatte FM-tilgjengelighetssjekken (se init) — av hovedtråden.
@@ -298,7 +307,7 @@ final class AssistantViewModel {
             uniquingKeysWith: { first, _ in first }
         )
         return FollowSnapshot(
-            presenter: FollowPresenter(feed: feed, index: idx, news: news, now: now),
+            presenter: FollowPresenter(feed: feed, index: idx, news: news, tracked: trackedProvider(), now: now),
             eventsById: byId
         )
     }
@@ -645,6 +654,17 @@ final class AssistantViewModel {
 
     func dismissRejection(_ rejection: RejectedMutation) {
         rejected.removeAll { $0.id == rejection.id }
+    }
+
+    /// WP-164 — the user chose «Følg likevel» on a rejection: the stale «ingen
+    /// endring»-account no longer holds (something DID change), so it is
+    /// replaced by a calm receipt. Called by the soft-follow arm in
+    /// Profile/AssistantViewModel+Follow.swift (which owns the actual rule
+    /// write); only the result-state bookkeeping lives here, next to the other
+    /// private(set) result setters.
+    func noteSoftFollowApplied(named name: String) {
+        explanation = nil
+        commandReceipt = "Følger «\(name)» — venter på dekning."
     }
 
     /// WP-16.2: the user tapped a "mente du …?" suggestion — re-ground the

--- a/ios/Sportivista/Assistant/MutationGrounder.swift
+++ b/ios/Sportivista/Assistant/MutationGrounder.swift
@@ -129,20 +129,28 @@ enum MutationGrounder {
         let suggestions = resolution.candidates.map(\.entity)
         return RejectedMutation(
             query: query,
-            explanation: rejectionText(query: query, suggestions: suggestions),
+            explanation: rejectionText(query: query, suggestions: suggestions, offerSoftFollow: proposal.kind == .add),
             suggestions: suggestions,
             proposal: proposal
         )
     }
 
     /// The Norwegian rejection message — with a "mente du …?" tail only when
-    /// there is a genuine near-match to offer.
-    static func rejectionText(query: String, suggestions: [Entity]) -> String {
+    /// there is a genuine near-match to offer. WP-164: a rejected FOLLOW
+    /// (`offerSoftFollow`) additionally names the honest way out — following
+    /// the bare name anyway — which the UI offers as an explicit user action.
+    /// The gate itself is unchanged: the model still can't invent ids; only
+    /// the user can choose the soft-follow.
+    static func rejectionText(query: String, suggestions: [Entity], offerSoftFollow: Bool = false) -> String {
         let subject = query.isEmpty ? "det" : "«\(query)»"
         if suggestions.isEmpty {
-            return "Fant ikke \(subject) i indeksen over det du kan følge. Prøv et navn eller en turnering jeg kjenner."
+            return offerSoftFollow
+                ? "Fant ikke \(subject) i indeksen over det du kan følge. Du kan likevel følge navnet — da venter det på dekning."
+                : "Fant ikke \(subject) i indeksen over det du kan følge. Prøv et navn eller en turnering jeg kjenner."
         }
         let names = suggestions.map { $0.name }.joined(separator: ", ")
-        return "Fant ikke \(subject) i indeksen — mente du: \(names)?"
+        var text = "Fant ikke \(subject) i indeksen — mente du: \(names)?"
+        if offerSoftFollow { text += " Du kan også følge navnet likevel." }
+        return text
     }
 }

--- a/ios/Sportivista/Onboarding/OnboardingView.swift
+++ b/ios/Sportivista/Onboarding/OnboardingView.swift
@@ -47,6 +47,21 @@
 
 import SwiftUI
 
+/// WP-164 CI-vakt — the onboarding copy's promise, as data. The converse step
+/// advertises concrete example utterances; every CONCRETE entity name they
+/// name-drop must actually ground against the entity index, or the copy
+/// promises something the assistant will reject. `converseStep` renders
+/// `converseIntro` verbatim and OnboardingCopyGroundingTests replays every
+/// `entityMentions` name against the checked-in entities fixture — copy and
+/// guard can never drift apart.
+enum OnboardingExamples {
+    /// The converse step's intro line, rendered verbatim.
+    static let converseIntro = "Skriv fritt på norsk — «Liverpool», «golf, mest de norske», «sjakk når Carlsen spiller». Jeg foreslår, du bekrefter. Si gjerne flere ting etter hverandre."
+    /// The concrete entity names the examples above name-drop («golf, mest de
+    /// norske» is a sport + lens, not an entity — deliberately not listed).
+    static let entityMentions = ["Liverpool", "Carlsen"]
+}
+
 struct OnboardingView: View {
     /// The SAME assistant ContentView owns — so a follow made here is the same
     /// profile the agenda behind the overlay recompiles against.
@@ -173,7 +188,7 @@ struct OnboardingView: View {
     private var converseStep: some View {
         VStack(alignment: .leading, spacing: 20) {
             stepHeading("Fortell meg hva du følger")
-            Text("Skriv fritt på norsk — «Liverpool», «golf, mest de norske», «sjakk når Carlsen spiller». Jeg foreslår, du bekrefter. Si gjerne flere ting etter hverandre.")
+            Text(OnboardingExamples.converseIntro)
                 .font(.sportivista(.subheadline))
                 .foregroundStyle(SportivistaTokens.label.opacity(0.8))
                 .fixedSize(horizontal: false, vertical: true)

--- a/ios/Sportivista/Profile/AddFollowSearchView.swift
+++ b/ios/Sportivista/Profile/AddFollowSearchView.swift
@@ -15,6 +15,12 @@
 //  therefore the "substring traps" — are handled by the shared EntityIndex
 //  helpers, not re-implemented.
 //
+//  WP-164 — the search never dead-ends: a miss offers «Følg likevel», which
+//  creates a NAME-based soft-follow rule (see InterestRule.softFollowId /
+//  AssistantViewModel.softFollow). Downstream matching is already
+//  name-tolerant, so the row waits honestly in «Det du følger» until coverage
+//  arrives.
+//
 
 import SwiftUI
 
@@ -45,6 +51,11 @@ struct AddFollowSearchView: View {
                         Text(emptyMessage)
                             .font(.sportivista(.subheadline))
                             .foregroundStyle(SportivistaTokens.secondaryLabel)
+                        // WP-164: the search never dead-ends at «finnes ikke» —
+                        // a name outside the index can be followed anyway.
+                        if let name = softFollowCandidate {
+                            softFollowRow(name)
+                        }
                     }
                     .listRowBackground(SportivistaTokens.cell)
                 } else {
@@ -85,7 +96,46 @@ struct AddFollowSearchView: View {
         if query.trimmingCharacters(in: .whitespaces).isEmpty {
             return "Søk opp et lag, en utøver eller en turnering å følge."
         }
-        return "Fant ingenting som passer «\(query)». Prøv et annet navn."
+        // WP-164: no «prøv et annet navn»-dead-end — the soft-follow row below
+        // offers the honest way forward.
+        return "Fant ingenting som passer «\(query)»."
+    }
+
+    // MARK: - WP-164 — «Følg likevel» (search never says just «finnes ikke»)
+
+    /// The trimmed query as a soft-follow candidate — non-nil exactly when the
+    /// user typed something and the index had no followable hit.
+    private var softFollowCandidate: String? {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The calm follow-anyway affordance: one quiet action + one honest line
+    /// about what it means. Already soft-followed → a muted read-out instead.
+    @ViewBuilder
+    private func softFollowRow(_ name: String) -> some View {
+        if viewModel.isFollowing(InterestRule.softFollowId(for: name)) {
+            Text("Du følger «\(name)» — venter på dekning.")
+                .font(.sportivista(.subheadline))
+                .foregroundStyle(SportivistaTokens.secondaryLabel)
+                .accessibilityIdentifier("addfollow.softfollowing")
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                Button("Følg «\(name)» likevel") {
+                    viewModel.softFollow(name: name)
+                }
+                .font(.sportivista(.subheadline, weight: .semibold))
+                .foregroundStyle(SportivistaTokens.accent)
+                .buttonStyle(.borderless)
+                .sportivistaTapTarget()
+                .accessibilityIdentifier("addfollow.softfollow")
+                Text("Vi kjenner ikke navnet ennå. Raden i Det du følger venter til dekningen kommer.")
+                    .font(.sportivista(.footnote))
+                    .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 2)
+        }
     }
 
     @ViewBuilder

--- a/ios/Sportivista/Profile/AssistantViewModel+Follow.swift
+++ b/ios/Sportivista/Profile/AssistantViewModel+Follow.swift
@@ -52,4 +52,47 @@ extension AssistantViewModel {
         onProfileChanged?()
         return saved
     }
+
+    // MARK: - WP-164 — soft-follow («Følg likevel»)
+
+    /// Follow a bare NAME the entity index doesn't know — the explicit user
+    /// choice behind «Følg likevel» at a search miss / a grounder rejection.
+    /// Builds a stand-in entity (deterministic soft id, empty type) and runs it
+    /// through the SAME apply path as every other follow; downstream the
+    /// feed/news matching is already name-tolerant, so the rule waits honestly
+    /// («venter på dekning») and starts matching the moment coverage arrives.
+    @discardableResult
+    func softFollow(name: String, sport: String = "", now: Date = Date()) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let entity = Entity(
+            id: InterestRule.softFollowId(for: trimmed),
+            name: trimmed,
+            aliases: [],
+            sport: sport,
+            type: ""
+        )
+        return follow(
+            entity,
+            reason: "Du valgte å følge «\(trimmed)» selv om vi ikke kjenner navnet ennå. Raden venter til dekningen kommer.",
+            now: now
+        )
+    }
+
+    /// Soft-follow the phrase behind a grounder REJECTION — the calm action in
+    /// the avvisningsraden. The anti-hallucination gate is untouched (the model
+    /// still can't invent ids); this is the USER explicitly choosing to follow
+    /// the name anyway. Clears the rejection it answers.
+    @discardableResult
+    func softFollow(from rejection: RejectedMutation, now: Date = Date()) -> Bool {
+        let name = rejection.query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let saved = softFollow(name: name, now: now)
+        dismissRejection(rejection)
+        if !name.isEmpty {
+            // The «ingen endring»-account no longer holds — replace it with a
+            // calm receipt (result-state bookkeeping lives in the main file).
+            noteSoftFollowApplied(named: name)
+        }
+        return saved
+    }
 }

--- a/ios/Sportivista/Profile/EffectiveInterests.swift
+++ b/ios/Sportivista/Profile/EffectiveInterests.swift
@@ -15,7 +15,10 @@
 //  bucket matching its entity type (athlete/team/league → the team & athlete
 //  buckets that ring the bell + earn the accent; tournament → the quieter
 //  tournament bucket), carrying the entity's real aliases from the index so
-//  word-boundary matching still finds it ("Lyn" as well as "FK Lyn Oslo"). It
+//  word-boundary matching still finds it ("Lyn" as well as "FK Lyn Oslo"). A
+//  rule of UNKNOWN type (WP-164: a soft-follow name the index can't resolve)
+//  matches from the athlete bucket too, but with an explicit neutral
+//  notify:false so it never inherits the bucket's bell default. It
 //  NEVER removes what the server already tracks — a `remove` in the profile
 //  simply drops that rule, so it stops being merged in. The local layer sits on
 //  top of the server config; it doesn't fight it (a rule can't suppress a sport
@@ -53,8 +56,16 @@ enum EffectiveInterests {
                 if !contains(teams, name) { teams.append(merged) }
             case "tournament":
                 if !contains(tournaments, name) { tournaments.append(merged) }
-            default: // athlete + any unknown type → the athlete bucket
+            case "athlete", "sport", "category":
                 if !contains(athletes, name) { athletes.append(merged) }
+            default:
+                // WP-164 — an UNKNOWN type (a soft-follow / an id the index can't
+                // resolve) still lands in the athlete bucket for MATCHING, but
+                // with an explicit neutral notify: the athlete bucket's implicit
+                // notify:true is bell semantics (FeedCompiler.notifyEntities)
+                // the user never opted into for a name we can't even resolve.
+                let neutral = Interests.Entity(name: name, aliases: aliases, sport: sport, notify: false)
+                if !contains(athletes, name) { athletes.append(neutral) }
             }
         }
 

--- a/ios/Sportivista/Profile/FollowPresenter.swift
+++ b/ios/Sportivista/Profile/FollowPresenter.swift
@@ -19,7 +19,10 @@
 //    • newsItems(for:)     — the lens-matched news pointers about the rule
 //                           (the detail's SISTE NYTT), via a single-rule NewsLens.
 //    • rowSubtitle(for:)   — the calm «Neste: lør 25. · Strømsgodset – Lyn · TV 2»
-//                           line, or an honest «Ikke satt opp ennå».
+//                           line, or an honest quiet-state line (WP-164): a
+//                           tracked.json season window when one is known,
+//                           «venter på dekning» for a soft-follow, else
+//                           «Fulgt — ingen kommende events på tavla ennå».
 //
 //  Foundation-only and clock-injected (`now` is passed), so FollowPresenterTests
 //  drives every branch against the checked-in fixtures with no SwiftUI + no app.
@@ -71,12 +74,17 @@ struct FollowPresenter {
     let feed: FeedQuery
     let index: EntityIndex
     let news: [NewsItem]
+    /// WP-164 — the synced tracked.json (read-only), the source of the honest
+    /// season line for a follow with nothing on the board. nil degrades to the
+    /// neutral «Fulgt — ingen kommende events …» line.
+    let tracked: TrackedConfig?
     let now: Date
 
-    init(feed: FeedQuery, index: EntityIndex, news: [NewsItem] = [], now: Date = Date()) {
+    init(feed: FeedQuery, index: EntityIndex, news: [NewsItem] = [], tracked: TrackedConfig? = nil, now: Date = Date()) {
         self.feed = feed
         self.index = index
         self.news = news
+        self.tracked = tracked
         self.now = now
     }
 
@@ -152,11 +160,14 @@ struct FollowPresenter {
     ///   • `.scheduled`  — ≥1 upcoming event → the «Neste: …» subtitle.
     ///   • `.idle`       — a real follow that just has nothing right now (a known
     ///                     entity, a whole-sport follow, or one still carrying
-    ///                     news): «Ikke satt opp ennå».
+    ///                     news): «Fulgt — …» with a season line when tracked.json
+    ///                     knows one (WP-164).
     ///   • `.unresolved` — the followed NAME resolves to nothing we know AND has no
-    ///                     news either — most likely a wrong/mistyped name:
-    ///                     «Ingen treff — sjekk navnet», with nearest-name help in
-    ///                     the detail.
+    ///                     news either. For a mistyped follow: «Ingen treff — sjekk
+    ///                     navnet», with nearest-name help in the detail. For a
+    ///                     deliberate soft-follow (WP-164, «Følg likevel»): the
+    ///                     honest «Fulgt — venter på dekning» instead — the user
+    ///                     chose the name knowingly; there is nothing to check.
     enum FollowMatchState: Equatable { case scheduled, idle, unresolved }
 
     /// Classify a rule (see `FollowMatchState`). A whole-sport / category follow is
@@ -188,16 +199,124 @@ struct FollowPresenter {
     // MARK: - Row subtitle
 
     /// The calm per-entity subtitle: «Neste: lør 25. · Strømsgodset – Lyn · TV 2»
-    /// (day · what · where) when scheduled; an honest «Ikke satt opp ennå» when a
-    /// real follow is quiet; or «Ingen treff — sjekk navnet» when the name resolves
-    /// to nothing (the WP-125 lens-miss signal). No technical words ever.
+    /// (day · what · where) when scheduled. When nothing is scheduled (WP-164,
+    /// honest off-season): «Fulgt — sesongstart medio august 2026» when
+    /// tracked.json knows the season window, else the neutral «Fulgt — ingen
+    /// kommende events på tavla ennå»; a soft-follow waits with «Fulgt — venter
+    /// på dekning», and only a genuinely mistyped name gets «Ingen treff — sjekk
+    /// navnet» (the WP-125 lens-miss signal). No technical words ever.
     func rowSubtitle(for rule: InterestRule) -> String {
         if let next = nextEvents(for: rule, limit: 1).first {
             var parts = ["Neste: \(shortDayLabel(dayKey: next.dayKey))", next.title]
             if next.channelLabel != "–" { parts.append(next.channelLabel) }
             return parts.joined(separator: " · ")
         }
-        return matchState(for: rule) == .unresolved ? "Ingen treff — sjekk navnet" : "Ikke satt opp ennå"
+        if let season = seasonLine(for: rule) { return "Fulgt — \(season)" }
+        if matchState(for: rule) == .unresolved {
+            return rule.isSoftFollow ? "Fulgt — venter på dekning" : "Ingen treff — sjekk navnet"
+        }
+        return "Fulgt — ingen kommende events på tavla ennå"
+    }
+
+    // MARK: - Season line (WP-164 — the honest off-season answer)
+
+    /// The season phrase for a quiet follow («sesongstart medio august 2026»),
+    /// pulled from the matching tracked.json entry's `reason` — the server
+    /// bookkeeping ALREADY narrates season windows in plain Norwegian there.
+    /// nil when tracked.json is absent, no entry matches, or no season sentence
+    /// is found (the caller degrades to the neutral line). A mistyped follow
+    /// (`.unresolved`, not soft) never gets a season line — «sjekk navnet» is
+    /// the honest answer there.
+    func seasonLine(for rule: InterestRule) -> String? {
+        if matchState(for: rule) == .unresolved, !rule.isSoftFollow { return nil }
+        return Self.seasonInfo(for: rule, entity: entity(for: rule), tracked: tracked)
+    }
+
+    /// Find the tracked.json entry matching this follow (by id, else by the
+    /// entity's name/alias terms word-boundary-matching the entry name — the
+    /// SAME TextMatch the feed uses, no new fuzzy) and extract its season
+    /// phrase. Static + pure so tests drive it directly.
+    static func seasonInfo(for rule: InterestRule, entity: Entity, tracked: TrackedConfig?) -> String? {
+        guard let tracked else { return nil }
+        let terms = ([rule.entityName, entity.name] + entity.aliases).filter { !$0.isEmpty }
+        let entries = tracked.leagues + tracked.tournaments + tracked.athletes
+        for entry in entries {
+            let hit = entry.id == rule.entityId || terms.contains { term in
+                TextMatch.containsName(entry.name, term) || TextMatch.containsName(term, entry.name)
+            }
+            guard hit else { continue }
+            if let phrase = seasonPhrase(in: entry.reason) { return phrase }
+        }
+        return nil
+    }
+
+    /// Pull the season-window sentence out of a tracked `reason`: the first
+    /// sentence that names BOTH a season/start cue and a month, trimmed at the
+    /// first dash/semicolon clause so only the calm fact remains
+    /// («Sesongstart medio august 2026 — statiske ESPN-fetchere …» →
+    /// «sesongstart medio august 2026»). nil when no such sentence exists or
+    /// the remainder is still too long for a subtitle — graceful degradation,
+    /// never a truncated half-sentence.
+    static func seasonPhrase(in reason: String) -> String? {
+        for sentence in sentences(in: reason) {
+            let lower = sentence.lowercased()
+            guard Self.seasonCues.contains(where: { lower.contains($0) }),
+                  Self.monthNames.contains(where: { lower.contains($0) }) else { continue }
+            var phrase = sentence
+            for separator in [" — ", " – ", "; ", " ("] {
+                if let range = phrase.range(of: separator) {
+                    phrase = String(phrase[..<range.lowerBound])
+                }
+            }
+            phrase = phrase.trimmingCharacters(in: CharacterSet(charactersIn: " .,:—–-"))
+            guard !phrase.isEmpty, phrase.count <= 90 else { continue }
+            return lowercasedIfCommonNoun(phrase)
+        }
+        return nil
+    }
+
+    /// «Sesongstart …» → «sesongstart …» after the subtitle's tankestrek, but a
+    /// phrase leading with a proper noun («Premier League starter …») keeps its
+    /// capital. Only the small closed set of season cue-words is lowered.
+    private static func lowercasedIfCommonNoun(_ phrase: String) -> String {
+        guard let firstWord = phrase.split(separator: " ").first else { return phrase }
+        let lowered = firstWord.lowercased()
+        guard seasonCues.contains(where: { lowered.hasPrefix($0) }) else { return phrase }
+        return lowered + phrase.dropFirst(firstWord.count)
+    }
+
+    private static let seasonCues = [
+        "sesongstart", "seriestart", "sesongåpning", "sesongen starter",
+        "starter", "begynner", "tilbake"
+    ]
+
+    private static let monthNames = [
+        "januar", "februar", "mars", "april", "mai", "juni",
+        "juli", "august", "september", "oktober", "november", "desember"
+    ]
+
+    /// Split a tracked `reason` into sentences: a period followed by whitespace
+    /// and an uppercase letter. Deliberately conservative so «kl. 21.00»,
+    /// «26. aug» and abbreviations never fragment a sentence.
+    private static func sentences(in text: String) -> [String] {
+        var out: [String] = []
+        var current = ""
+        var previous: Character?
+        for (i, ch) in text.enumerated() {
+            current.append(ch)
+            if previous == ".", ch == " " || ch == "\n" {
+                // Peek: next non-space char uppercase ⇒ sentence boundary.
+                let rest = text.dropFirst(i + 1)
+                if let next = rest.first(where: { $0 != " " && $0 != "\n" }), next.isUppercase {
+                    out.append(current.trimmingCharacters(in: .whitespacesAndNewlines))
+                    current = ""
+                }
+            }
+            previous = ch
+        }
+        let tail = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tail.isEmpty { out.append(tail) }
+        return out
     }
 
     // MARK: - Helpers

--- a/ios/Sportivista/Profile/FollowedListView.swift
+++ b/ios/Sportivista/Profile/FollowedListView.swift
@@ -12,7 +12,7 @@
 //      KATEGORIER), so the list reads as what you follow, not one flat blur.
 //    • Row = canonical sport symbol (SportSymbol, WP-108) + name + the PER-ENTITY
 //      next event as the subtitle («Neste: lør 25. · Strømsgodset – Lyn · TV 2»)
-//      or an honest «Ikke satt opp ennå».
+//      or an honest quiet-state line («Fulgt — …», see FollowPresenter WP-164).
 //    • Safe handling: a `.swipeActions` «Slutt å følge» (same confirmation as the
 //      detail) + a calm undo snackbar after a removal.
 //  The next-event / news / grouping is the pure `FollowPresenter` (reusing the
@@ -32,7 +32,7 @@ struct FollowedListView: View {
     /// The read snapshot (relevance-filtered agenda + news + index), rebuilt when
     /// the rule set changes so a just-added follow's next event shows at once.
     @State private var snapshot: AssistantViewModel.FollowSnapshot?
-    /// Precomputed row subtitles (entityId → «Neste: …» / «Ikke satt opp ennå»),
+    /// Precomputed row subtitles (entityId → «Neste: …» / «Fulgt — …»),
     /// so scrolling never re-runs the per-rule event scan.
     @State private var subtitles: [String: String] = [:]
     /// The rule a swipe/detail is confirming a stop for (drives the dialog).
@@ -247,24 +247,47 @@ struct FollowDetailView: View {
     var body: some View {
         List {
             if isUnresolved {
-                Section {
-                    Text("Vi finner ingen kamper eller nyheter for «\(rule.entityName)». Navnet stemmer kanskje ikke helt.")
-                        .font(.sportivista(.subheadline))
-                        .foregroundStyle(SportivistaTokens.label)
-                        .fixedSize(horizontal: false, vertical: true)
-                    ForEach(nameSuggestions, id: \.id) { suggestion in
-                        suggestionRow(suggestion)
+                // WP-164: a deliberate soft-follow («Følg likevel») is not a typo
+                // — it waits honestly for coverage instead of blaming the name.
+                if rule.isSoftFollow {
+                    Section {
+                        Text("Vi kjenner ikke «\(rule.entityName)» ennå, men følger navnet. Raden fylles når events eller nyheter dukker opp.")
+                            .font(.sportivista(.subheadline))
+                            .foregroundStyle(SportivistaTokens.label)
+                            .fixedSize(horizontal: false, vertical: true)
+                        ForEach(nameSuggestions, id: \.id) { suggestion in
+                            suggestionRow(suggestion)
+                        }
+                    } header: {
+                        groupHeader("VENTER PÅ DEKNING")
+                    } footer: {
+                        Text(nameSuggestions.isEmpty
+                            ? "Du trenger ikke gjøre noe — dekning kan komme senere."
+                            : "Mente du ett av disse? Legg det til på nytt i så fall.")
+                            .font(.sportivista(.footnote))
+                            .foregroundStyle(SportivistaTokens.secondaryLabel)
                     }
-                } header: {
-                    groupHeader("SJEKK NAVNET")
-                } footer: {
-                    Text(nameSuggestions.isEmpty
-                        ? "Prøv å legge til på nytt med et litt annet navn."
-                        : "Kanskje du mente ett av disse? Legg det til på nytt om navnet er feil.")
-                        .font(.sportivista(.footnote))
-                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    .listRowBackground(SportivistaTokens.cell)
+                } else {
+                    Section {
+                        Text("Vi finner ingen kamper eller nyheter for «\(rule.entityName)». Navnet stemmer kanskje ikke helt.")
+                            .font(.sportivista(.subheadline))
+                            .foregroundStyle(SportivistaTokens.label)
+                            .fixedSize(horizontal: false, vertical: true)
+                        ForEach(nameSuggestions, id: \.id) { suggestion in
+                            suggestionRow(suggestion)
+                        }
+                    } header: {
+                        groupHeader("SJEKK NAVNET")
+                    } footer: {
+                        Text(nameSuggestions.isEmpty
+                            ? "Prøv å legge til på nytt med et litt annet navn."
+                            : "Kanskje du mente ett av disse? Legg det til på nytt om navnet er feil.")
+                            .font(.sportivista(.footnote))
+                            .foregroundStyle(SportivistaTokens.secondaryLabel)
+                    }
+                    .listRowBackground(SportivistaTokens.cell)
                 }
-                .listRowBackground(SportivistaTokens.cell)
             }
 
             if !upcoming.isEmpty {
@@ -300,7 +323,9 @@ struct FollowDetailView: View {
             }
 
             Section {
-                detailInfoRow("Sport", SportVocabulary.display(for: rule.sport))
+                // WP-164: a soft-follow has no resolved sport yet — honest
+                // «ukjent ennå» beats a silently blank value.
+                detailInfoRow("Sport", rule.sport.isEmpty ? "ukjent ennå" : SportVocabulary.display(for: rule.sport))
                 if let scope = rule.scope, !scope.isEmpty {
                     detailInfoRow("Avgrensning", scope)
                 }

--- a/ios/Sportivista/Profile/InterestProfile.swift
+++ b/ios/Sportivista/Profile/InterestProfile.swift
@@ -74,6 +74,34 @@ struct InterestRule: Codable, Equatable, Identifiable, Sendable {
     }
 }
 
+// MARK: - WP-164 — soft-follow (a NAME-based rule for something the index doesn't know)
+
+extension InterestRule {
+    /// Id prefix for a soft-follow rule — a follow the user created for a NAME
+    /// the entity index couldn't resolve («Følg likevel»). The prefix is what
+    /// lets the presentation layer tell a deliberate name-follow (honest
+    /// «venter på dekning») apart from a mistyped one («sjekk navnet»).
+    /// Downstream matching needs no special case: FeedQuery/EffectiveInterests
+    /// are already name-tolerant (id-first, then name/alias), so a soft rule
+    /// simply starts matching the moment coverage arrives.
+    static let softFollowIdPrefix = "soft-"
+
+    /// Deterministic id for a soft-follow of `name` — the same name yields the
+    /// same id on every device, so the CRDT profile sync converges instead of
+    /// duplicating («soft-erling-haaland» everywhere).
+    static func softFollowId(for name: String) -> String {
+        let normalized = TextMatch.normalize(name)
+        let slug = normalized
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return softFollowIdPrefix + (slug.isEmpty ? "navn" : slug)
+    }
+
+    /// Whether this rule is a soft-follow (created by name, not from the index).
+    var isSoftFollow: Bool { entityId.hasPrefix(Self.softFollowIdPrefix) }
+}
+
 struct InterestProfile: Codable, Equatable, Sendable {
     /// Neutral default weight for a freshly added rule with no explicit weight.
     static let defaultWeight: Double = 0.5

--- a/ios/SportivistaTests/FollowPresenterTests.swift
+++ b/ios/SportivistaTests/FollowPresenterTests.swift
@@ -133,9 +133,10 @@ final class FollowPresenterTests: XCTestCase {
     }
 
     func test_rowSubtitle_honestGapWhenNothingScheduled() {
+        // WP-164: the quiet state says «Fulgt — …», never a bare dead-end.
         XCTAssertEqual(
             presenter().rowSubtitle(for: rule("casper-ruud", "Casper Ruud", "tennis")),
-            "Ikke satt opp ennå"
+            "Fulgt — ingen kommende events på tavla ennå"
         )
     }
 
@@ -159,7 +160,7 @@ final class FollowPresenterTests: XCTestCase {
 
     func test_matchState_unknownNameWithNews_staysIdle() {
         // An entity absent from the index but WITH matching news is a real follow,
-        // just quiet on the agenda — «Ikke satt opp ennå», not «sjekk navnet».
+        // just quiet on the agenda — «Fulgt — …», not «sjekk navnet».
         let news = [NewsItem(id: "n", title: "Nytt", link: "https://x/n", source: "nrk", sport: "esports", entityIds: ["mystery-x"])]
         let p = presenter(news: news)
         XCTAssertEqual(p.matchState(for: rule("mystery-x", "Mystery", "esports")), .idle)
@@ -173,6 +174,121 @@ final class FollowPresenterTests: XCTestCase {
         XCTAssertEqual(p.rowSubtitle(for: typo), "Ingen treff — sjekk navnet")
         // The suggestion reuses the index fuzzy (no new matching) → real Casper Ruud.
         XCTAssertEqual(p.nameSuggestions(for: typo).map(\.name), ["Casper Ruud"])
+    }
+
+    // MARK: - Soft-follow (WP-164 — «Følg likevel» waits honestly)
+
+    func test_softFollow_isUnresolvedButWaitsHonestly() {
+        // A deliberate name-follow of something the index doesn't know: still
+        // `.unresolved` (nothing resolves), but the subtitle never blames the
+        // name — the user chose it knowingly.
+        let p = presenter()
+        let soft = rule(InterestRule.softFollowId(for: "Storhamar"), "Storhamar", "")
+        XCTAssertTrue(soft.isSoftFollow)
+        XCTAssertEqual(p.matchState(for: soft), .unresolved)
+        XCTAssertEqual(p.rowSubtitle(for: soft), "Fulgt — venter på dekning")
+    }
+
+    func test_softFollow_healsToScheduledWhenCoverageArrives() {
+        // The moment an event name-matches, the soft rule behaves like any other
+        // follow — no re-grounding needed (FeedQuery matches id-first, then name).
+        let softFeed = FeedQuery(now: now, events: [
+            event(id: "e-sh", title: "Storhamar – Sola", sport: "handball",
+                  dayKey: "2026-07-25", timeLabel: "18:00", channel: "TV 2 Play",
+                  haystack: "Storhamar Sola REMA 1000-ligaen", hoursFromNow: 30),
+        ])
+        let p = FollowPresenter(feed: softFeed, index: index(), now: now)
+        let soft = rule(InterestRule.softFollowId(for: "Storhamar"), "Storhamar", "")
+        XCTAssertEqual(p.matchState(for: soft), .scheduled)
+        XCTAssertEqual(p.rowSubtitle(for: soft), "Neste: i morgen · Storhamar – Sola · TV 2 Play")
+    }
+
+    // MARK: - Season line (WP-164 — the honest off-season answer)
+
+    private func trackedConfig() -> TrackedConfig {
+        let json = """
+        {
+          "version": 1,
+          "leagues": [
+            {
+              "id": "premier-league-2026-27",
+              "name": "Premier League 2026/27",
+              "sport": "football",
+              "reason": "alwaysTrack.tournaments + interesse for generell oversikt. Sesongstart medio august 2026 — statiske ESPN-fetchere dekker kampene når terminlisten publiseres. Ingen konkrete events ennå.",
+              "addedAt": "2026-07-02T00:00:00Z",
+              "addedBy": "research-agent",
+              "evidence": []
+            }
+          ],
+          "athletes": [
+            {
+              "id": "casper-ruud",
+              "name": "Casper Ruud",
+              "sport": "tennis",
+              "reason": "alwaysTrack.athletes — ingen turneringer på tavla akkurat nå.",
+              "addedAt": "2026-07-02T00:00:00Z",
+              "addedBy": "research-agent",
+              "evidence": []
+            }
+          ],
+          "tournaments": [],
+          "notes": []
+        }
+        """
+        // swiftlint:disable:next force_try
+        return try! SportivistaJSON.decoder.decode(TrackedConfig.self, from: Data(json.utf8))
+    }
+
+    private func seasonIndex() -> EntityIndex {
+        EntityIndex([
+            Entity(id: "premier-league-2026-27", name: "Premier League 2026/27", aliases: ["Premier League"], sport: "football", type: "league"),
+            Entity(id: "casper-ruud", name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis", type: "athlete"),
+        ])
+    }
+
+    func test_rowSubtitle_quietFollow_getsSeasonLineFromTracked() {
+        // Premier League IS known, has no events — tracked.json's reason knows
+        // the season window, so the row says so instead of a bare neutral line.
+        let p = FollowPresenter(feed: FeedQuery(now: now), index: seasonIndex(), tracked: trackedConfig(), now: now)
+        XCTAssertEqual(
+            p.rowSubtitle(for: rule("premier-league-2026-27", "Premier League", "football")),
+            "Fulgt — sesongstart medio august 2026"
+        )
+    }
+
+    func test_rowSubtitle_quietFollow_degradesToNeutralWhenNoSeasonInfo() {
+        // Casper Ruud's tracked reason has no season sentence → the neutral line.
+        let p = FollowPresenter(feed: FeedQuery(now: now), index: seasonIndex(), tracked: trackedConfig(), now: now)
+        XCTAssertEqual(
+            p.rowSubtitle(for: rule("casper-ruud", "Casper Ruud", "tennis")),
+            "Fulgt — ingen kommende events på tavla ennå"
+        )
+    }
+
+    func test_seasonPhrase_extractsAndTrimsTheSeasonSentence() {
+        XCTAssertEqual(
+            FollowPresenter.seasonPhrase(in: "alwaysTrack.tournaments + interesse. Sesongstart medio august 2026 — statiske ESPN-fetchere dekker kampene. Ingen konkrete events ennå."),
+            "sesongstart medio august 2026"
+        )
+        // A proper-noun lead keeps its capital.
+        XCTAssertEqual(
+            FollowPresenter.seasonPhrase(in: "Premier League starter medio august 2026."),
+            "Premier League starter medio august 2026"
+        )
+        // No season sentence → nil (graceful degradation, never a half-sentence).
+        XCTAssertNil(FollowPresenter.seasonPhrase(in: "alwaysTrack.teams — neste kamp er bekreftet mot fotball.no."))
+        // A cue WITHOUT a month is not season info («Verstappen starter fra pole»).
+        XCTAssertNil(FollowPresenter.seasonPhrase(in: "Verstappen starter fra pole i kveld."))
+    }
+
+    func test_seasonLine_neverForAMistypedFollow() {
+        // A mistyped (non-soft) unresolved follow keeps «sjekk navnet» even when
+        // a tracked entry happens to name-match loosely — the honest answer there
+        // is still to check the name.
+        let p = FollowPresenter(feed: FeedQuery(now: now), index: seasonIndex(), tracked: trackedConfig(), now: now)
+        let typo = rule("premier-liga-typo", "Premier Liga", "football")
+        XCTAssertEqual(p.matchState(for: typo), .unresolved)
+        XCTAssertNil(p.seasonLine(for: typo))
     }
 
     // MARK: - News (SISTE NYTT)

--- a/ios/SportivistaTests/OnboardingCopyGroundingTests.swift
+++ b/ios/SportivistaTests/OnboardingCopyGroundingTests.swift
@@ -1,0 +1,56 @@
+//
+//  OnboardingCopyGroundingTests.swift
+//  SportivistaTests
+//
+//  WP-164 (3) — the CI-vakt for the onboarding copy's promise: the converse
+//  step advertises concrete example utterances («Liverpool», «sjakk når Carlsen
+//  spiller»), and every CONCRETE entity name they name-drop must actually
+//  ground against the entity index — otherwise the very first thing the copy
+//  invites a user to say gets rejected. The copy renders from
+//  `OnboardingExamples.converseIntro` and the guard replays
+//  `OnboardingExamples.entityMentions` against the checked-in entities fixture,
+//  so copy and guard can never drift apart.
+//
+//  The grounding basis is `EntityIndex.search` — the real assistant may only
+//  use ids the `searchEntities` tool returns, so a followable search hit IS
+//  what makes an example utterance groundable at runtime.
+//
+
+import XCTest
+
+final class OnboardingCopyGroundingTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    /// Whether a mention can ground at runtime: a followable (non-sport,
+    /// non-category) hit from the same search the FM tool exposes.
+    private func grounds(_ mention: String) -> Bool {
+        !index.search(mention).filter { $0.type != "sport" && $0.type != "category" }.isEmpty
+    }
+
+    func test_everyMentionAppearsInTheRenderedCopy() {
+        for mention in OnboardingExamples.entityMentions {
+            XCTAssertTrue(
+                OnboardingExamples.converseIntro.contains(mention),
+                "«\(mention)» is guarded but no longer in the copy — update OnboardingExamples.entityMentions"
+            )
+        }
+    }
+
+    func test_carlsenExample_groundsAgainstTheFixtureIndex() {
+        XCTAssertTrue(grounds("Carlsen"), "the copy promises «sjakk når Carlsen spiller» — Carlsen must ground")
+    }
+
+    func test_liverpoolExample_groundsAgainstTheFixtureIndex() {
+        // TODO(WP-160): aktiveres når tier2-fixturen lander — WP-160 folder
+        // catalog.tier2 (med Liverpool) inn i entities.json og re-fryser
+        // fixturen. Frem til da er dette en KJENT mangel: non-strict expected
+        // failure, så vakten er grønn både før og etter re-frysen; hovedsesjonen
+        // fjerner XCTExpectFailure etter WP-160-merge.
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("TODO(WP-160): «Liverpool» er ikke i entities-fixturen ennå", options: options) {
+            XCTAssertTrue(grounds("Liverpool"), "the copy promises «Liverpool» — it must ground")
+        }
+    }
+}

--- a/ios/SportivistaTests/SoftFollowTests.swift
+++ b/ios/SportivistaTests/SoftFollowTests.swift
@@ -1,0 +1,181 @@
+//
+//  SoftFollowTests.swift
+//  SportivistaTests
+//
+//  WP-164 — soft-follow («Følg likevel»): a NAME outside the entity index can
+//  still be followed. Proves the whole pure chain with no model and no app:
+//
+//    • the deterministic soft id (same name ⇒ same id on every device, so the
+//      CRDT profile sync converges instead of duplicating);
+//    • navneregel-KOMPILERING: the name rule folds into the effective interests
+//      (athlete bucket) and pulls a name-matched event onto the board — the
+//      downstream matching was already name-tolerant, soft-follow just uses it;
+//    • the notify-default fix: an UNKNOWN entity type gets a NEUTRAL
+//      notify:false instead of inheriting the athlete bucket's bell default,
+//      while a known athlete keeps the bucket default;
+//    • the view-model arm (mock, 0E-regelen): a grounder REJECTION offers the
+//      soft-follow as an explicit user choice — the anti-hallucination gate is
+//      untouched, the user's tap creates the rule and clears the rejection.
+//
+
+import XCTest
+
+@MainActor
+final class SoftFollowTests: XCTestCase {
+
+    private let index = AssistantTestSupport.liveIndex()
+
+    private func makeVM(store: ProfileStore? = nil) -> AssistantViewModel {
+        AssistantViewModel(
+            assistant: MockInterestAssistant(behavior: .available),
+            profileStore: store ?? AssistantTestSupport.tempProfileStore(),
+            index: self.index,
+            misunderstoodLog: AssistantTestSupport.tempMisunderstoodLog()
+        )
+    }
+
+    // MARK: - The deterministic soft id
+
+    func test_softFollowId_isDeterministicSlug() {
+        XCTAssertEqual(InterestRule.softFollowId(for: "Liverpool"), "soft-liverpool")
+        XCTAssertEqual(InterestRule.softFollowId(for: "Erling Haaland"), "soft-erling-haaland")
+        // Diacritics normalise the same way TextMatch does everywhere else.
+        XCTAssertEqual(InterestRule.softFollowId(for: "Vålerenga"), "soft-valerenga")
+        // Same name, same id — whitespace/case never forks the CRDT.
+        XCTAssertEqual(
+            InterestRule.softFollowId(for: "  liverpool "),
+            InterestRule.softFollowId(for: "Liverpool")
+        )
+    }
+
+    func test_isSoftFollow_flagsOnlySoftIds() {
+        let soft = InterestRule(entityId: "soft-liverpool", entityName: "Liverpool", sport: "", weight: 0.5, reason: "r", addedAt: Date())
+        let real = InterestRule(entityId: "fk-lyn-oslo", entityName: "Lyn", sport: "football", weight: 0.5, reason: "r", addedAt: Date())
+        XCTAssertTrue(soft.isSoftFollow)
+        XCTAssertFalse(real.isSoftFollow)
+    }
+
+    // MARK: - The view-model apply path
+
+    func test_softFollow_createsNameRule_throughTheOneApplyPath() {
+        let store = AssistantTestSupport.tempProfileStore()
+        let vm = makeVM(store: store)
+
+        XCTAssertTrue(vm.softFollow(name: "Liverpool"))
+
+        let rule = vm.profile.rule(for: "soft-liverpool")
+        XCTAssertNotNil(rule)
+        XCTAssertEqual(rule?.entityName, "Liverpool")
+        XCTAssertTrue(rule?.isSoftFollow ?? false)
+        XCTAssertFalse(rule?.reason.isEmpty ?? true, "the transparency contract: always a Norwegian reason")
+        XCTAssertTrue(vm.isFollowing("soft-liverpool"))
+        // Persisted through the same store the diff/confirm path uses.
+        XCTAssertNotNil(store.load().rule(for: "soft-liverpool"))
+        // Upsert semantics: soft-following the same name twice is one rule.
+        XCTAssertTrue(vm.softFollow(name: "liverpool "))
+        XCTAssertEqual(vm.profile.rules.filter(\.isSoftFollow).count, 1)
+    }
+
+    func test_softFollow_rejectsEmptyName() {
+        let vm = makeVM()
+        XCTAssertFalse(vm.softFollow(name: "   "))
+        XCTAssertTrue(vm.profile.isEmpty)
+    }
+
+    // MARK: - Navneregel-kompilering (the downstream name tolerance, proven)
+
+    private func softRule(_ name: String) -> InterestRule {
+        InterestRule(
+            entityId: InterestRule.softFollowId(for: name), entityName: name,
+            sport: "", weight: 0.5, reason: "test", addedAt: Date()
+        )
+    }
+
+    func test_merge_softRule_landsInAthleteBucket_withNeutralNotify() {
+        let profile = InterestProfile(rules: [softRule("Liverpool")])
+        let merged = EffectiveInterests.merge(profile: profile, into: Interests(), index: index)
+
+        let entry = merged.alwaysTrack.athletes.first { $0.name == "Liverpool" }
+        XCTAssertNotNil(entry, "an unknown-type name rule matches from the athlete bucket")
+        XCTAssertEqual(entry?.notify, false,
+                       "WP-164: an unknown type gets a NEUTRAL notify — never the bucket's bell default")
+        // And therefore never arms the bell:
+        XCTAssertFalse(FeedCompiler.notifyEntities(merged).contains { $0.name == "Liverpool" })
+    }
+
+    func test_merge_knownAthlete_keepsBucketNotifyDefault() {
+        let entity = index.entity(id: "casper-ruud")!
+        let profile = InterestProfile().applying(GroundedMutation(
+            kind: .add, entity: entity, scope: nil, weight: 0.5, reason: "test", previousRule: nil
+        ))
+        let merged = EffectiveInterests.merge(profile: profile, into: Interests(), index: index)
+
+        let entry = merged.alwaysTrack.athletes.first { $0.name == "Casper Ruud" }
+        XCTAssertNil(entry?.notify, "a KNOWN athlete keeps the bucket default (nil ⇒ notify:true)")
+        XCTAssertTrue(FeedCompiler.notifyEntities(merged).contains { $0.name == "Casper Ruud" })
+    }
+
+    func test_softFollow_bringsNameMatchedEventOntoTheBoard() {
+        let now = AssistantTestSupport.iso("2026-07-21T09:00:00Z")
+        // A handball match — handball is not followed broadly and «Storhamar» is
+        // NOT in the entity index. Invisible before the soft-follow.
+        let event = EventBuilder.make(
+            sport: "handball", title: "Storhamar – Sola", time: "2026-07-21T18:00:00Z",
+            homeTeam: "Storhamar", awayTeam: "Sola", id: "e-storhamar"
+        )
+        XCTAssertNil(index.entity(id: InterestRule.softFollowId(for: "Storhamar")))
+
+        let before = FeedQuery.build(events: [event], interests: Interests(), now: now)
+        XCTAssertTrue(before.events.isEmpty, "an unfollowed handball match is not on the board")
+
+        let effective = EffectiveInterests.merge(
+            profile: InterestProfile(rules: [softRule("Storhamar")]), into: Interests(), index: index
+        )
+        let after = FeedQuery.build(events: [event], interests: effective, now: now)
+        XCTAssertEqual(after.events.map(\.title), ["Storhamar – Sola"],
+                       "the name rule compiles into the effective interests and matches by name")
+    }
+
+    // MARK: - The rejection arm (mock — 0E-regelen)
+
+    func test_softFollowFromRejection_createsRuleAndClearsRejection() async {
+        let vm = makeVM()
+        vm.utterance = "Følg quidditch"
+        await vm.submit()
+        XCTAssertEqual(vm.rejected.count, 1, "the unknown name is rejected — the gate is untouched")
+        let rejection = vm.rejected[0]
+        XCTAssertEqual(rejection.proposal.kind, .add)
+        XCTAssertTrue(rejection.explanation.contains("likevel"),
+                      "the rejection copy names the honest way out")
+
+        XCTAssertTrue(vm.softFollow(from: rejection))
+
+        XCTAssertTrue(vm.rejected.isEmpty, "the rejection is answered, not left dangling")
+        let rule = vm.profile.rules.first { $0.isSoftFollow }
+        XCTAssertNotNil(rule)
+        XCTAssertEqual(rule?.entityName.lowercased(), "quidditch")
+        // The stale «ingen endring»-account is replaced by an honest receipt.
+        XCTAssertNil(vm.explanation, "«jeg endret ingenting» would now be untrue")
+        XCTAssertTrue(vm.commandReceipt?.contains("venter på dekning") ?? false,
+                      "a calm receipt says what happened instead")
+    }
+
+    func test_rejectionText_offersSoftFollowOnlyForAdd() {
+        // A rejected FOLLOW names the way out …
+        let add = MutationGrounder.rejectionText(query: "quidditch", suggestions: [], offerSoftFollow: true)
+        XCTAssertTrue(add.contains("Fant ikke"))
+        XCTAssertTrue(add.contains("likevel"))
+        // … a rejected REMOVE (or the default) never suggests following.
+        let remove = MutationGrounder.rejectionText(query: "quidditch", suggestions: [])
+        XCTAssertTrue(remove.contains("Fant ikke"))
+        XCTAssertFalse(remove.contains("likevel"))
+    }
+
+    func test_ground_rejectedRemove_doesNotOfferSoftFollow() {
+        let proposal = ProposedMutation(kind: .remove, entityId: "", entityQuery: "quidditch", reason: "slutt")
+        let result = MutationGrounder.ground([proposal], index: index, profile: InterestProfile())
+        XCTAssertEqual(result.rejected.count, 1)
+        XCTAssertFalse(result.rejected[0].explanation.contains("likevel"),
+                       "only a rejected FOLLOW offers the soft-follow")
+    }
+}

--- a/ios/SportivistaUITests/FollowedListUITests.swift
+++ b/ios/SportivistaUITests/FollowedListUITests.swift
@@ -6,6 +6,10 @@
 //  the plain list, and its «+» opens the Legg til-søk. In its own file (not the
 //  WP-104-owned MainFlowsUITests) so the parallel waves never touch the same file.
 //
+//  WP-164 — the soft-follow acceptance flow: a search MISS never dead-ends;
+//  «Følg likevel» creates a name-based rule that shows up in «Det du følger»
+//  with the honest «venter på dekning» status.
+//
 
 import XCTest
 
@@ -30,5 +34,64 @@ final class FollowedListUITests: SportivistaUITestCase {
         assertExists(add, "«Det du følger» offers a Legg til «+»")
         add.tap()
         assertExists(app.navigationBars["Legg til"], "«+» opens the Legg til-søk")
+    }
+
+    // WP-164 — søk-miss → «Følg likevel» → rad i «Det du følger» med ærlig status.
+    // «Storhamar» is deliberately ASCII (typeText + æøå is flaky) and absent from
+    // the seeded entities fixture, so the search genuinely misses.
+    func testSearchMissOffersFollowAnyway_andRowWaitsHonestly() {
+        let app = launchApp(state: "agenda")
+
+        app.buttons["nav.settings"].tap()
+        let followsRow = app.buttons["deg.follows"]
+        assertExists(followsRow, "Deg should home «Det du følger»")
+        followsRow.tap()
+        let add = app.buttons["followed.add"]
+        assertExists(add, "«Det du følger» offers a Legg til «+»")
+        add.tap()
+        assertExists(app.navigationBars["Legg til"], "«+» opens the Legg til-søk")
+
+        // Type a name the index doesn't know.
+        let search = app.searchFields.firstMatch
+        assertExists(search, "the Legg til sheet has a search field")
+        search.tap()
+        search.typeText("Storhamar")
+
+        // The miss never dead-ends: the soft-follow affordance appears.
+        let followAnyway = app.buttons["addfollow.softfollow"]
+        assertExists(followAnyway, "a search miss offers «Følg likevel»")
+        attachScreenshot(app, name: "wp164-search-miss")
+        followAnyway.tap()
+
+        // The affordance flips to the honest followed read-out.
+        assertExists(staticText(containing: "venter på dekning", in: app),
+                     "after «Følg likevel» the sheet reads back the waiting follow")
+
+        // Close the sheet — the new rule is a row in «Det du følger» with the
+        // honest «Fulgt — venter på dekning» subtitle (never «sjekk navnet»).
+        // iOS 26 renders the toolbar Lukk as a lowercase-labelled glyph while
+        // the search is active, so match the label case-insensitively (and tap
+        // once more if the first tap only ended the search).
+        let close = app.buttons.matching(NSPredicate(format: "label ==[c] %@", "lukk")).firstMatch
+        assertExists(close, "the Legg til sheet offers a close control")
+        close.tap()
+        if app.navigationBars["Legg til"].waitForExistence(timeout: 2) {
+            let closeAgain = app.buttons.matching(NSPredicate(format: "label ==[c] %@", "lukk")).firstMatch
+            if closeAgain.waitForExistence(timeout: 5) { closeAgain.tap() }
+        }
+        let row = app.buttons["followed.row.soft-storhamar"]
+        assertExists(row, "the soft-follow is a row in «Det du følger»")
+        XCTAssertTrue(row.label.contains("venter på dekning"),
+                      "the row carries the honest waiting status, got: «\(row.label)»")
+        attachScreenshot(app, name: "wp164-followed-row")
+    }
+
+    /// Evidence helper (regel 8: skjermbilder bor i PR-en, aldri i repoet) —
+    /// keepAlways so the PNGs can be exported from the .xcresult afterwards.
+    private func attachScreenshot(_ app: XCUIApplication, name: String) {
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = name
+        shot.lifetime = .keepAlways
+        add(shot)
     }
 }


### PR DESCRIPTION
## Hva

Lukker FASE 0J-pakken WP-164: søket sier aldri bare «finnes ikke», og en stille følging forklarer seg ærlig.

1. **«Følg likevel» ved søke-miss** (`AddFollowSearchView`) — en miss tilbyr én rolig amber-handling + en ærlig linje («Vi kjenner ikke navnet ennå. Raden i Det du følger venter til dekningen kommer.»). Oppretter en **navnebasert regel** med deterministisk soft-id (`InterestRule.softFollowId`: samme navn ⇒ samme id på alle enheter ⇒ CRDT-konvergens, aldri dubletter) gjennom den ENE apply-stien (`AssistantViewModel.follow`). Nedstrøms er `FeedQuery`/`EffectiveInterests` alt navne-tolerante — raden begynner å matche i det dekningen kommer (unit-testet: soft-follow «Storhamar» trekker en navne-matchet håndballkamp på tavla).
2. **Grounder-avvisningen tilbyr soft-follow som eksplisitt BRUKERVALG** (`AssistantResultThread`, kun for FØLG-forslag — aldri for «slutt å følge»). `MutationGrounder` **beholder anti-hallusinasjons-gaten** uendret (modellen kan fortsatt aldri finne på id-er); kun avvisnings-copyen nevner utveien («Du kan likevel følge navnet — da venter det på dekning.»). Etter valget erstattes den nå usanne «ingen endring»-kontoen av en rolig UTFØRT-kvittering.
3. **Notify-default-fiksen** (`EffectiveInterests`): ukjent entitetstype lander fortsatt i atlet-bøtta for MATCHING, men med eksplisitt nøytral `notify:false` — arver ikke lenger bjelle-semantikken (bucket-default `true`) brukeren aldri ba om. Kjente typer (athlete/sport/category) beholder dagens oppførsel bit for bit.
4. **Ærlige stille-linjer i «Det du følger»** (`FollowPresenter`, ny `tracked`-injeksjon via `trackedProvider`):
   - `«Fulgt — sesongstart medio august 2026»` når den matchende tracked.json-entryens `reason` kjenner sesongvinduet (konservativ setnings-ekstraksjon: krever sesong-cue + månedsnavn, trimmer ved tankestrek/semikolon, grasiøs nil ved alt annet);
   - `«Fulgt — venter på dekning»` for soft-follows (aldri «sjekk navnet» — brukeren valgte navnet med viten);
   - nøytral `«Fulgt — ingen kommende events på tavla ennå»` ellers;
   - `«Ingen treff — sjekk navnet»` KUN for reelt feilstavede follows. Detaljarket får en egen **VENTER PÅ DEKNING**-seksjon for soft-follows (og «Sport: ukjent ennå» i stedet for blank verdi).
5. **CI-vakt for onboarding-copyen**: eksemplene er nå data (`OnboardingExamples` — copy rendres fra samme konstant vakten leser), og `OnboardingCopyGroundingTests` grounder hver navngitt entitet mot entitets-fixturen via samme søk FM-verktøyet bruker. «Carlsen» grønn; **«Liverpool»-asserten er non-strict expected failure med `TODO(WP-160): aktiveres når tier2-fixturen lander`** — hovedsesjonen flipper den på etter WP-160-merge (non-strict valgt med vilje så vakten er grønn både før og etter re-frysen, uansett merge-rekkefølge).

## Ikke rørt (bindende ikke-mål)
FM-prompten (`AssistantInstructions`) uendret; diff/bekreft-flyten (`confirm`/`confirmAll`/`reject`) uendret; de fem feed-predikatene uendret; `scripts/`/`docs/` uberørt. Delte fixtures (`entities.json` m.fl.) uberørt — testene bruker test-lokale indekser der WP-160-naboen eier fixturen.

## Verifisering
- **iOS unit-suite: 672 tester, 0 feil** (2 skipped = pre-eksisterende opt-outs). **13 gylne feed-vektorer bit-like** — soft-follow er en additiv regel, ingen predikatendring.
- **Alle 4 schemes bygger** (Sportivista, SportivistaWidgetExtension, SportivistaDeviceDev, SportivistaUITests).
- **Ny UI-flyt-test** `testSearchMissOffersFollowAnyway_andRowWaitsHonestly` (aksept-flyten søk-miss → «Følg likevel» → rad i «Det du følger» med «Fulgt — venter på dekning») **grønn i både dark og light** simulator-appearance.
- **0E-regelen:** assistent-endringen (avvisnings-copy + soft-follow-valget) er deterministisk post-grounding og dekket av mock-tester i samme PR (`SoftFollowTests`: rejection → soft-follow → regel + kvittering; `rejectionText` add-vs-remove). Eval-corpusens eksisterende rejection-case pinner utfallet (tom grounded-mengde), ikke copy-strengen — fortsatt grønn; ingen FM-prompt-endring ⇒ ingen ny eval-case nødvendig.
- **vitest: 877/877 grønt** etter rebase på main (WP-163 landet under arbeidet; null JS endret her).
- Nye unit-tester: navneregel-kompilering (athlete-bøtta + navne-match på tavla), notify-nøytral vs. bucket-default, deterministisk soft-id (inkl. æøå-normalisering), sesonglinje-ekstraksjon (4 kanter), soft-follow-subtitler, selvhelbredende soft-rad når dekning kommer.

## Verifisert visuelt (regel 8 — skjermbilder bor i PR-en, aldri i repoet)
4 skjermbilder tatt via UI-testens attachments og inspisert: **søk-miss med «Følg «Storhamar» likevel»** (dark + light — én amber-handling, ærlig caption, ingen dead-end) og **«Det du følger»-listen** (dark + light — LAG-raden med nøytral «Fulgt — ingen kommende events på tavla ennå», ANNET-raden «Storhamar · Fulgt — venter på dekning» med fallback-glyf).

## Status på Liverpool-vakten
`TODO(WP-160)` — aktiv som non-strict expected failure; flippes til hard assert av hovedsesjonen når WP-160s tier2-refrys av `ios/SportivistaTests/Fixtures/entities.json` er merget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)