### PR TITLE
WP-171: resultat- og tabelldybde — alle sporter, målscorere, standings på iOS

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -261,7 +261,10 @@ null personvern-lekkasje.
 
 Seksjoner: Arena · Om · **Hvor ser jeg det** (lenker) · **Funnet av AI**
 (confidence + kilder, kun AI-events) · **Varsel** (stille status) · **Resultat**
-(spoiler-maskert bak tapp når spoilervern er på). Ingen kort-i-kortet.
+(spoiler-maskert bak tapp når spoilervern er på) · **Tabell** (WP-171: ligatabell /
+golf-ledertavle / F1-VM-stilling, rang · navn · verdi, maks 5 rader + de involverte;
+result-avledet, så den ligger bak SAMME spoiler-maskering som Resultat).
+Ingen kort-i-kortet.
 
 ## Hjelperen (ambient, kontekstbevisst)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2011,7 +2011,7 @@ Bølge 1: WP-170 (iOS-klient) ∥ WP-171 (web-klient + pipeline-visning) ∥ WP-
 | WP | Tittel | Fase | Avhenger av | Status |
 |---|---|---|---|---|
 | WP-170 | Entitetssiden: «laget mitt»-objektet (begge flater) | 0K | 0J WP-160 | planlagt |
-| WP-171 | Resultat- og tabelldybde: alle sporter, målscorere, standings på iOS | 0K | — | planlagt |
+| WP-171 | Resultat- og tabelldybde: alle sporter, målscorere, standings på iOS | 0K | — | 🔬 branch wp-171-resultat-tabell — RESULTAT dekker nå ALLE sporter i recent-results.json på begge flater (én rad-DNA per sport: nøytral tittel · utfall · meta · detaljlinjer), målscorere med minutt rendres (web XSS-trygt via escapeHtml), per-sport round robin + cap 5 med «Vis alle»-disclosure, `standings.json` inn i SyncClient + ny TABELL-flate i event-detalj (ligatabell/golf-ledertavle/F1-VM-stilling, kun når det ER eventets tabell) — alt nytt resultatinnhold bak SAMME spoilervern |
 | WP-172 | Live-paritet: iOS-scorepolling + config-drevet ligaliste (nor.1/nor.2) | 0K | — | planlagt |
 | WP-173 | Kvelds-ferskhet: pipeline-cron 22/23/00/03 UTC (BESKYTTET STI — eier merger) | 0K | — | planlagt |
 | WP-174 | «Min brief»: deterministisk personlig brief on-device (begge flater) | 0K | WP-171 | planlagt |

--- a/docs/js/news-web.js
+++ b/docs/js/news-web.js
@@ -4,7 +4,9 @@
 // quiet hero line above, so it isn't repeated here):
 //
 //   1. NYTT     — news.json pointers, lens-matched, newest first (capped).
-//   2. RESULTAT — followed teams' recent football results (or catalog-wide).
+//   2. RESULTAT — recent results for what you follow, ALL sports in
+//                 recent-results.json (WP-171: football with goal scorers, golf
+//                 leaderboards, F1 podiums, tennis), capped + «Vis alle».
 //   3. FREMOVER — forvarsler beyond 14 d (rendered by dashboard.renderFremover
 //                 into #fremover, which now lives inside the Nyheter view).
 //
@@ -31,6 +33,176 @@ function ssNewsRelevant(item, lens) {
 	const ids = Array.isArray(item.entityIds) ? item.entityIds : [];
 	if (ids.some((id) => lens.entityIds.has(id))) return true;
 	return lens.sports.has(ssCanonicalNewsSport(item.sport));
+}
+
+// ── RESULTAT (WP-171): one row DNA for every sport ───────────────────────────
+// «Hva skjedde i går» must be answered for ALL you follow — the board used to
+// read only `recent-results.json`'s `.football` key while The Open's final
+// leaderboard and the F1 podium sat unused in the same file. The sports have
+// different result DNA (golf = leaderboard position/score, F1 = finishing order,
+// tennis = sets), so instead of three special cases each sport is projected onto
+// ONE row shape — the same shape NewsBoard.swift's NewsResultRow carries:
+//
+//   { id, sport, title, outcome, meta, date, details[], names[] }
+//
+//   • title    — WHO/WHAT played (deliberately outcome-neutral: the tennis title
+//                is the two names sorted alphabetically, never "winner – loser").
+//   • outcome  — the spoiler-carrying payload (score / winner + score).
+//   • details  — the extra lines the fetchers already pay for but nobody showed:
+//                football goal scorers with minute, the golf top-3 + Norwegians,
+//                the F1 podium. Outcome-revealing, so they live WITH `outcome`
+//                (iOS masks both behind the same «Vis resultat» shield).
+//   • names    — the participant names the on-device lens matches against.
+
+/** The result cap per section (ro — the RESULTAT section must never become a
+ *  result stream). Everything beyond it is reachable in a «Vis alle» disclosure,
+ *  never dropped. Mirrors NewsBoard.resultCap. */
+const SS_RESULT_CAP = 5;
+
+/** Detail lines per row. Ro again: a 10-goal World Cup match would otherwise
+ *  render eleven scorer lines and turn one row into a wall. Five is the honest
+ *  floor — a golf row's top-3 PLUS both Norwegians must survive it. Mirrors
+ *  NewsBoard.detailCap. */
+const SS_RESULT_DETAIL_CAP = 5;
+
+const SS_GOLF_TOUR_NB = { pga: 'PGA Tour', dpWorld: 'DP World Tour' };
+
+/** Cap the detail lines, saying honestly how many were left out. */
+function ssCapDetails(lines) {
+	const list = (lines || []).filter(Boolean);
+	if (list.length <= SS_RESULT_DETAIL_CAP) return list;
+	return list.slice(0, SS_RESULT_DETAIL_CAP).concat([`+${list.length - SS_RESULT_DETAIL_CAP} til`]);
+}
+
+/** "8' Kristian Eriksen (SK Brann)" — one line per goal, minute first (the data
+ *  fetch-results.js has always carried in `goalScorers` and no surface rendered). */
+function ssGoalScorerLines(result) {
+	const scorers = Array.isArray(result && result.goalScorers) ? result.goalScorers : [];
+	return scorers.map((g) => {
+		const player = String((g && g.player) || '').trim();
+		if (!player) return '';
+		const minute = String((g && g.minute) || '').trim();
+		const team = String((g && g.team) || '').trim();
+		return `${minute ? `${minute} ` : ''}${player}${team ? ` (${team})` : ''}`;
+	}).filter(Boolean);
+}
+
+/** "1. Ryan Fox −10" — a leaderboard/finishing-order line. */
+function ssPositionLine(position, name, score) {
+	const who = String(name || '').trim();
+	if (!who) return '';
+	const pos = position != null && position !== '' ? `${position}. ` : '';
+	const sc = String(score == null ? '' : score).trim();
+	return `${pos}${who}${sc ? ` ${sc}` : ''}`;
+}
+
+/** Project `recent-results.json` onto the shared row DNA — every sport in the
+ *  file, not just football. Pure; the lens filters afterwards. */
+function ssResultRows(recentResults) {
+	const data = recentResults || {};
+	const rows = [];
+
+	for (const r of Array.isArray(data.football) ? data.football : []) {
+		const home = String(r.homeTeam || '').trim(), away = String(r.awayTeam || '').trim();
+		if (!home || !away) continue;
+		const hasScore = Number.isFinite(r.homeScore) && Number.isFinite(r.awayScore);
+		rows.push({
+			id: `football|${home}|${away}|${r.date || ''}`,
+			sport: 'football',
+			title: `${home} – ${away}`,
+			outcome: hasScore ? `${r.homeScore}–${r.awayScore}` : '',
+			meta: String(r.league || ''),
+			date: r.date || '',
+			details: ssCapDetails(ssGoalScorerLines(r)),
+			names: [home, away],
+		});
+	}
+
+	const golf = (data.golf && typeof data.golf === 'object') ? data.golf : {};
+	for (const key of Object.keys(golf)) {
+		const tour = golf[key];
+		// Only a FINISHED tournament is a result; an in-progress leaderboard
+		// belongs to the agenda/live surface, not to «hva skjedde».
+		if (!tour || tour.status !== 'final') continue;
+		const top = Array.isArray(tour.topPlayers) ? tour.topPlayers : [];
+		const norwegians = Array.isArray(tour.norwegianPlayers) ? tour.norwegianPlayers : [];
+		if (!top.length) continue;
+		const winner = top[0];
+		const details = top.slice(0, 3).map((p) => ssPositionLine(p.position, p.player, p.score))
+			.concat(norwegians.map((p) => ssPositionLine(p.position, p.player, p.score)))
+			.filter(Boolean);
+		rows.push({
+			id: `golf|${key}|${tour.tournamentName || ''}`,
+			sport: 'golf',
+			title: String(tour.tournamentName || 'Golfturnering'),
+			outcome: ssPositionLine('', winner.player, winner.score),
+			meta: [SS_GOLF_TOUR_NB[key] || key, 'sluttresultat'].filter(Boolean).join(' · '),
+			date: tour.date || '',
+			details: ssCapDetails(details),
+			names: top.map((p) => p.player).concat(norwegians.map((p) => p.player)).filter(Boolean),
+		});
+	}
+
+	for (const r of Array.isArray(data.f1) ? data.f1 : []) {
+		const drivers = Array.isArray(r.topDrivers) ? r.topDrivers : [];
+		if (!drivers.length) continue;
+		rows.push({
+			id: `f1|${r.raceName || ''}|${r.date || ''}`,
+			sport: 'f1',
+			title: String(r.raceName || 'Grand Prix'),
+			outcome: String(drivers[0].driver || ''),
+			meta: [String(r.circuit || ''), String(r.type || '')].filter(Boolean).join(' · '),
+			date: r.date || '',
+			details: drivers.slice(0, 3).map((d) => ssPositionLine(d.position, d.driver, '')).filter(Boolean),
+			names: drivers.map((d) => d.driver).filter(Boolean),
+		});
+	}
+
+	for (const r of Array.isArray(data.tennis) ? data.tennis : []) {
+		const winner = String(r.winner || '').trim(), loser = String(r.loser || '').trim();
+		if (!winner || !loser) continue;
+		// Outcome-neutral title: the pair sorted alphabetically, so the row itself
+		// never spoils who won (the outcome lives in `outcome`, which iOS masks).
+		const pair = [winner, loser].sort((a, b) => a.localeCompare(b, 'nb'));
+		rows.push({
+			id: `tennis|${winner}|${loser}|${r.date || ''}`,
+			sport: 'tennis',
+			title: `${pair[0]} – ${pair[1]}`,
+			outcome: [winner, String(r.score || '')].filter(Boolean).join(' '),
+			meta: [String(r.tournament || ''), String(r.round || '')].filter(Boolean).join(' · '),
+			date: r.date || '',
+			details: [],
+			names: [winner, loser],
+		});
+	}
+
+	return rows;
+}
+
+/** Order the rows so EVERY sport gets an answer before any sport gets a second
+ *  one: per-sport newest-first, then a round-robin across sports (sports ordered
+ *  by their own newest result). Without it a busy football weekend would push
+ *  The Open's final result out of the capped section entirely. Mirrors
+ *  NewsBoard.interleaveBySport. */
+function ssInterleaveBySport(rows) {
+	const stamp = (r) => { const t = Date.parse((r && r.date) || ''); return Number.isNaN(t) ? -Infinity : t; };
+	const groups = new Map();
+	for (const r of rows || []) {
+		if (!groups.has(r.sport)) groups.set(r.sport, []);
+		groups.get(r.sport).push(r);
+	}
+	for (const list of groups.values()) list.sort((a, b) => stamp(b) - stamp(a));
+	const order = Array.from(groups.keys()).sort((a, b) => stamp(groups.get(b)[0]) - stamp(groups.get(a)[0]));
+	const out = [];
+	for (let i = 0; ; i++) {
+		let took = false;
+		for (const sport of order) {
+			const list = groups.get(sport);
+			if (i < list.length) { out.push(list[i]); took = true; }
+		}
+		if (!took) break;
+	}
+	return out;
 }
 
 // ── Dashboard prototype extension (DOM) ──────────────────────────────────────
@@ -103,13 +275,18 @@ if (typeof Dashboard !== 'undefined') Object.assign(Dashboard.prototype, {
 			: `<div class="nw-row">${inner}</div>`;
 	},
 
-	/** One RESULTAT row: a followed team's recent football result with its score. */
+	/** One RESULTAT row, in the shared per-sport DNA (WP-171): what · quiet meta ·
+	 *  the detail lines the data already carries (goal scorers with minute, the
+	 *  golf top-3 + Norwegians, the F1 podium) · the outcome on the right. Every
+	 *  data string goes through escapeHtml (client-render rule). */
 	resultRow(r) {
-		const title = `${escapeHtml(r.homeTeam || '')} – ${escapeHtml(r.awayTeam || '')}`;
-		const hasScore = Number.isFinite(r.homeScore) && Number.isFinite(r.awayScore);
-		const score = hasScore ? `<span class="rs-score">${r.homeScore}–${r.awayScore}</span>` : '';
-		const meta = r.league ? `<span class="rs-meta">${escapeHtml(r.league)}</span>` : '';
-		return `<div class="rs-row"><span class="rs-main"><span class="rs-title">${title}</span>${meta}</span>${score}</div>`;
+		const title = `<span class="rs-title">${escapeHtml(r.title || '')}</span>`;
+		const outcome = r.outcome ? `<span class="rs-score">${escapeHtml(r.outcome)}</span>` : '';
+		const meta = r.meta ? `<span class="rs-meta">${escapeHtml(r.meta)}</span>` : '';
+		const details = (Array.isArray(r.details) ? r.details : [])
+			.map((line) => `<span class="rs-meta rs-detail">${escapeHtml(line)}</span>`)
+			.join('');
+		return `<div class="rs-row"><span class="rs-main">${title}${meta}${details}</span>${outcome}</div>`;
 	},
 
 	/** The lens-matched news, newest first, capped. */
@@ -122,24 +299,27 @@ if (typeof Dashboard !== 'undefined') Object.assign(Dashboard.prototype, {
 			.slice(0, max);
 	},
 
-	/** Followed teams' recent football results (newest first); catalog-wide when
-	 *  the profile is empty. Matched by an entity NAME hit on either team. */
-	resultItems(max = 8) {
-		const football = (this.recentResults && this.recentResults.football) || [];
+	/** Recent results for what you follow — ALL sports in recent-results.json
+	 *  (WP-171), not just football. A row is in when the profile is empty
+	 *  (catalog-wide, the web's default elsewhere), when its sport is a followed
+	 *  WHOLE-sport, or when a followed entity's name hits one of its
+	 *  participants. Returned interleaved per sport, uncapped — the caller caps
+	 *  the visible part and puts the rest in the «Vis alle» disclosure. */
+	resultItems() {
+		const rows = ssResultRows(this.recentResults);
 		const lens = this.newsLens();
-		let list = football;
+		let list = rows;
 		if (!lens.catalogWide) {
 			const names = [];
 			const live = (this.profile && this.profile.rules || []).filter((r) => !r.deleted).map((r) => r.rule || r);
 			for (const rule of live) if (rule && rule.entityName) names.push(rule.entityName);
-			list = football.filter((r) => {
-				const hay = `${r.homeTeam || ''} ${r.awayTeam || ''}`;
+			list = rows.filter((r) => {
+				if (lens.sports.has(ssCanonicalNewsSport(r.sport))) return true;
+				const hay = (r.names || []).join(' ');
 				return names.some((n) => ssContainsTerm(hay, n));
 			});
 		}
-		return list.slice()
-			.sort((a, b) => (Date.parse(b.date || 0) - Date.parse(a.date || 0)))
-			.slice(0, max);
+		return ssInterleaveBySport(list);
 	},
 
 	/** Render the Nyheter board's NYTT + RESULTAT sections into #nyheter. FREMOVER
@@ -156,8 +336,17 @@ if (typeof Dashboard !== 'undefined') Object.assign(Dashboard.prototype, {
 			: '<p class="nw-empty">Ingen nyheter om det du følger akkurat nå.</p>';
 		html += '</section>';
 		if (results.length) {
+			// Ro: a capped section, with the remainder in one quiet disclosure
+			// («Vis alle») instead of an endless result stream. Same cap the iOS
+			// board uses (NewsBoard.resultCap).
+			const shown = results.slice(0, SS_RESULT_CAP);
+			const rest = results.slice(SS_RESULT_CAP);
 			html += '<section class="nw-section"><h2 class="nw-head">Resultat</h2>';
-			html += results.map((r) => this.resultRow(r)).join('');
+			html += shown.map((r) => this.resultRow(r)).join('');
+			if (rest.length) {
+				html += `<details class="fremover rs-all"><summary>Vis alle <span class="fwd-count">${rest.length}</span></summary>`;
+				html += `<div class="fwd-body">${rest.map((r) => this.resultRow(r)).join('')}</div></details>`;
+			}
 			html += '</section>';
 		}
 		el.innerHTML = html;
@@ -185,5 +374,5 @@ if (typeof Dashboard !== 'undefined') Object.assign(Dashboard.prototype, {
 
 // Node/vitest interop (pure helpers).
 if (typeof module !== 'undefined' && module.exports) {
-	module.exports = { ssNewsRelevant, ssCanonicalNewsSport };
+	module.exports = { ssNewsRelevant, ssCanonicalNewsSport, ssResultRows, ssInterleaveBySport, SS_RESULT_CAP };
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -201,7 +201,9 @@ SyncResult`):
    `SyncState.appliedFiles` (a **reconciled** snapshot of what the cache has actually
    applied, *not* a copy of the last server manifest), and fetch only files that
    changed **and** are in `filesOfInterest` (`events`/`entities`/`tracked`/
-   `interests`.json — the ~24 other manifest entries are irrelevant here).
+   `app-version`/`news`/`featured`/`recent-results`/`standings`.json — the ~22 other
+   manifest entries are irrelevant here; `standings.json` joined in WP-171 for the
+   detail sheet's TABELL surface).
 4. Each fetched file is **verified against the manifest's declared sha256**
    (`Checksum.swift`, CryptoKit) before it is trusted, then written **atomically**.
    A mismatch or network hiccup silently discards that one file, leaves the old copy
@@ -289,7 +291,11 @@ varsel state is in the detail sheet); a quiet mono `ⓘ` trails only on
 notification reconcile (see [Notifications](#notifications)). Tapping a row opens
 `EventDetailSheet` (venue, summary, streaming as real `Link`s, the AI-provenance
 block only on `ai-research` rows, a quiet varsel read-out, the spoiler-masked
-`RESULTAT`, and the assistant [context actions](#assistant)) or `SeriesDetailSheet`
+`RESULTAT`, the **`TABELL`** section (WP-171 — `EventStandingsSection`: the league
+table / golf leaderboard / F1 championship from `standings.json`, built by the pure
+`StandingsTable`, shown only when it is genuinely THIS event's table and masked
+behind the same spoiler reveal), and the assistant [context actions](#assistant))
+or `SeriesDetailSheet`
 (the expanded stage race: every Norwegian rider de-duplicated, the next stage's
 summary, every stage as its own line).
 
@@ -313,9 +319,13 @@ unread counters, no engagement mechanics (spec § Nyheter-v0, DESIGN § Nyheter)
   no clock read, so the whole board is unit-testable directly (`NewsBoardTests` /
   `NewsLensTests`) and the view is a thin renderer over it. Four sections: **I DIN
   VERDEN I DAG** (the editorial headline from `featured.json`, one line), **NYTT**
-  (lens-matched `news.json` pointers, newest first, capped 20), **RESULTAT** (followed
-  teams' recent football results, each stamped whether the spoiler shield must mask
-  its score), **FREMOVER** (followed events beyond the 7-day near horizon —
+  (lens-matched `news.json` pointers, newest first, capped 20), **RESULTAT** (recent
+  results for what you follow across EVERY sport in `recent-results.json` — football
+  with goal scorers + minute, a finished golf tournament's leaderboard, the F1
+  finishing order, tennis — projected onto ONE row DNA, ordered by a per-sport round
+  robin (`interleaveBySport`) so every sport gets an answer inside the `resultCap` of
+  5, the rest behind «Vis alle»; each row stamped whether the spoiler shield must
+  mask its outcome AND its detail lines), **FREMOVER** (followed events beyond the 7-day near horizon —
   forvarsler; capped 8, via `FeedCompiler.isEventInWindow`, never a manual `time >= x`
   filter so multi-day events survive).
 - `NewsLens.swift` — the **client-side lens** (the two-layer architecture: the server

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -94,6 +94,12 @@ struct EventDetailSheet: View {
                 // The result (spoiler-masked when needed) is the LAST section, so a
                 // glance at the sheet never lands on the outcome first.
                 resultSection
+
+                // WP-171: TABELL last — the league table / golf leaderboard /
+                // F1 championship for this event (web has had it in the detail
+                // sheet since WP-14). One call site; everything it needs lives
+                // in EventStandingsSection, including the spoiler masking.
+                EventStandingsSection(row: row)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)

--- a/ios/Sportivista/Agenda/EventStandingsSection.swift
+++ b/ios/Sportivista/Agenda/EventStandingsSection.swift
@@ -1,0 +1,249 @@
+//
+//  EventStandingsSection.swift
+//  Sportivista
+//
+//  WP-171 — the TABELL surface in the event detail sheet: the league table, the
+//  golf leaderboard or the F1 championship for the event you just tapped. The
+//  web detail sheet has answered "hvor står de?" since WP-14 (detail.js
+//  `footballStanding` / `golfContext` / `addF1Context`); the app didn't even
+//  sync standings.json. This closes that parity debt.
+//
+//  Two halves, deliberately split:
+//    • `StandingsTable` — PURE. Event + Standings in, rows out. No I/O, no
+//      clock, no SwiftUI, so the fixture test drives the real thing.
+//    • `EventStandingsSection` — the thin renderer, which reads the cached
+//      standings OFF the main actor and respects the SPOILER SHIELD: a table is
+//      derived from results (a league table after last night's round, a live
+//      leaderboard, the championship after the last race), so it is masked
+//      behind the same «Vis tabell» reveal as the sheet's own RESULTAT section
+//      whenever `row.spoilerSafe` is false.
+//
+//  Non-goal (WP-171): NO live updating. The hourly static pipeline's cadence is
+//  the cadence — the section reads the cache once when the sheet appears.
+//
+
+import SwiftUI
+
+// MARK: - Pure table builder
+
+/// One rendered standings table: a heading, a handful of rows, and an honest
+/// footnote when rows were left out.
+struct StandingsTable: Equatable {
+    var title: String
+    var rows: [StandingsTableRow]
+
+    /// How many rows a table shows before the "highlighted" extras (ro — the
+    /// sheet answers "hvor står de", it is not a full-table browser).
+    static let topRows = 5
+
+    /// Build the table for an event, or `nil` when there is nothing honest to
+    /// show (no standings synced, or a sport with no table).
+    static func build(event: Event, standings: Standings?) -> StandingsTable? {
+        guard let standings, !standings.isEmpty else { return nil }
+        switch TextMatch.normalize(event.sport) {
+        case "football": return football(event: event, standings: standings.football)
+        case "golf": return golf(event: event, tours: standings.golf)
+        case "f1": return formula1(standings.f1)
+        default: return nil
+        }
+    }
+
+    // MARK: Football — the league table, with BOTH teams always visible
+
+    private static func football(event: Event, standings: FootballStandings) -> StandingsTable? {
+        let tournament = (event.tournament ?? "").lowercased()
+        let isSpanish = tournament.contains("la liga") || tournament.contains("copa")
+        let table = isSpanish ? standings.laLiga : standings.premierLeague
+        guard !table.isEmpty else { return nil }
+
+        let involved = [event.homeTeam, event.awayTeam].compactMap { $0 }.filter { !$0.isEmpty }
+        let highlighted = table.filter { entry in
+            involved.contains { TextMatch.containsName(entry.team, $0) || TextMatch.containsName($0, entry.team) }
+        }
+        // HONEST GATE: show a table only when it is actually THIS match's table.
+        // Football events cover far more leagues than we publish standings for
+        // (Eliteserien, OBOS, friendlies …); without this, an OBOS fixture would
+        // render the Premier League top five as if it were its own table. The web
+        // detail sheet applies the same rule (detail.js `footballStanding` returns
+        // "" unless it finds the teams).
+        guard !highlighted.isEmpty else { return nil }
+        // Top of the table plus the two teams playing — a team down in 14th is
+        // exactly what the tap was asking about, so it is never cut away.
+        var picked = Array(table.prefix(topRows))
+        for entry in highlighted where !picked.contains(where: { $0.position == entry.position }) {
+            picked.append(entry)
+        }
+        picked.sort { $0.position < $1.position }
+
+        let rows = picked.map { entry in
+            StandingsTableRow(
+                id: "table|\(entry.position)|\(entry.team)",
+                rank: "\(entry.position).",
+                name: entry.team,
+                value: "\(entry.points)",
+                highlighted: highlighted.contains(entry)
+            )
+        }
+        return StandingsTable(title: isSpanish ? "LA LIGA" : "PREMIER LEAGUE", rows: rows)
+    }
+
+    // MARK: Golf — the leaderboard, with the tracked (Norwegian) players kept
+
+    private static func golf(event: Event, tours: [String: GolfLeaderboard]) -> StandingsTable? {
+        let haystack = "\(event.tournament ?? "") \(event.title)".lowercased()
+        // Only THIS event's tournament (same honest gate as football): a
+        // leaderboard from another week's tour is not this event's table.
+        let ordered = tours.keys.sorted().compactMap { key -> GolfLeaderboard? in tours[key] }
+        let board = ordered.first { board in
+            guard let name = board.name?.lowercased(), !name.isEmpty, !board.leaderboard.isEmpty else { return false }
+            return haystack.contains(name)
+        }
+        guard let board else { return nil }
+
+        var rows = board.leaderboard.prefix(topRows).map { entry in
+            StandingsTableRow(
+                id: "golf|\(entry.player)",
+                rank: entry.positionDisplay ?? entry.position.map { "\($0)." } ?? "–",
+                name: entry.player,
+                value: entry.score ?? "–",
+                highlighted: false
+            )
+        }
+        for entry in board.trackedPlayers where !rows.contains(where: { $0.name == entry.player }) {
+            rows.append(StandingsTableRow(
+                id: "golf|\(entry.player)",
+                rank: entry.positionDisplay ?? entry.position.map { "\($0)." } ?? "–",
+                name: entry.player,
+                value: entry.score ?? "–",
+                highlighted: true
+            ))
+        }
+        return StandingsTable(title: (board.name ?? "LEDERTAVLE").uppercased(), rows: rows)
+    }
+
+    // MARK: F1 — the drivers' championship
+
+    private static func formula1(_ standings: F1Standings) -> StandingsTable? {
+        guard !standings.drivers.isEmpty else { return nil }
+        let rows = standings.drivers.prefix(topRows).map { d in
+            StandingsTableRow(
+                id: "f1|\(d.driver)",
+                rank: "\(d.position).",
+                name: d.driver,
+                value: "\(d.points)",
+                highlighted: false
+            )
+        }
+        return StandingsTable(title: "VM-STILLING", rows: Array(rows))
+    }
+}
+
+/// One table line: rank · name · value (points / score). `highlighted` marks the
+/// row the tap was actually about (a team playing, a tracked Norwegian).
+struct StandingsTableRow: Identifiable, Equatable {
+    var id: String
+    var rank: String
+    var name: String
+    var value: String
+    var highlighted: Bool
+}
+
+// MARK: - The sheet section
+
+/// The TABELL section of the event detail sheet. Reads the cached standings
+/// off the main actor once, then renders the pure table — masked behind «Vis
+/// tabell» whenever the spoiler shield applies to this event, because a table
+/// is result-derived and would otherwise leak exactly what the shield exists to
+/// hide.
+struct EventStandingsSection: View {
+    let row: AgendaEventRow
+    /// Injected so the fixture tests (and previews) can drive the section with a
+    /// literal `Standings` and no cache at all.
+    var load: @Sendable () -> Standings? = { DataStore().loadStandings() }
+
+    @State private var standings: Standings?
+    @State private var loaded = false
+    @State private var revealed = false
+
+    private var table: StandingsTable? { StandingsTable.build(event: row.event, standings: standings) }
+
+    var body: some View {
+        Group {
+            if let table {
+                Section {
+                    if row.spoilerSafe || revealed {
+                        ForEach(table.rows) { line in
+                            StandingsRowView(line: line)
+                                .listRowBackground(SportivistaTokens.cell)
+                        }
+                    } else {
+                        Button {
+                            revealed = true
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "eye.slash")
+                                    .font(.sportivista(.caption))
+                                Text("Vis tabell")
+                                    .font(.sportivista(.subheadline, weight: .semibold))
+                            }
+                            .foregroundStyle(SportivistaTokens.accent)
+                            .frame(minHeight: 44, alignment: .leading)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("detail.standings.reveal")
+                        .listRowBackground(SportivistaTokens.cell)
+                    }
+                } header: {
+                    Text(table.title)
+                        .font(.sportivista(.caption2, weight: .semibold))
+                        .foregroundStyle(SportivistaTokens.secondaryLabel)
+                        .tracking(0.5)
+                        .accessibilityIdentifier("detail.section.standings")
+                }
+            } else {
+                // The load has to hang off a view that EXISTS before the table
+                // does — an empty `Group` has no children, so a `.task` on it
+                // would never run and the section could never appear (chicken
+                // and egg). A zero-height, invisible row carries it and vanishes
+                // the moment the table renders.
+                Color.clear
+                    .frame(height: 0)
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .task {
+                        guard !loaded else { return }
+                        loaded = true
+                        let loader = load
+                        standings = await Task.detached { loader() }.value
+                    }
+            }
+        }
+    }
+}
+
+/// One table line: a tabular rank column, the name, and the value on the right.
+/// The involved team / tracked player is set apart by WEIGHT, never by a second
+/// colour (DESIGN § Farge: amber is the one accent, reserved for action/state).
+private struct StandingsRowView: View {
+    let line: StandingsTableRow
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(line.rank)
+                .font(.sportivistaTabular(.footnote))
+                .foregroundStyle(SportivistaTokens.secondaryLabel)
+                .frame(minWidth: 34, alignment: .leading)
+            Text(line.name)
+                .font(.sportivista(.subheadline, weight: line.highlighted ? .semibold : .regular))
+                .foregroundStyle(SportivistaTokens.label)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(line.value)
+                .font(.sportivistaTabular(.subheadline, weight: line.highlighted ? .semibold : .regular))
+                .foregroundStyle(SportivistaTokens.label)
+        }
+        .padding(.vertical, 1)
+    }
+}

--- a/ios/Sportivista/Demo/NewsDemoSeed.swift
+++ b/ios/Sportivista/Demo/NewsDemoSeed.swift
@@ -58,16 +58,74 @@ enum NewsDemoSeed {
 			"blocks": [["type": "headline", "text": "Opprykksfest for Lyn — og langrennssesongen banker på"]],
 		]
 
-		// SECTION 3 — RESULTAT: a followed-team result (no spoiler policy seeded,
-		// so it shows plainly — the masked path is unit-tested).
+		// SECTION 3 — RESULTAT: followed results across EVERY sport the file
+		// carries (WP-171) — football with goal scorers, a finished golf major, an
+		// F1 race, a tennis match — so the screenshot shows the per-sport row DNA
+		// and the interleave. No spoiler policy seeded, so they show plainly; the
+		// masked path is unit-tested.
 		let recentResults: [String: Any] = [
 			"football": [
 				[
 					"homeTeam": "Lyn", "awayTeam": "Sogndal", "homeScore": 2, "awayScore": 1,
 					"date": at(days: -1), "league": "OBOS-ligaen", "venue": "Bislett stadion, Oslo",
+					"goalScorers": [
+						["player": "Kristian Eriksen", "team": "Lyn", "minute": "8'"],
+						["player": "Ola Nordmann", "team": "Sogndal", "minute": "51'"],
+						["player": "Simen Juklerød", "team": "Lyn", "minute": "88'"],
+					],
 					"isFavorite": true,
 				],
 			],
+			"golf": [
+				"pga": [
+					"tournamentName": "The Open", "status": "final", "completedRound": 4,
+					"topPlayers": [
+						["position": 1, "player": "Ryan Fox", "score": "-10"],
+						["position": 2, "player": "Cameron Young", "score": "-9"],
+						["position": 3, "player": "Sam Burns", "score": "-8"],
+					],
+					"norwegianPlayers": [["position": 121, "player": "Viktor Hovland", "score": "+4"]],
+				],
+			],
+			"f1": [
+				[
+					"raceName": "Belgias Grand Prix", "type": "Race", "date": at(days: -2),
+					"circuit": "Spa-Francorchamps",
+					"topDrivers": [
+						["position": 1, "driver": "Kimi Antonelli"],
+						["position": 2, "driver": "Charles Leclerc"],
+						["position": 3, "driver": "Max Verstappen"],
+					],
+				],
+			],
+			"tennis": [
+				[
+					"winner": "Casper Ruud", "loser": "Alexander Zverev", "score": "6-4, 7-5",
+					"date": at(days: -3), "tournament": "ATP Hamburg", "round": "Semifinale",
+				],
+			],
+		]
+
+		// WP-171 — the event-detail TABELL surface reads standings.json; seed the
+		// league table the Premier League fixture below opens on.
+		let standings: [String: Any] = [
+			"football": [
+				"premierLeague": [
+					["position": 1, "team": "Liverpool", "teamShort": "LIV", "played": 12, "points": 29, "gd": 18],
+					["position": 2, "team": "Arsenal", "teamShort": "ARS", "played": 12, "points": 27, "gd": 14],
+					["position": 3, "team": "Manchester City", "teamShort": "MCI", "played": 12, "points": 25, "gd": 12],
+					["position": 4, "team": "Chelsea", "teamShort": "CHE", "played": 12, "points": 24, "gd": 9],
+					["position": 5, "team": "Newcastle United", "teamShort": "NEW", "played": 12, "points": 22, "gd": 7],
+					["position": 14, "team": "Everton", "teamShort": "EVE", "played": 12, "points": 13, "gd": -4],
+				],
+				"laLiga": [],
+			],
+			"f1": ["drivers": [
+				["position": 1, "driver": "Kimi Antonelli", "team": "Mercedes", "points": 204],
+				["position": 2, "driver": "Lewis Hamilton", "team": "Ferrari", "points": 159],
+				["position": 3, "driver": "George Russell", "team": "Mercedes", "points": 154],
+			]],
+			"golf": [:],
 		]
 
 		// SECTION 4 — FREMOVER: two followed events beyond the 7-day horizon.
@@ -85,16 +143,29 @@ enum NewsDemoSeed {
 				"homeTeamEntityId": "fk-lyn-oslo",
 				"streaming": [["platform": "TV 2 Play", "url": "https://play.tv2.no"]],
 			],
+			// WP-171: a near-term Premier League fixture, so the agenda has a row
+			// whose detail sheet shows the TABELL section against the seeded table.
+			[
+				"sport": "football", "title": "Everton – Liverpool", "tournament": "Premier League",
+				"time": at(days: 2), "homeTeam": "Everton", "awayTeam": "Liverpool",
+				"venue": "Goodison Park",
+				"streaming": [["platform": "Viaplay", "url": "https://viaplay.no"]],
+			],
 		]
 
 		let entities: [[String: Any]] = [
 			["id": "fk-lyn-oslo", "name": "FK Lyn Oslo", "aliases": ["Lyn"], "sport": "football", "type": "team"],
 			["id": "sport-cross-country", "name": "Langrenn", "aliases": ["langrenn"], "sport": "cross-country", "type": "sport"],
+			["id": "viktor-hovland", "name": "Viktor Hovland", "aliases": ["Hovland"], "sport": "golf", "type": "athlete"],
+			["id": "sport-f1", "name": "Formel 1", "aliases": ["F1"], "sport": "f1", "type": "sport"],
+			["id": "casper-ruud", "name": "Casper Ruud", "aliases": ["Ruud"], "sport": "tennis", "type": "athlete"],
+			["id": "liverpool-fc", "name": "Liverpool", "aliases": ["Liverpool FC"], "sport": "football", "type": "team"],
 		]
 
 		write(news, "news.json", cache)
 		write(featured, "featured.json", cache)
 		write(recentResults, "recent-results.json", cache)
+		write(standings, "standings.json", cache)
 		write(events, "events.json", cache)
 		write(entities, "entities.json", cache)
 		try? cache.writeSyncState(SyncState(etag: nil, appliedFiles: [:], lastSync: now))
@@ -104,6 +175,16 @@ enum NewsDemoSeed {
 			             weight: 0.7, reason: "Følger FK Lyn Oslo.", addedAt: now),
 			InterestRule(entityId: "sport-cross-country", entityName: "Langrenn", sport: "cross-country",
 			             weight: 0.6, reason: "Følger langrenn.", addedAt: now),
+			// WP-171: the three follows that make the golf/F1/tennis results
+			// relevant — an athlete, a whole sport, an athlete.
+			InterestRule(entityId: "viktor-hovland", entityName: "Viktor Hovland", sport: "golf",
+			             weight: 0.7, reason: "Følger Viktor Hovland.", addedAt: now),
+			InterestRule(entityId: "sport-f1", entityName: "Formel 1", sport: "f1",
+			             weight: 0.6, reason: "Følger Formel 1.", addedAt: now),
+			InterestRule(entityId: "casper-ruud", entityName: "Casper Ruud", sport: "tennis",
+			             weight: 0.6, reason: "Følger Casper Ruud.", addedAt: now),
+			InterestRule(entityId: "liverpool-fc", entityName: "Liverpool", sport: "football",
+			             weight: 0.6, reason: "Følger Liverpool.", addedAt: now),
 		]
 		try? profileStore.save(InterestProfile(rules: rules), now: now)
 	}

--- a/ios/Sportivista/Models/RecentResults.swift
+++ b/ios/Sportivista/Models/RecentResults.swift
@@ -4,31 +4,203 @@
 //
 //  WP-106 — mirrors the parts of docs/data/recent-results.json (fetch-results.js)
 //  the Nyheter «RESULTAT» section consumes. That file is keyed by sport
-//  (`football`, `golf`, `tennis`, `f1`, …); v0 models the FOOTBALL array — the
-//  populated, team-named results the client can lens-match to a followed team
-//  and mask behind the spoiler shield. Other sport keys are ignored (decoded to
-//  absent) rather than modelled, so a niche/empty sport array is never a crash;
-//  they can be added here when the section grows to cover them.
+//  (`football`, `golf`, `tennis`, `f1`, …); v0 modelled only the FOOTBALL array.
+//
+//  WP-171 adds the other three keys: The Open's final leaderboard and the F1
+//  podium were already IN this file, fetched every pipeline run, and no surface
+//  ever showed them — «hva skjedde i går» was football-only. Every sport is
+//  still decoded leniently (decodeIfPresent + defaults), so a missing or empty
+//  sport key is an absent section, never a crash.
 //
 
 import Foundation
 
 struct RecentResults: Codable, Equatable {
 	var football: [FootballResult]
+	/// Keyed by tour (`pga`, `dpWorld`); a null tour (no tournament in window)
+	/// decodes to absent.
+	var golf: [String: GolfTourResult]
+	var tennis: [TennisResult]
+	var f1: [F1RaceResult]
 
-	private enum CodingKeys: String, CodingKey { case football }
+	private enum CodingKeys: String, CodingKey { case football, golf, tennis, f1 }
 
-	init(football: [FootballResult] = []) { self.football = football }
+	init(football: [FootballResult] = [], golf: [String: GolfTourResult] = [:],
+	     tennis: [TennisResult] = [], f1: [F1RaceResult] = []) {
+		self.football = football
+		self.golf = golf
+		self.tennis = tennis
+		self.f1 = f1
+	}
 
 	init(from decoder: Decoder) throws {
 		let c = try decoder.container(keyedBy: CodingKeys.self)
 		football = try c.decodeIfPresent([FootballResult].self, forKey: .football) ?? []
+		// The tour values are nullable in the source file — decode optionals and
+		// drop the nulls rather than failing the whole decode.
+		let tours = try c.decodeIfPresent([String: GolfTourResult?].self, forKey: .golf) ?? [:]
+		golf = tours.compactMapValues { $0 }
+		tennis = try c.decodeIfPresent([TennisResult].self, forKey: .tennis) ?? []
+		f1 = try c.decodeIfPresent([F1RaceResult].self, forKey: .f1) ?? []
 	}
 }
 
-/// One finished football match (fetch-results.js `football[]`). Only the fields
-/// the RESULTAT row needs are modelled; the goal-scorer list, leagueCode etc.
-/// are ignored by Codable.
+/// One tour's tournament result (`golf.pga` / `golf.dpWorld`). `status` is
+/// ESPN's lowercased status — only `final` is a RESULT (an in-progress
+/// leaderboard belongs to the agenda, not to «hva skjedde»).
+struct GolfTourResult: Codable, Equatable {
+	var tournamentName: String?
+	var status: String?
+	var completedRound: Int?
+	var topPlayers: [GolfResultPlayer]
+	var norwegianPlayers: [GolfResultPlayer]
+
+	init(tournamentName: String? = nil, status: String? = nil, completedRound: Int? = nil,
+	     topPlayers: [GolfResultPlayer] = [], norwegianPlayers: [GolfResultPlayer] = []) {
+		self.tournamentName = tournamentName
+		self.status = status
+		self.completedRound = completedRound
+		self.topPlayers = topPlayers
+		self.norwegianPlayers = norwegianPlayers
+	}
+
+	private enum CodingKeys: String, CodingKey { case tournamentName, status, completedRound, topPlayers, norwegianPlayers }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		tournamentName = try c.decodeIfPresent(String.self, forKey: .tournamentName)
+		status = try c.decodeIfPresent(String.self, forKey: .status)
+		completedRound = try c.decodeIfPresent(Int.self, forKey: .completedRound)
+		topPlayers = try c.decodeIfPresent([GolfResultPlayer].self, forKey: .topPlayers) ?? []
+		norwegianPlayers = try c.decodeIfPresent([GolfResultPlayer].self, forKey: .norwegianPlayers) ?? []
+	}
+
+	var isFinal: Bool { (status ?? "").lowercased() == "final" }
+}
+
+/// One line of a golf leaderboard result.
+struct GolfResultPlayer: Codable, Equatable {
+	var position: Int?
+	var player: String
+	var score: String?
+	var roundScore: String?
+	var thru: String?
+
+	init(position: Int? = nil, player: String, score: String? = nil, roundScore: String? = nil, thru: String? = nil) {
+		self.position = position
+		self.player = player
+		self.score = score
+		self.roundScore = roundScore
+		self.thru = thru
+	}
+
+	private enum CodingKeys: String, CodingKey { case position, player, score, roundScore, thru }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		position = try c.decodeIfPresent(Int.self, forKey: .position)
+		player = try c.decodeIfPresent(String.self, forKey: .player) ?? ""
+		score = try c.decodeIfPresent(String.self, forKey: .score)
+		roundScore = try c.decodeIfPresent(String.self, forKey: .roundScore)
+		thru = try c.decodeIfPresent(String.self, forKey: .thru)
+	}
+}
+
+/// One finished tennis match (`tennis[]`). The file names the WINNER explicitly;
+/// the board deliberately builds an outcome-NEUTRAL title from the pair so the
+/// row itself never spoils who won (the outcome sits behind the shield).
+struct TennisResult: Codable, Equatable {
+	var winner: String
+	var loser: String
+	var score: String?
+	var date: Date?
+	var tournament: String?
+	var round: String?
+	var isFavorite: Bool
+
+	init(winner: String, loser: String, score: String? = nil, date: Date? = nil,
+	     tournament: String? = nil, round: String? = nil, isFavorite: Bool = false) {
+		self.winner = winner
+		self.loser = loser
+		self.score = score
+		self.date = date
+		self.tournament = tournament
+		self.round = round
+		self.isFavorite = isFavorite
+	}
+
+	private enum CodingKeys: String, CodingKey { case winner, loser, score, date, tournament, round, isFavorite }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		winner = try c.decodeIfPresent(String.self, forKey: .winner) ?? ""
+		loser = try c.decodeIfPresent(String.self, forKey: .loser) ?? ""
+		score = try c.decodeIfPresent(String.self, forKey: .score)
+		// Same lenient parse as FootballResult: the fetchers emit several ISO
+		// shapes; an unparseable stamp is a nil date, never a decode failure.
+		date = (try c.decodeIfPresent(String.self, forKey: .date)).flatMap(FootballResult.parseISODate)
+		tournament = try c.decodeIfPresent(String.self, forKey: .tournament)
+		round = try c.decodeIfPresent(String.self, forKey: .round)
+		isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
+	}
+}
+
+/// One finished F1 session (`f1[]`) with its finishing order.
+struct F1RaceResult: Codable, Equatable {
+	var raceName: String
+	var type: String?
+	var date: Date?
+	var circuit: String?
+	var topDrivers: [F1ResultDriver]
+
+	init(raceName: String, type: String? = nil, date: Date? = nil, circuit: String? = nil, topDrivers: [F1ResultDriver] = []) {
+		self.raceName = raceName
+		self.type = type
+		self.date = date
+		self.circuit = circuit
+		self.topDrivers = topDrivers
+	}
+
+	private enum CodingKeys: String, CodingKey { case raceName, type, date, circuit, topDrivers }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		raceName = try c.decodeIfPresent(String.self, forKey: .raceName) ?? ""
+		type = try c.decodeIfPresent(String.self, forKey: .type)
+		date = (try c.decodeIfPresent(String.self, forKey: .date)).flatMap(FootballResult.parseISODate)
+		circuit = try c.decodeIfPresent(String.self, forKey: .circuit)
+		topDrivers = try c.decodeIfPresent([F1ResultDriver].self, forKey: .topDrivers) ?? []
+	}
+}
+
+/// One finishing position in an F1 session.
+struct F1ResultDriver: Codable, Equatable {
+	var position: Int?
+	var driver: String
+	var team: String?
+	var status: String?
+
+	init(position: Int? = nil, driver: String, team: String? = nil, status: String? = nil) {
+		self.position = position
+		self.driver = driver
+		self.team = team
+		self.status = status
+	}
+
+	private enum CodingKeys: String, CodingKey { case position, driver, team, status }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		position = try c.decodeIfPresent(Int.self, forKey: .position)
+		driver = try c.decodeIfPresent(String.self, forKey: .driver) ?? ""
+		team = try c.decodeIfPresent(String.self, forKey: .team)
+		status = try c.decodeIfPresent(String.self, forKey: .status)
+	}
+}
+
+/// One finished football match (fetch-results.js `football[]`). WP-171 models
+/// `goalScorers` too — the fetcher has always paid for it and no surface ever
+/// rendered it, so «2–1» never said WHO scored or WHEN.
 struct FootballResult: Codable, Equatable {
 	var homeTeam: String
 	var awayTeam: String
@@ -37,16 +209,17 @@ struct FootballResult: Codable, Equatable {
 	var date: Date?
 	var league: String?
 	var venue: String?
+	var goalScorers: [GoalScorer]
 	var recapHeadline: String?
 	var isFavorite: Bool
 
 	private enum CodingKeys: String, CodingKey {
-		case homeTeam, awayTeam, homeScore, awayScore, date, league, venue, recapHeadline, isFavorite
+		case homeTeam, awayTeam, homeScore, awayScore, date, league, venue, goalScorers, recapHeadline, isFavorite
 	}
 
 	init(homeTeam: String, awayTeam: String, homeScore: Int? = nil, awayScore: Int? = nil,
 	     date: Date? = nil, league: String? = nil, venue: String? = nil,
-	     recapHeadline: String? = nil, isFavorite: Bool = false) {
+	     goalScorers: [GoalScorer] = [], recapHeadline: String? = nil, isFavorite: Bool = false) {
 		self.homeTeam = homeTeam
 		self.awayTeam = awayTeam
 		self.homeScore = homeScore
@@ -54,6 +227,7 @@ struct FootballResult: Codable, Equatable {
 		self.date = date
 		self.league = league
 		self.venue = venue
+		self.goalScorers = goalScorers
 		self.recapHeadline = recapHeadline
 		self.isFavorite = isFavorite
 	}
@@ -69,9 +243,10 @@ struct FootballResult: Codable, Equatable {
 		// required) rejects. Decode the raw string and parse it leniently here so a
 		// truncated timestamp is a nil date, never a whole-file decode failure —
 		// the score/teams (what RESULTAT shows) never depend on it.
-		date = (try c.decodeIfPresent(String.self, forKey: .date)).flatMap(Self.parseDate)
+		date = (try c.decodeIfPresent(String.self, forKey: .date)).flatMap(Self.parseISODate)
 		league = try c.decodeIfPresent(String.self, forKey: .league)
 		venue = try c.decodeIfPresent(String.self, forKey: .venue)
+		goalScorers = try c.decodeIfPresent([GoalScorer].self, forKey: .goalScorers) ?? []
 		recapHeadline = try c.decodeIfPresent(String.self, forKey: .recapHeadline)
 		isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
 	}
@@ -79,8 +254,9 @@ struct FootballResult: Codable, Equatable {
 	/// Parse an ISO 8601 date in any of the shapes fetch-results.js / the agents
 	/// emit: with fractional seconds, with whole seconds, or WITHOUT seconds
 	/// ("…THH:mmZ"). `nil` for anything else (a missing/garbled date just sorts
-	/// last — it never fails the decode).
-	private static func parseDate(_ raw: String) -> Date? {
+	/// last — it never fails the decode). Shared by the tennis/F1 results
+	/// (WP-171) — they come out of the same fetcher with the same shapes.
+	static func parseISODate(_ raw: String) -> Date? {
 		if let d = withFractionalSeconds.date(from: raw) { return d }
 		if let d = withSeconds.date(from: raw) { return d }
 		return withoutSeconds.date(from: raw)
@@ -105,5 +281,38 @@ struct FootballResult: Codable, Equatable {
 	var scoreLine: String? {
 		guard let h = homeScore, let a = awayScore else { return nil }
 		return "\(h)–\(a)"
+	}
+}
+
+/// One goal (fetch-results.js `goalScorers[]`): who scored, for which team, in
+/// which minute (the raw source string, e.g. "8'" / "90'+2").
+struct GoalScorer: Codable, Equatable {
+	var player: String
+	var team: String?
+	var minute: String?
+
+	init(player: String, team: String? = nil, minute: String? = nil) {
+		self.player = player
+		self.team = team
+		self.minute = minute
+	}
+
+	private enum CodingKeys: String, CodingKey { case player, team, minute }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		player = try c.decodeIfPresent(String.self, forKey: .player) ?? ""
+		team = try c.decodeIfPresent(String.self, forKey: .team)
+		minute = try c.decodeIfPresent(String.self, forKey: .minute)
+	}
+
+	/// "8' Kristian Eriksen (SK Brann)" — the row's detail line. Empty when the
+	/// scorer has no name (nothing honest to show).
+	var line: String {
+		let who = player.trimmingCharacters(in: .whitespaces)
+		guard !who.isEmpty else { return "" }
+		let min = (minute ?? "").trimmingCharacters(in: .whitespaces)
+		let side = (team ?? "").trimmingCharacters(in: .whitespaces)
+		return "\(min.isEmpty ? "" : "\(min) ")\(who)\(side.isEmpty ? "" : " (\(side))")"
 	}
 }

--- a/ios/Sportivista/Models/Standings.swift
+++ b/ios/Sportivista/Models/Standings.swift
@@ -1,0 +1,182 @@
+//
+//  Standings.swift
+//  Sportivista
+//
+//  WP-171 — mirrors docs/data/standings.json (fetch-standings.js): the league
+//  table, the golf leaderboards and the F1 championship the static pipeline has
+//  published every hour since v2. The web detail sheet has shown this since
+//  WP-14 (detail.js `footballStanding`/`golfContext`/`addF1Context`); the app
+//  did not even SYNC the file. This closes that parity debt — the model is
+//  read-only and lenient (decodeIfPresent + defaults everywhere), so a missing
+//  or reshaped key is an absent table, never a crash.
+//
+//  NB: standings are pipeline-cadence data. There is deliberately NO live
+//  updating of tables (WP-171 non-goal) — the hourly static pipeline is enough.
+//
+
+import Foundation
+
+struct Standings: Codable, Equatable, Sendable {
+	var football: FootballStandings
+	/// Keyed by tour (`pga`, `dpWorld`).
+	var golf: [String: GolfLeaderboard]
+	var f1: F1Standings
+
+	private enum CodingKeys: String, CodingKey { case football, golf, f1 }
+
+	init(football: FootballStandings = FootballStandings(), golf: [String: GolfLeaderboard] = [:], f1: F1Standings = F1Standings()) {
+		self.football = football
+		self.golf = golf
+		self.f1 = f1
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		football = try c.decodeIfPresent(FootballStandings.self, forKey: .football) ?? FootballStandings()
+		let tours = try c.decodeIfPresent([String: GolfLeaderboard?].self, forKey: .golf) ?? [:]
+		golf = tours.compactMapValues { $0 }
+		f1 = try c.decodeIfPresent(F1Standings.self, forKey: .f1) ?? F1Standings()
+	}
+
+	var isEmpty: Bool {
+		football.premierLeague.isEmpty && football.laLiga.isEmpty && golf.isEmpty && f1.drivers.isEmpty
+	}
+}
+
+struct FootballStandings: Codable, Equatable, Sendable {
+	var premierLeague: [FootballStandingRow]
+	var laLiga: [FootballStandingRow]
+
+	private enum CodingKeys: String, CodingKey { case premierLeague, laLiga }
+
+	init(premierLeague: [FootballStandingRow] = [], laLiga: [FootballStandingRow] = []) {
+		self.premierLeague = premierLeague
+		self.laLiga = laLiga
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		premierLeague = try c.decodeIfPresent([FootballStandingRow].self, forKey: .premierLeague) ?? []
+		laLiga = try c.decodeIfPresent([FootballStandingRow].self, forKey: .laLiga) ?? []
+	}
+}
+
+struct FootballStandingRow: Codable, Equatable, Sendable {
+	var position: Int
+	var team: String
+	var teamShort: String?
+	var played: Int
+	var points: Int
+	var gd: Int
+
+	init(position: Int, team: String, teamShort: String? = nil, played: Int = 0, points: Int = 0, gd: Int = 0) {
+		self.position = position
+		self.team = team
+		self.teamShort = teamShort
+		self.played = played
+		self.points = points
+		self.gd = gd
+	}
+
+	private enum CodingKeys: String, CodingKey { case position, team, teamShort, played, points, gd }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		position = try c.decodeIfPresent(Int.self, forKey: .position) ?? 0
+		team = try c.decodeIfPresent(String.self, forKey: .team) ?? ""
+		teamShort = try c.decodeIfPresent(String.self, forKey: .teamShort)
+		played = try c.decodeIfPresent(Int.self, forKey: .played) ?? 0
+		points = try c.decodeIfPresent(Int.self, forKey: .points) ?? 0
+		gd = try c.decodeIfPresent(Int.self, forKey: .gd) ?? 0
+	}
+}
+
+struct GolfLeaderboard: Codable, Equatable, Sendable {
+	var name: String?
+	var status: String?
+	var leaderboard: [GolfStandingRow]
+	/// The players interests/catalog track (the Norwegians) — shown even when
+	/// they are far down the board, which is the whole point of the surface.
+	var trackedPlayers: [GolfStandingRow]
+
+	private enum CodingKeys: String, CodingKey { case name, status, leaderboard, trackedPlayers }
+
+	init(name: String? = nil, status: String? = nil, leaderboard: [GolfStandingRow] = [], trackedPlayers: [GolfStandingRow] = []) {
+		self.name = name
+		self.status = status
+		self.leaderboard = leaderboard
+		self.trackedPlayers = trackedPlayers
+	}
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		name = try c.decodeIfPresent(String.self, forKey: .name)
+		status = try c.decodeIfPresent(String.self, forKey: .status)
+		leaderboard = try c.decodeIfPresent([GolfStandingRow].self, forKey: .leaderboard) ?? []
+		trackedPlayers = try c.decodeIfPresent([GolfStandingRow].self, forKey: .trackedPlayers) ?? []
+	}
+}
+
+struct GolfStandingRow: Codable, Equatable, Sendable {
+	var position: Int?
+	var positionDisplay: String?
+	var player: String
+	var score: String?
+	var thru: String?
+
+	init(position: Int? = nil, positionDisplay: String? = nil, player: String, score: String? = nil, thru: String? = nil) {
+		self.position = position
+		self.positionDisplay = positionDisplay
+		self.player = player
+		self.score = score
+		self.thru = thru
+	}
+
+	private enum CodingKeys: String, CodingKey { case position, positionDisplay, player, score, thru }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		position = try c.decodeIfPresent(Int.self, forKey: .position)
+		positionDisplay = try c.decodeIfPresent(String.self, forKey: .positionDisplay)
+		player = try c.decodeIfPresent(String.self, forKey: .player) ?? ""
+		score = try c.decodeIfPresent(String.self, forKey: .score)
+		thru = try c.decodeIfPresent(String.self, forKey: .thru)
+	}
+}
+
+struct F1Standings: Codable, Equatable, Sendable {
+	var drivers: [F1DriverStanding]
+
+	private enum CodingKeys: String, CodingKey { case drivers }
+
+	init(drivers: [F1DriverStanding] = []) { self.drivers = drivers }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		drivers = try c.decodeIfPresent([F1DriverStanding].self, forKey: .drivers) ?? []
+	}
+}
+
+struct F1DriverStanding: Codable, Equatable, Sendable {
+	var position: Int
+	var driver: String
+	var team: String?
+	var points: Int
+
+	init(position: Int, driver: String, team: String? = nil, points: Int = 0) {
+		self.position = position
+		self.driver = driver
+		self.team = team
+		self.points = points
+	}
+
+	private enum CodingKeys: String, CodingKey { case position, driver, team, points }
+
+	init(from decoder: Decoder) throws {
+		let c = try decoder.container(keyedBy: CodingKeys.self)
+		position = try c.decodeIfPresent(Int.self, forKey: .position) ?? 0
+		driver = try c.decodeIfPresent(String.self, forKey: .driver) ?? ""
+		team = try c.decodeIfPresent(String.self, forKey: .team)
+		points = try c.decodeIfPresent(Int.self, forKey: .points) ?? 0
+	}
+}

--- a/ios/Sportivista/News/NewsBoard.swift
+++ b/ios/Sportivista/News/NewsBoard.swift
@@ -12,8 +12,9 @@
 //  engagement mechanics.
 //    1. headline  — the editorial brief's headline (featured.json), one line.
 //    2. news      — lens-matched pointers (NewsLens), newest first, capped.
-//    3. results   — followed teams' recent results, each carrying whether the
-//                   spoiler shield must mask its score.
+//    3. results   — recent results for what you follow, EVERY sport in
+//                   recent-results.json (WP-171), each carrying whether the
+//                   spoiler shield must mask its outcome + detail lines.
 //    4. forward   — followed events beyond the near horizon (forvarsler).
 //
 
@@ -61,7 +62,7 @@ struct NewsBoard: Equatable {
 		return NewsBoard(
 			headline: freshHeadline(featured, now: now),
 			news: Array(matchedNews),
-			results: footballResultRows(results.football, lens: lens, index: index, shield: shield),
+			results: resultRows(results, lens: lens, index: index, shield: shield),
 			forward: forwardRows(events, lens: lens, index: index, now: now, max: maxForward)
 		)
 	}
@@ -87,57 +88,197 @@ struct NewsBoard: Equatable {
 		return headline
 	}
 
-	// MARK: - RESULTAT (followed teams)
+	// MARK: - RESULTAT (WP-171 — every sport, one row DNA)
 
-	/// Football results ABOUT a followed team, each stamped with whether its
-	/// score must be masked (the spoiler shield, keyed off the resolved entity
-	/// ids + sport). A result matches when a followed rule's entity name/alias
-	/// word-boundary-hits a team name (reusing the resolver + TextMatch, not a
-	/// new predicate); newest first.
-	private static func footballResultRows(_ results: [FootballResult], lens: NewsLens, index: EntityIndex, shield: SpoilerShield) -> [NewsResultRow] {
+	/// How many result rows the section SHOWS. Ro: the RESULTAT section must
+	/// never become a result stream — everything beyond the cap is reachable in
+	/// the view's «Vis alle» disclosure, never dropped. Mirrors the web's
+	/// `SS_RESULT_CAP` (news-web.js).
+	static let resultCap = 5
+
+	/// Detail lines per row. Ro again: a 10-goal World Cup match would otherwise
+	/// render eleven scorer lines and turn ONE row into a wall. Five is the
+	/// honest floor — a golf row's top-3 PLUS both Norwegians must survive it.
+	/// Mirrors the web's `SS_RESULT_DETAIL_CAP`.
+	static let detailCap = 5
+
+	/// Cap the detail lines, saying honestly how many were left out.
+	static func capDetails(_ lines: [String]) -> [String] {
+		let list = lines.filter { !$0.isEmpty }
+		guard list.count > detailCap else { return list }
+		return Array(list.prefix(detailCap)) + ["+\(list.count - detailCap) til"]
+	}
+
+	/// Recent results ABOUT what the user follows — for EVERY sport in
+	/// recent-results.json, not just football (WP-171: The Open's final
+	/// leaderboard and the F1 podium were already in the file and never shown).
+	///
+	/// The sports have different result DNA (golf = leaderboard position/score,
+	/// F1 = finishing order, tennis = sets), so rather than three special cases
+	/// each is projected onto ONE row shape (`NewsResultRow`): a neutral title,
+	/// the outcome (the spoiler-carrying payload), a quiet meta line, and the
+	/// detail lines the data already carries. The same discipline
+	/// `LensRenderer`/`AgendaFormat` apply to the agenda row.
+	///
+	/// Ordering is a per-sport round robin (`interleaveBySport`) so a busy
+	/// football weekend can't push the golf/F1 answer out of the capped section.
+	private static func resultRows(_ results: RecentResults, lens: NewsLens, index: EntityIndex, shield: SpoilerShield) -> [NewsResultRow] {
 		var rows: [NewsResultRow] = []
-		for r in results {
+
+		for r in results.football {
 			guard !r.homeTeam.isEmpty, !r.awayTeam.isEmpty else { continue }
-			let matchedIds = followedTeamIds(home: r.homeTeam, away: r.awayTeam, lens: lens, index: index)
-			guard !matchedIds.isEmpty else { continue }
-			let sensitive = shield.isSpoilerSensitive(sport: "football", entityIds: matchedIds)
+			guard let ids = followedIds(names: [r.homeTeam, r.awayTeam], sport: "football", lens: lens, index: index) else { continue }
 			rows.append(NewsResultRow(
-				id: resultId(r),
+				id: "result|football|\(r.homeTeam)|\(r.awayTeam)|\(stampKey(r.date))",
+				sport: "football",
 				title: AgendaFormat.title(homeTeam: r.homeTeam, awayTeam: r.awayTeam, fallback: r.recapHeadline ?? ""),
 				score: r.scoreLine,
 				meta: r.league,
+				details: capDetails(r.goalScorers.map(\.line)),
 				date: r.date,
-				spoilerSensitive: sensitive
+				spoilerSensitive: shield.isSpoilerSensitive(sport: "football", entityIds: ids)
 			))
 		}
-		return rows.sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
+
+		for key in results.golf.keys.sorted() {
+			guard let tour = results.golf[key], tour.isFinal, let winner = tour.topPlayers.first else { continue }
+			let names = (tour.topPlayers + tour.norwegianPlayers).map(\.player).filter { !$0.isEmpty }
+			guard let ids = followedIds(names: names, sport: "golf", lens: lens, index: index) else { continue }
+			let details = (tour.topPlayers.prefix(3) + tour.norwegianPlayers)
+				.map { positionLine(position: $0.position, name: $0.player, value: $0.score) }
+				.filter { !$0.isEmpty }
+			rows.append(NewsResultRow(
+				id: "result|golf|\(key)|\(tour.tournamentName ?? "")",
+				sport: "golf",
+				title: tour.tournamentName ?? "Golfturnering",
+				score: positionLine(position: nil, name: winner.player, value: winner.score),
+				meta: [golfTourLabel(key), "sluttresultat"].joined(separator: " · "),
+				details: capDetails(details),
+				date: nil,
+				spoilerSensitive: shield.isSpoilerSensitive(sport: "golf", entityIds: ids)
+			))
+		}
+
+		for r in results.f1 {
+			guard let winner = r.topDrivers.first else { continue }
+			let names = r.topDrivers.map(\.driver).filter { !$0.isEmpty }
+			guard let ids = followedIds(names: names, sport: "f1", lens: lens, index: index) else { continue }
+			rows.append(NewsResultRow(
+				id: "result|f1|\(r.raceName)|\(stampKey(r.date))",
+				sport: "f1",
+				title: r.raceName.isEmpty ? "Grand Prix" : r.raceName,
+				score: winner.driver,
+				meta: [r.circuit, r.type].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · "),
+				details: capDetails(r.topDrivers.prefix(3).map { positionLine(position: $0.position, name: $0.driver, value: nil) }),
+				date: r.date,
+				spoilerSensitive: shield.isSpoilerSensitive(sport: "f1", entityIds: ids)
+			))
+		}
+
+		for r in results.tennis {
+			guard !r.winner.isEmpty, !r.loser.isEmpty else { continue }
+			guard let ids = followedIds(names: [r.winner, r.loser], sport: "tennis", lens: lens, index: index) else { continue }
+			// Outcome-NEUTRAL title: the pair sorted alphabetically, never
+			// "winner – loser" — otherwise the row spoils the match it is about
+			// to mask.
+			let pair = [r.winner, r.loser].sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+			rows.append(NewsResultRow(
+				id: "result|tennis|\(r.winner)|\(r.loser)|\(stampKey(r.date))",
+				sport: "tennis",
+				title: "\(pair[0]) – \(pair[1])",
+				score: [r.winner, r.score ?? ""].filter { !$0.isEmpty }.joined(separator: " "),
+				meta: [r.tournament, r.round].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · "),
+				details: [],
+				date: r.date,
+				spoilerSensitive: shield.isSpoilerSensitive(sport: "tennis", entityIds: ids)
+			))
+		}
+
+		return interleaveBySport(rows)
 	}
 
-	/// The followed entity ids either team resolves to. Two signals, both reusing
-	/// existing machinery: the resolver's served entity for the team NAME, and a
+	/// Per-sport newest-first, then a round robin across sports (sports ordered
+	/// by their own newest result) — every sport gets ONE answer before any sport
+	/// gets a second. Twin of news-web.js `ssInterleaveBySport`.
+	static func interleaveBySport(_ rows: [NewsResultRow]) -> [NewsResultRow] {
+		var groups: [String: [NewsResultRow]] = [:]
+		var firstSeen: [String] = []
+		for row in rows {
+			if groups[row.sport] == nil { firstSeen.append(row.sport) }
+			groups[row.sport, default: []].append(row)
+		}
+		for sport in firstSeen {
+			groups[sport] = groups[sport]?.sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
+		}
+		// Sort sports by their newest row, keeping first-seen order for ties
+		// (a stable sort over the enumerated index).
+		let order = firstSeen.enumerated().sorted { a, b in
+			let da = groups[a.element]?.first?.date ?? .distantPast
+			let db = groups[b.element]?.first?.date ?? .distantPast
+			return da == db ? a.offset < b.offset : da > db
+		}.map(\.element)
+
+		var out: [NewsResultRow] = []
+		var i = 0
+		while true {
+			var took = false
+			for sport in order {
+				guard let list = groups[sport], i < list.count else { continue }
+				out.append(list[i])
+				took = true
+			}
+			if !took { break }
+			i += 1
+		}
+		return out
+	}
+
+	/// The followed entity ids these participant names resolve to, or `nil` when
+	/// the result isn't about anything the user follows. Two signals, both
+	/// reusing existing machinery: the resolver's served entity for a NAME, and a
 	/// sport-scoped name/alias hit for each followed rule (so an alias like "Lyn"
-	/// on "FK Lyn Oslo" counts). Never invents a new fuzzy scheme.
-	private static func followedTeamIds(home: String, away: String, lens: NewsLens, index: EntityIndex) -> Set<String> {
+	/// on "FK Lyn Oslo" counts). A followed WHOLE-sport admits the result even
+	/// with no name hit (the ids are then whatever matched — possibly none, which
+	/// still lets a sport-scoped spoiler policy mask it). Never a new fuzzy scheme.
+	private static func followedIds(names: [String], sport: String, lens: NewsLens, index: EntityIndex) -> Set<String>? {
 		var ids = Set<String>()
-		for name in [home, away] {
+		for name in names where !name.isEmpty {
 			if let served = index.servedEntity(for: name), lens.followedEntityIds.contains(served.id) {
 				ids.insert(served.id)
 			}
 		}
-		let hay = "\(home) \(away)"
+		let hay = names.joined(separator: " ")
 		for id in lens.followedEntityIds {
 			guard let e = index.entity(id: id) else { continue }
-			if !e.sport.isEmpty, TextMatch.normalize(e.sport) != "football" { continue }
+			if !e.sport.isEmpty, TextMatch.normalize(e.sport) != TextMatch.normalize(sport) { continue }
 			if ([e.name] + e.aliases).contains(where: { !$0.isEmpty && TextMatch.containsName(hay, $0) }) {
 				ids.insert(id)
 			}
 		}
+		if ids.isEmpty, !lens.followedSports.contains(NewsLens.canonicalSport(sport)) { return nil }
 		return ids
 	}
 
-	private static func resultId(_ r: FootballResult) -> String {
-		let stamp = r.date.map { String($0.timeIntervalSince1970) } ?? "?"
-		return "result|\(r.homeTeam)|\(r.awayTeam)|\(stamp)"
+	/// "1. Ryan Fox -10" / "Ryan Fox -10" (no position) — the shared
+	/// leaderboard/finishing-order line.
+	private static func positionLine(position: Int?, name: String, value: String?) -> String {
+		let who = name.trimmingCharacters(in: .whitespaces)
+		guard !who.isEmpty else { return "" }
+		let pos = position.map { "\($0). " } ?? ""
+		let val = (value ?? "").trimmingCharacters(in: .whitespaces)
+		return "\(pos)\(who)\(val.isEmpty ? "" : " \(val)")"
+	}
+
+	private static func golfTourLabel(_ key: String) -> String {
+		switch key {
+		case "pga": return "PGA Tour"
+		case "dpWorld": return "DP World Tour"
+		default: return key
+		}
+	}
+
+	private static func stampKey(_ date: Date?) -> String {
+		date.map { String($0.timeIntervalSince1970) } ?? "?"
 	}
 
 	// MARK: - FREMOVER (forvarsler beyond the near horizon)
@@ -202,13 +343,23 @@ struct NewsBoard: Equatable {
 	}
 }
 
-/// SECTION 3 row — a followed team's recent result. `score` is nil when the
-/// source carried no final score; `spoilerSensitive` drives the tap-to-reveal.
+/// SECTION 3 row — one recent result about something the user follows, in the
+/// per-sport DNA every sport is projected onto (WP-171). `title` is deliberately
+/// outcome-NEUTRAL (who/what played); `score` is the outcome payload and
+/// `details` the outcome-revealing extra lines (goal scorers with minute, the
+/// golf top-3 + Norwegians, the F1 podium) — so `spoilerSensitive` masks BOTH
+/// behind the same «Vis resultat». `score` is nil when the source carried no
+/// final outcome.
 struct NewsResultRow: Identifiable, Equatable {
 	var id: String
+	/// Canonical sport tag ("football"/"golf"/"f1"/"tennis") — drives the
+	/// per-sport interleave (and nothing visual).
+	var sport: String
 	var title: String
 	var score: String?
 	var meta: String?
+	/// Extra outcome-revealing lines. Empty for a sport/row that has none.
+	var details: [String] = []
 	var date: Date?
 	var spoilerSensitive: Bool
 }

--- a/ios/Sportivista/News/NewsView.swift
+++ b/ios/Sportivista/News/NewsView.swift
@@ -44,6 +44,9 @@ struct NewsView: View {
 	/// each NYTT row presents its own SFSafariViewController; the board owns the
 	/// single sheet, the rows just hand it a URL.
 	@State private var browserTarget: BrowserTarget?
+	/// WP-171 — the RESULTAT section's «Vis alle» disclosure. Collapsed by
+	/// default: a capped section is the calm state, the full list is a choice.
+	@State private var allResultsShown = false
 
 	/// The board the model currently holds — a plain accessor so the section
 	/// builders below read exactly as before.
@@ -164,10 +167,29 @@ struct NewsView: View {
 	@ViewBuilder
 	private var resultatSection: some View {
 		if !board.results.isEmpty {
+			// WP-171: capped (ro — the section must never become a result
+			// stream), with the remainder behind ONE quiet «Vis alle» so nothing
+			// is silently dropped. Same cap the web board uses (SS_RESULT_CAP).
+			let shown = allResultsShown ? board.results : Array(board.results.prefix(NewsBoard.resultCap))
+			let hidden = board.results.count - shown.count
 			Section {
-				ForEach(board.results) { row in
+				ForEach(shown) { row in
 					NewsResultRowView(row: row)
 						.listRowBackground(SportivistaTokens.cell)
+				}
+				if hidden > 0 {
+					Button {
+						allResultsShown = true
+					} label: {
+						Text("Vis alle (\(board.results.count))")
+							.font(.sportivista(.subheadline, weight: .semibold))
+							.foregroundStyle(SportivistaTokens.accent)
+							.frame(minHeight: 44, alignment: .leading)
+							.contentShape(Rectangle())
+					}
+					.buttonStyle(.plain)
+					.accessibilityIdentifier("news.results.showAll")
+					.listRowBackground(SportivistaTokens.cell)
 				}
 			} header: {
 				sectionHeader("RESULTAT", id: "news.section.resultat")
@@ -311,13 +333,21 @@ private struct NewsPointerRow: View {
 
 // MARK: - RESULTAT row (spoiler-masked)
 
-/// A followed team's result. When the spoiler shield applies, the score stays
+/// One recent result about something the user follows — any sport (WP-171).
+/// When the spoiler shield applies, the outcome AND the detail lines (goal
+/// scorers, podium, leaderboard — every one of them reveals the outcome) stay
 /// behind a calm «Vis resultat» (eye.slash) until tapped — the exact same
 /// reveal mechanism the event detail sheet uses (WP-30), so a glance never
-/// spoils a game watched on delay.
+/// spoils a game watched on delay. Only the outcome-neutral title + meta ever
+/// show unmasked.
 private struct NewsResultRowView: View {
 	let row: NewsResultRow
 	@State private var revealed = false
+
+	/// The outcome-revealing content is visible only when the shield doesn't
+	/// apply or the user asked for it. ONE gate for score + details, so a new
+	/// detail line can never leak past the shield.
+	private var outcomeVisible: Bool { !row.spoilerSensitive || revealed }
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 3) {
@@ -333,17 +363,31 @@ private struct NewsResultRowView: View {
 					.foregroundStyle(SportivistaTokens.secondaryLabel)
 					.lineLimit(1)
 			}
+			if outcomeVisible {
+				ForEach(Array(row.details.enumerated()), id: \.offset) { _, line in
+					Text(line)
+						.font(.sportivista(.caption))
+						.foregroundStyle(SportivistaTokens.secondaryLabel)
+						.fixedSize(horizontal: false, vertical: true)
+						.frame(maxWidth: .infinity, alignment: .leading)
+				}
+			}
 		}
 		.padding(.vertical, 2)
 	}
 
 	@ViewBuilder
 	private var scoreLine: some View {
-		if let score = row.score {
-			if !row.spoilerSensitive || revealed {
-				Text(score)
-					.font(.sportivistaTabular(.subheadline, weight: .semibold))
-					.foregroundStyle(SportivistaTokens.label)
+		// The reveal must also appear for a row whose outcome lives ONLY in the
+		// detail lines (e.g. a golf leaderboard with no single "score"), or the
+		// shield would hide them with no way back.
+		if row.score != nil || !row.details.isEmpty {
+			if outcomeVisible {
+				if let score = row.score {
+					Text(score)
+						.font(.sportivistaTabular(.subheadline, weight: .semibold))
+						.foregroundStyle(SportivistaTokens.label)
+				}
 			} else {
 				Button {
 					revealed = true

--- a/ios/Sportivista/Sync/DataStore.swift
+++ b/ios/Sportivista/Sync/DataStore.swift
@@ -76,6 +76,14 @@ struct DataStore: Sendable {
         return (try? SportivistaJSON.decoder.decode(RecentResults.self, from: data)) ?? RecentResults()
     }
 
+    /// WP-171: the league table / golf leaderboard / F1 championship
+    /// (docs/data/standings.json) the event-detail table surface reads. An empty
+    /// `Standings` when never synced or corrupt — an absent table, never a crash.
+    func loadStandings() -> Standings {
+        guard let data = cache.read("standings.json") else { return Standings() }
+        return (try? SportivistaJSON.decoder.decode(Standings.self, from: data)) ?? Standings()
+    }
+
     /// `nil` means "never synced" — see the type-level doc above for why
     /// this is the flag callers should check, not an empty `loadEvents()`.
     var lastSync: Date? {

--- a/ios/Sportivista/Sync/SyncClient.swift
+++ b/ios/Sportivista/Sync/SyncClient.swift
@@ -40,7 +40,10 @@ struct SyncClient: Sendable {
 
     /// The published files this iOS client actually consumes. See the
     /// type-level doc above for why the rest of the manifest is ignored.
-    static let defaultFilesOfInterest: Set<String> = ["events.json", "entities.json", "tracked.json", "app-version.json", "news.json", "featured.json", "recent-results.json"]
+    /// WP-171 adds standings.json — the league table / golf leaderboard / F1
+    /// championship the event-detail table surface reads. The app did not sync
+    /// it at all while the web detail sheet had shown it since WP-14.
+    static let defaultFilesOfInterest: Set<String> = ["events.json", "entities.json", "tracked.json", "app-version.json", "news.json", "featured.json", "recent-results.json", "standings.json"]
 
     private static let manifestFilename = "manifest.json"
 

--- a/ios/SportivistaTests/Fixtures/standings.json
+++ b/ios/SportivistaTests/Fixtures/standings.json
@@ -1,0 +1,44 @@
+{
+  "lastUpdated": "2026-07-22T10:39:07.612Z",
+  "football": {
+    "premierLeague": [
+      { "position": 1, "team": "Liverpool", "teamShort": "LIV", "played": 12, "won": 9, "drawn": 2, "lost": 1, "gd": 18, "points": 29 },
+      { "position": 2, "team": "Arsenal", "teamShort": "ARS", "played": 12, "won": 8, "drawn": 3, "lost": 1, "gd": 14, "points": 27 },
+      { "position": 3, "team": "Manchester City", "teamShort": "MCI", "played": 12, "won": 8, "drawn": 1, "lost": 3, "gd": 12, "points": 25 },
+      { "position": 4, "team": "Chelsea", "teamShort": "CHE", "played": 12, "won": 7, "drawn": 3, "lost": 2, "gd": 9, "points": 24 },
+      { "position": 5, "team": "Newcastle United", "teamShort": "NEW", "played": 12, "won": 6, "drawn": 4, "lost": 2, "gd": 7, "points": 22 },
+      { "position": 6, "team": "Aston Villa", "teamShort": "AVL", "played": 12, "won": 6, "drawn": 2, "lost": 4, "gd": 4, "points": 20 },
+      { "position": 14, "team": "Everton", "teamShort": "EVE", "played": 12, "won": 3, "drawn": 4, "lost": 5, "gd": -4, "points": 13 }
+    ],
+    "laLiga": [
+      { "position": 1, "team": "Real Madrid", "teamShort": "RMA", "played": 12, "won": 10, "drawn": 1, "lost": 1, "gd": 20, "points": 31 },
+      { "position": 2, "team": "Barcelona", "teamShort": "BAR", "played": 12, "won": 9, "drawn": 2, "lost": 1, "gd": 17, "points": 29 }
+    ]
+  },
+  "golf": {
+    "pga": {
+      "name": "3M Open",
+      "status": "in-progress",
+      "leaderboard": [
+        { "position": 1, "positionDisplay": null, "player": "Mackenzie Hughes", "score": "-12", "today": "-3", "thru": "F" },
+        { "position": 2, "positionDisplay": "T2", "player": "Max Greyserman", "score": "-11", "today": "-2", "thru": "F" },
+        { "position": 3, "positionDisplay": "T2", "player": "Chris Kirk", "score": "-10", "today": "-1", "thru": "F" }
+      ],
+      "trackedPlayers": [
+        { "position": 42, "positionDisplay": "T42", "player": "Kristoffer Ventura", "score": "-2", "today": "E", "thru": "F", "tracked": true }
+      ]
+    },
+    "dpWorld": null
+  },
+  "f1": {
+    "drivers": [
+      { "position": 1, "driver": "Kimi Antonelli", "team": "Mercedes", "points": 204, "wins": 4 },
+      { "position": 2, "driver": "Lewis Hamilton", "team": "Ferrari", "points": 159, "wins": 3 },
+      { "position": 3, "driver": "George Russell", "team": "Mercedes", "points": 154, "wins": 2 },
+      { "position": 4, "driver": "Charles Leclerc", "team": "Ferrari", "points": 126, "wins": 2 },
+      { "position": 5, "driver": "Lando Norris", "team": "McLaren", "points": 103, "wins": 1 },
+      { "position": 6, "driver": "Oscar Piastri", "team": "McLaren", "points": 92, "wins": 1 }
+    ]
+  },
+  "tennis": {}
+}

--- a/ios/SportivistaTests/NewsBoardTests.swift
+++ b/ios/SportivistaTests/NewsBoardTests.swift
@@ -137,6 +137,146 @@ final class NewsBoardTests: XCTestCase {
 		XCTAssertEqual(board.results.first?.spoilerSensitive, false)
 	}
 
+	// MARK: - Section 3 · WP-171 (every sport, goal scorers, interleave, cap)
+
+	private let hovland = Entity(id: "viktor-hovland", name: "Viktor Hovland", aliases: ["Hovland"], sport: "golf", type: "athlete")
+	private let f1Sport = Entity(id: "sport-f1", name: "Formel 1", aliases: ["F1"], sport: "f1", type: "sport")
+	private let ruud = Entity(id: "casper-ruud", name: "Casper Ruud", aliases: ["Ruud"], sport: "tennis", type: "athlete")
+
+	/// Football + a golf ATHLETE + F1 as a WHOLE sport + a tennis athlete — the
+	/// three ways a result can be about you.
+	private var multiSportProfile: InterestProfile {
+		InterestProfile(rules: [
+			rule("fk-lyn-oslo", "FK Lyn Oslo", sport: "football"),
+			rule("viktor-hovland", "Viktor Hovland", sport: "golf"),
+			rule("sport-f1", "Formel 1", sport: "f1"),
+			rule("casper-ruud", "Casper Ruud", sport: "tennis"),
+		])
+	}
+
+	private var multiSportResults: RecentResults {
+		RecentResults(
+			football: [FootballResult(
+				homeTeam: "Lyn", awayTeam: "Sogndal", homeScore: 2, awayScore: 1,
+				date: now.addingTimeInterval(-3600), league: "OBOS-ligaen",
+				goalScorers: [
+					GoalScorer(player: "Kristian Eriksen", team: "Lyn", minute: "8'"),
+					GoalScorer(player: "Ola Nordmann", team: "Sogndal", minute: "77'"),
+				]
+			)],
+			golf: [
+				"pga": GolfTourResult(
+					tournamentName: "The Open", status: "final", completedRound: 4,
+					topPlayers: [
+						GolfResultPlayer(position: 1, player: "Ryan Fox", score: "-10"),
+						GolfResultPlayer(position: 2, player: "Cameron Young", score: "-9"),
+						GolfResultPlayer(position: 3, player: "Sam Burns", score: "-8"),
+						GolfResultPlayer(position: 4, player: "Scottie Scheffler", score: "-7"),
+					],
+					norwegianPlayers: [GolfResultPlayer(position: 121, player: "Viktor Hovland", score: "+4")]
+				),
+				// NOT final → not a result (an in-progress leaderboard belongs to Uka).
+				"dpWorld": GolfTourResult(
+					tournamentName: "BMW International", status: "in-progress",
+					topPlayers: [GolfResultPlayer(position: 1, player: "Viktor Hovland", score: "-3")]
+				),
+			],
+			tennis: [TennisResult(winner: "Casper Ruud", loser: "Alexander Zverev", score: "6-4, 7-5",
+			                      date: now.addingTimeInterval(-7200), tournament: "ATP Hamburg", round: "Semifinale")],
+			f1: [F1RaceResult(raceName: "Belgian Grand Prix", type: "Race", date: now.addingTimeInterval(-86400), circuit: "Spa",
+			                  topDrivers: [
+			                      F1ResultDriver(position: 1, driver: "Kimi Antonelli"),
+			                      F1ResultDriver(position: 2, driver: "Charles Leclerc"),
+			                      F1ResultDriver(position: 3, driver: "Max Verstappen"),
+			                      F1ResultDriver(position: 4, driver: "Lewis Hamilton"),
+			                  ])]
+		)
+	}
+
+	private func multiSportBoard(shield: SpoilerShield = SpoilerShield()) -> NewsBoard {
+		NewsBoard.build(news: [], featured: nil, results: multiSportResults, events: [],
+		                entities: [lynTeam, hovland, f1Sport, ruud], profile: multiSportProfile,
+		                shield: shield, now: now)
+	}
+
+	func testResultat_coversEverySportInTheFile_notJustFootball() {
+		let board = multiSportBoard()
+		XCTAssertEqual(Set(board.results.map(\.sport)), ["football", "golf", "f1", "tennis"],
+		               "golf/F1/tennis results were already in recent-results.json and never shown (WP-171)")
+	}
+
+	func testResultat_footballRow_rendersGoalScorersWithMinute() {
+		let row = multiSportBoard().results.first { $0.sport == "football" }
+		XCTAssertEqual(row?.score, "2–1")
+		XCTAssertEqual(row?.details, ["8' Kristian Eriksen (Lyn)", "77' Ola Nordmann (Sogndal)"])
+	}
+
+	func testResultat_detailLinesAreCapped_soAGoalFestIsNotAWall() {
+		let scorers = (1...11).map { GoalScorer(player: "Spiller \($0)", team: "Sogndal", minute: "\($0)'") }
+		let results = RecentResults(football: [FootballResult(homeTeam: "Lyn", awayTeam: "Sogndal", homeScore: 4, awayScore: 6,
+		                                                     date: now, league: "OBOS-ligaen", goalScorers: scorers)])
+		let board = NewsBoard.build(news: [], featured: nil, results: results, events: [], entities: [lynTeam],
+		                            profile: followProfile, shield: SpoilerShield(), now: now)
+		XCTAssertEqual(board.results.first?.details.count, NewsBoard.detailCap + 1)
+		XCTAssertEqual(board.results.first?.details.last, "+6 til")
+	}
+
+	func testResultat_golfRow_onlyFinalTournament_withTopThreeAndNorwegians() {
+		let golf = multiSportBoard().results.filter { $0.sport == "golf" }
+		XCTAssertEqual(golf.count, 1, "the in-progress tour is not a result")
+		XCTAssertEqual(golf.first?.title, "The Open")
+		XCTAssertEqual(golf.first?.score, "Ryan Fox -10")
+		XCTAssertEqual(golf.first?.meta, "PGA Tour · sluttresultat")
+		XCTAssertEqual(golf.first?.details, ["1. Ryan Fox -10", "2. Cameron Young -9", "3. Sam Burns -8", "121. Viktor Hovland +4"])
+	}
+
+	func testResultat_f1Row_winnerIsTheOutcome_podiumIsTheDetail() {
+		let f1 = multiSportBoard().results.first { $0.sport == "f1" }
+		XCTAssertEqual(f1?.title, "Belgian Grand Prix")
+		XCTAssertEqual(f1?.score, "Kimi Antonelli")
+		XCTAssertEqual(f1?.details, ["1. Kimi Antonelli", "2. Charles Leclerc", "3. Max Verstappen"])
+	}
+
+	func testResultat_tennisTitleIsOutcomeNeutral() {
+		let tennis = multiSportBoard().results.first { $0.sport == "tennis" }
+		// Alphabetical pair — the row must not spoil who won before the shield does.
+		XCTAssertEqual(tennis?.title, "Alexander Zverev – Casper Ruud")
+		XCTAssertEqual(tennis?.score, "Casper Ruud 6-4, 7-5")
+	}
+
+	/// Spoilervernet er hellig: a sport-scoped policy must mask the row's WHOLE
+	/// outcome — score AND the new detail lines (each one gives the result away).
+	func testResultat_spoilerPolicyMarksTheRowSensitive_forAnySport() {
+		let board = multiSportBoard(shield: SpoilerShield(sports: ["golf", "f1"], entityIds: []))
+		XCTAssertEqual(board.results.first { $0.sport == "golf" }?.spoilerSensitive, true)
+		XCTAssertEqual(board.results.first { $0.sport == "f1" }?.spoilerSensitive, true)
+		XCTAssertEqual(board.results.first { $0.sport == "football" }?.spoilerSensitive, false)
+	}
+
+	func testResultat_interleavesSports_soEverySportGetsAnAnswerInsideTheCap() {
+		var results = multiSportResults
+		// A busy football weekend: five more matches, all newer than the rest.
+		results.football += (1...5).map {
+			FootballResult(homeTeam: "Lyn", awayTeam: "Klubb \($0)", homeScore: 1, awayScore: 0,
+			               date: now.addingTimeInterval(Double(-$0) * 60), league: "OBOS-ligaen")
+		}
+		let board = NewsBoard.build(news: [], featured: nil, results: results, events: [],
+		                            entities: [lynTeam, hovland, f1Sport, ruud], profile: multiSportProfile,
+		                            shield: SpoilerShield(), now: now)
+		let capped = board.results.prefix(NewsBoard.resultCap)
+		XCTAssertEqual(Set(capped.map(\.sport)), ["football", "golf", "f1", "tennis"],
+		               "golf/F1/tennis must survive the cap on a football-heavy day")
+		XCTAssertEqual(board.results.count, 9, "nothing is dropped — the rest lives behind «Vis alle»")
+	}
+
+	func testResultat_unfollowedSportIsExcluded() {
+		// A profile with ONLY the football team: golf/F1/tennis are not about them.
+		let board = NewsBoard.build(news: [], featured: nil, results: multiSportResults, events: [],
+		                            entities: [lynTeam, hovland, f1Sport, ruud], profile: followProfile,
+		                            shield: SpoilerShield(), now: now)
+		XCTAssertEqual(board.results.map(\.sport), ["football"])
+	}
+
 	// MARK: - Section 4 (FREMOVER)
 
 	func testFremover_excludesNearHorizon_keepsFarFollowed() {

--- a/ios/SportivistaTests/StandingsTableTests.swift
+++ b/ios/SportivistaTests/StandingsTableTests.swift
@@ -1,0 +1,110 @@
+//
+//  StandingsTableTests.swift
+//  SportivistaTests
+//
+//  WP-171 — the event-detail TABELL surface, driven by the CHECKED-IN
+//  standings.json fixture (the same fasit shape the pipeline publishes), not by
+//  hand-built structs: the point of the package is that the app finally reads
+//  the file it never synced, so the test reads the file too.
+//
+//  Covers: the Codable model over the real fixture, the per-sport table build
+//  (PL table / golf leaderboard / F1 championship), the "both teams always
+//  visible" rule that keeps a mid-table side in the picture, and the honest nil
+//  when there is nothing to show.
+//
+
+import XCTest
+
+final class StandingsTableTests: XCTestCase {
+
+    private lazy var standings: Standings = {
+        // swiftlint:disable:next force_try
+        try! SportivistaJSON.decoder.decode(Standings.self, from: Fixture.data("standings"))
+    }()
+
+    // MARK: - Decoding the published shape
+
+    func testDecodesTheFixture_everySport() {
+        XCTAssertEqual(standings.football.premierLeague.count, 7)
+        XCTAssertEqual(standings.football.premierLeague.first?.team, "Liverpool")
+        XCTAssertEqual(standings.football.premierLeague.first?.points, 29)
+        XCTAssertEqual(standings.football.laLiga.count, 2)
+        XCTAssertEqual(standings.f1.drivers.first?.driver, "Kimi Antonelli")
+        // A NULL tour (`dpWorld`) is dropped, never a decode failure.
+        XCTAssertEqual(standings.golf.keys.sorted(), ["pga"])
+        XCTAssertEqual(standings.golf["pga"]?.trackedPlayers.first?.player, "Kristoffer Ventura")
+        XCTAssertFalse(standings.isEmpty)
+    }
+
+    func testEmptyStandings_isEmpty() {
+        XCTAssertTrue(Standings().isEmpty)
+    }
+
+    // MARK: - Football
+
+    func testFootball_showsTheTopPlusBothTeamsPlaying() {
+        let event = EventBuilder.make(sport: "football", title: "Everton vs Liverpool", time: "2026-07-25T18:00:00Z",
+                                      homeTeam: "Everton", awayTeam: "Liverpool", tournament: "Premier League")
+        let table = StandingsTable.build(event: event, standings: standings)
+        XCTAssertEqual(table?.title, "PREMIER LEAGUE")
+        // Top 5 + Everton (14th) — the team the tap was about is never cut away.
+        XCTAssertEqual(table?.rows.map(\.name), ["Liverpool", "Arsenal", "Manchester City", "Chelsea", "Newcastle United", "Everton"])
+        XCTAssertEqual(table?.rows.last?.rank, "14.")
+        XCTAssertEqual(table?.rows.last?.value, "13")
+        XCTAssertEqual(table?.rows.filter(\.highlighted).map(\.name), ["Liverpool", "Everton"])
+    }
+
+    func testFootball_laLigaTournamentPicksTheSpanishTable() {
+        let event = EventBuilder.make(sport: "football", title: "Real Madrid vs Barcelona", time: "2026-07-25T18:00:00Z",
+                                      homeTeam: "Real Madrid", awayTeam: "Barcelona", tournament: "La Liga")
+        let table = StandingsTable.build(event: event, standings: standings)
+        XCTAssertEqual(table?.title, "LA LIGA")
+        XCTAssertEqual(table?.rows.map(\.name), ["Real Madrid", "Barcelona"])
+    }
+
+    // MARK: - Golf
+
+    func testGolf_leaderboardKeepsTheTrackedNorwegian() {
+        let event = EventBuilder.make(sport: "golf", title: "3M Open", time: "2026-07-25T14:00:00Z", tournament: "3M Open")
+        let table = StandingsTable.build(event: event, standings: standings)
+        XCTAssertEqual(table?.title, "3M OPEN")
+        XCTAssertEqual(table?.rows.map(\.name), ["Mackenzie Hughes", "Max Greyserman", "Chris Kirk", "Kristoffer Ventura"])
+        XCTAssertEqual(table?.rows.last?.rank, "T42")   // positionDisplay wins over the raw position
+        XCTAssertEqual(table?.rows.last?.highlighted, true)
+    }
+
+    func testGolf_noTableForAnotherTournament() {
+        let event = EventBuilder.make(sport: "golf", title: "Ryder Cup", time: "2026-07-25T14:00:00Z", tournament: "Ryder Cup")
+        XCTAssertNil(StandingsTable.build(event: event, standings: standings))
+    }
+
+    // MARK: - F1
+
+    func testF1_showsTheDriversChampionshipTop() {
+        let event = EventBuilder.make(sport: "f1", title: "Belgian Grand Prix", time: "2026-07-25T13:00:00Z", tournament: "Formula 1")
+        let table = StandingsTable.build(event: event, standings: standings)
+        XCTAssertEqual(table?.title, "VM-STILLING")
+        XCTAssertEqual(table?.rows.count, StandingsTable.topRows)
+        XCTAssertEqual(table?.rows.first?.name, "Kimi Antonelli")
+        XCTAssertEqual(table?.rows.first?.value, "204")
+    }
+
+    // MARK: - Honest absence
+
+    func testFootball_noTableWhenNeitherTeamIsInIt() {
+        // An OBOS-ligaen fixture must NOT render the Premier League top five as
+        // if it were its own table (the honest gate).
+        let event = EventBuilder.make(sport: "football", title: "Lyn vs Bryne", time: "2026-07-25T18:00:00Z",
+                                      homeTeam: "Lyn", awayTeam: "Bryne", tournament: "OBOS-ligaen")
+        XCTAssertNil(StandingsTable.build(event: event, standings: standings))
+    }
+
+    func testNoTableForASportWithoutOne_orWithoutData() {
+        let chess = EventBuilder.make(sport: "chess", title: "Norway Chess", time: "2026-07-25T13:00:00Z")
+        XCTAssertNil(StandingsTable.build(event: chess, standings: standings))
+        let football = EventBuilder.make(sport: "football", title: "X vs Y", time: "2026-07-25T13:00:00Z",
+                                         homeTeam: "X", awayTeam: "Y", tournament: "Premier League")
+        XCTAssertNil(StandingsTable.build(event: football, standings: nil), "never synced → no table, no crash")
+        XCTAssertNil(StandingsTable.build(event: football, standings: Standings()))
+    }
+}

--- a/ios/SportivistaTests/SyncTestSupport.swift
+++ b/ios/SportivistaTests/SyncTestSupport.swift
@@ -39,10 +39,13 @@ enum SyncTestSupport {
     /// fixtures. `canonicalManifestData` overrides the manifest's entries for
     /// these to match — the base fixture's featured/recent-results hashes are
     /// stale and it carries no news.json entry.
+    /// WP-171 adds standings.json (the event-detail table surface) the same way:
+    /// the base manifest lists it, but its declared hash predates this fixture.
     static let newFilesOfInterest: [String: Data] = [
         "featured.json": Fixture.data("featured"),
         "recent-results.json": Fixture.data("recent-results"),
         "news.json": Fixture.data("news"),
+        "standings.json": Fixture.data("standings"),
     ]
 
     /// The full manifest fixture with the WP-106 file entries overridden to match
@@ -98,6 +101,7 @@ enum SyncTestSupport {
         "featured.json": Fixture.data("featured"),
         "recent-results.json": Fixture.data("recent-results"),
         "news.json": Fixture.data("news"),
+        "standings.json": Fixture.data("standings"),
     ]
 
     /// The filenames of `baselineFileBodies`, sorted — the expected

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -14,6 +14,7 @@ beforeAll(() => {
 	loadClientScript(sandbox, "detail.js");
 	loadClientScript(sandbox, "followed.js");
 	loadClientScript(sandbox, "chrome.js");
+	loadClientScript(sandbox, "news-web.js");
 	dash = sandbox.window.dashboard;
 	win = sandbox.window;
 });
@@ -901,5 +902,66 @@ describe("the 'Direkte nå' line (live.js)", () => {
 		} finally {
 			Date.now = realNow;
 		}
+	});
+});
+
+// ── RESULTAT-seksjonen (news-web.js, WP-171) ─────────────────────────────────
+// The section now answers "hva skjedde" for every sport in recent-results.json,
+// renders the goal scorers the fetcher already pays for, stays CAPPED (ro), and
+// puts the remainder in one quiet «Vis alle» disclosure.
+describe("Nyheter · RESULTAT (all sports, goal scorers, cap + disclosure)", () => {
+	const results = {
+		football: [
+			{ homeTeam: "Molde", awayTeam: "SK Brann", homeScore: 1, awayScore: 2, date: "2026-07-18T16:00Z", league: "Eliteserien", goalScorers: [{ player: "Kristian Eriksen", team: "SK Brann", minute: "35'" }] },
+			{ homeTeam: "Lyn", awayTeam: "KFUM", homeScore: 2, awayScore: 1, date: "2026-07-17T16:00Z", league: "OBOS-ligaen" },
+			{ homeTeam: "Rosenborg", awayTeam: "Viking", homeScore: 0, awayScore: 0, date: "2026-07-16T16:00Z", league: "Eliteserien" },
+			{ homeTeam: "Odd", awayTeam: "Sarpsborg", homeScore: 1, awayScore: 3, date: "2026-07-15T16:00Z", league: "Eliteserien" },
+			{ homeTeam: "Tromsø", awayTeam: "Bodø/Glimt", homeScore: 0, awayScore: 2, date: "2026-07-14T16:00Z", league: "Eliteserien" },
+		],
+		golf: { pga: { tournamentName: "The Open", status: "final", topPlayers: [{ position: 1, player: "Ryan Fox", score: "-10" }], norwegianPlayers: [] } },
+		f1: [{ raceName: "Belgian Grand Prix", date: "2026-07-17T11:30Z", circuit: "Spa", topDrivers: [{ position: 1, driver: "Kimi Antonelli" }] }],
+	};
+
+	function renderInto(recentResults) {
+		let html = "";
+		const el = { set innerHTML(v) { html = v; } };
+		const realGet = win.document.getElementById;
+		win.document.getElementById = (id) => (id === "nyheter" ? el : null);
+		try {
+			dash.recentResults = recentResults;
+			dash.news = [];
+			dash.renderNyheter();
+		} finally {
+			win.document.getElementById = realGet;
+		}
+		return html;
+	}
+
+	it("shows golf + F1 results alongside football, with goal scorers and minute", () => {
+		const html = renderInto(results);
+		expect(html).toContain("The Open");
+		expect(html).toContain("Ryan Fox -10");
+		expect(html).toContain("Belgian Grand Prix");
+		expect(html).toContain("35&#039; Kristian Eriksen (SK Brann)"); // escaped apostrophe — escapeHtml, per the client-render rule
+	});
+
+	it("caps the visible rows and puts the rest behind a «Vis alle» disclosure", () => {
+		const html = renderInto(results);
+		const rowsBeforeDisclosure = html.split("<details")[0].split('class="rs-row"').length - 1;
+		expect(rowsBeforeDisclosure).toBe(5);
+		expect(html).toContain("Vis alle");
+		expect(html.split('class="rs-row"').length - 1).toBe(7); // nothing dropped
+	});
+
+	it("escapes every data string in a result row (XSS)", () => {
+		const html = dash.resultRow({
+			sport: "football", title: '<img src=x onerror=alert(1)>', outcome: "1–<b>2</b>",
+			meta: '"><script>bad()</script>', details: ["<i>90'</i> Ond"],
+		});
+		expect(html).not.toContain("<img");
+		expect(html).not.toContain("<script>");
+		expect(html).not.toContain("<b>");
+		expect(html).toContain("&lt;img");
+		expect(html).toContain("&lt;i&gt;90");
 	});
 });

--- a/tests/news-web.test.js
+++ b/tests/news-web.test.js
@@ -4,7 +4,7 @@
 // prototype extension covered by the client render tests; here we pin the lens.
 
 import { describe, it, expect } from "vitest";
-import { ssNewsRelevant, ssCanonicalNewsSport } from "../docs/js/news-web.js";
+import { ssNewsRelevant, ssCanonicalNewsSport, ssResultRows, ssInterleaveBySport, SS_RESULT_CAP } from "../docs/js/news-web.js";
 
 describe("ssCanonicalNewsSport", () => {
 	it("folds aliases and lowercases", () => {
@@ -46,5 +46,120 @@ describe("ssNewsRelevant", () => {
 		// him (stamped id), not every golf headline.
 		const lens = { entityIds: new Set(["viktor-hovland"]), sports: new Set() };
 		expect(ssNewsRelevant(item({ sport: "golf", entityIds: [] }), lens)).toBe(false);
+	});
+});
+
+// ── RESULTAT (WP-171) — the shared per-sport row DNA ─────────────────────────
+// The board used to read only recent-results.json's `.football` key while The
+// Open's final leaderboard and the F1 podium sat unused in the same file. These
+// pin the projection (every sport onto ONE row shape), the goal-scorer lines the
+// fetcher has always paid for, and the interleave that keeps a golf/F1 result
+// inside the capped section on a busy football weekend.
+
+const RESULTS_FIXTURE = {
+	football: [
+		{
+			homeTeam: "Molde", awayTeam: "SK Brann", homeScore: 1, awayScore: 2,
+			date: "2026-07-18T16:00Z", league: "Eliteserien",
+			goalScorers: [
+				{ player: "Denzel De Roeve", team: "SK Brann", minute: "8'" },
+				{ player: "Seydina Diop", team: "Molde", minute: "88'" },
+			],
+		},
+		{ homeTeam: "Lyn", awayTeam: "Kongsvinger", homeScore: 3, awayScore: 0, date: "2026-07-17T16:00Z", league: "OBOS-ligaen" },
+		{ homeTeam: "Rosenborg", awayTeam: "Viking", homeScore: 1, awayScore: 1, date: "2026-07-16T16:00Z", league: "Eliteserien" },
+		{ homeTeam: "Bodø/Glimt", awayTeam: "Tromsø", homeScore: 2, awayScore: 0, date: "2026-07-15T16:00Z", league: "Eliteserien" },
+		{ homeTeam: "Sarpsborg", awayTeam: "Odd", homeScore: 0, awayScore: 0, date: "2026-07-14T16:00Z", league: "Eliteserien" },
+	],
+	golf: {
+		pga: {
+			tournamentName: "The Open", status: "final", completedRound: 4,
+			topPlayers: [
+				{ position: 1, player: "Ryan Fox", score: "-10" },
+				{ position: 2, player: "Cameron Young", score: "-9" },
+				{ position: 3, player: "Sam Burns", score: "-8" },
+				{ position: 4, player: "Scottie Scheffler", score: "-7" },
+			],
+			norwegianPlayers: [{ position: 121, player: "Viktor Hovland", score: "+4" }],
+		},
+		dpWorld: { tournamentName: "BMW International", status: "in-progress", topPlayers: [{ position: 1, player: "X", score: "-3" }], norwegianPlayers: [] },
+	},
+	f1: [{
+		raceName: "Belgian Grand Prix", type: "Race", date: "2026-07-17T11:30Z", circuit: "Spa",
+		topDrivers: [
+			{ position: 1, driver: "Kimi Antonelli" },
+			{ position: 2, driver: "Charles Leclerc" },
+			{ position: 3, driver: "Max Verstappen" },
+			{ position: 4, driver: "Lewis Hamilton" },
+		],
+	}],
+	tennis: [{ winner: "Casper Ruud", loser: "Alexander Zverev", score: "6-4, 7-5", date: "2026-07-16T12:00Z", tournament: "ATP Hamburg", round: "Semifinale" }],
+};
+
+describe("ssResultRows — every sport, one row DNA", () => {
+	const rows = ssResultRows(RESULTS_FIXTURE);
+	const bySport = (s) => rows.filter((r) => r.sport === s);
+
+	it("keeps football with the score AND renders goal scorers with minute", () => {
+		const molde = bySport("football").find((r) => r.title.includes("Molde"));
+		expect(molde.outcome).toBe("1–2");
+		expect(molde.meta).toBe("Eliteserien");
+		expect(molde.details).toEqual(["8' Denzel De Roeve (SK Brann)", "88' Seydina Diop (Molde)"]);
+		expect(molde.names).toEqual(["Molde", "SK Brann"]);
+	});
+
+	it("projects a FINISHED golf tournament onto the same shape (winner + top-3 + Norwegians)", () => {
+		const golf = bySport("golf");
+		expect(golf).toHaveLength(1); // the in-progress tour is NOT a result
+		expect(golf[0].title).toBe("The Open");
+		expect(golf[0].outcome).toBe("Ryan Fox -10");
+		expect(golf[0].meta).toBe("PGA Tour · sluttresultat");
+		expect(golf[0].details).toEqual(["1. Ryan Fox -10", "2. Cameron Young -9", "3. Sam Burns -8", "121. Viktor Hovland +4"]);
+		expect(golf[0].names).toContain("Viktor Hovland");
+	});
+
+	it("projects an F1 race: winner as the outcome, podium as the details", () => {
+		const f1 = bySport("f1")[0];
+		expect(f1.title).toBe("Belgian Grand Prix");
+		expect(f1.outcome).toBe("Kimi Antonelli");
+		expect(f1.details).toEqual(["1. Kimi Antonelli", "2. Charles Leclerc", "3. Max Verstappen"]);
+	});
+
+	it("keeps the tennis TITLE outcome-neutral (alphabetical), outcome carries the winner", () => {
+		const t = bySport("tennis")[0];
+		expect(t.title).toBe("Alexander Zverev – Casper Ruud");
+		expect(t.outcome).toBe("Casper Ruud 6-4, 7-5");
+		expect(t.meta).toBe("ATP Hamburg · Semifinale");
+	});
+
+	it("caps the detail lines so a 10-goal match is not a wall (ro)", () => {
+		const scorers = Array.from({ length: 11 }, (_, i) => ({ player: `Spiller ${i}`, team: "England", minute: `${i + 1}'` }));
+		const row = ssResultRows({ football: [{ homeTeam: "France", awayTeam: "England", homeScore: 4, awayScore: 6, date: "2026-07-18T16:00Z", goalScorers: scorers }] })[0];
+		expect(row.details).toHaveLength(6); // 5 lines + the honest remainder
+		expect(row.details.at(-1)).toBe("+6 til");
+	});
+
+	it("is empty-safe", () => {
+		expect(ssResultRows(null)).toEqual([]);
+		expect(ssResultRows({})).toEqual([]);
+		expect(ssResultRows({ football: [{ homeTeam: "", awayTeam: "" }], golf: { pga: null } })).toEqual([]);
+	});
+});
+
+describe("ssInterleaveBySport", () => {
+	it("gives every sport an answer before any sport gets a second one", () => {
+		const all = ssResultRows(RESULTS_FIXTURE);
+		const ordered = ssInterleaveBySport(all);
+		const sports = ordered.slice(0, SS_RESULT_CAP).map((r) => r.sport);
+		// Golf/F1/tennis survive inside the cap despite five football rows.
+		expect(new Set(sports)).toEqual(new Set(["football", "golf", "f1", "tennis"]));
+		expect(sports.filter((s) => s === "football")).toHaveLength(2);
+		expect(ordered).toHaveLength(all.length); // nothing dropped
+	});
+
+	it("orders within a sport newest first", () => {
+		const football = ssInterleaveBySport(ssResultRows(RESULTS_FIXTURE)).filter((r) => r.sport === "football");
+		expect(football[0].title).toContain("Molde");
+		expect(football.at(-1).title).toContain("Sarpsborg");
 	});
 });


### PR DESCRIPTION
## WP-171 · Resultat- og tabelldybde (FASE 0K, bølge 1)

«Hva skjedde i går» var **fotball-only** på begge flater og kastet bort data som
ALLEREDE hentes hver pipeline-kjøring: The Opens sluttresultat og F1-podiene lå i
`recent-results.json` uten å bli vist noe sted, og målscorerne med minutt ble
hentet av `fetch-results.js` og aldri rendret. iOS synket ikke engang
`standings.json`, mens web-detaljarket har vist tabell siden WP-14.

### De fire punktene i kontrakten

**1 · RESULTAT dekker nå ALLE sporter i `recent-results.json` (begge flater).**
Sportene har ulik resultat-DNA (golf = ledertavleposisjon/score, F1 = rekkefølge,
tennis = sett), så i stedet for tre særtilfeller projiseres hver sport på **ÉN
rad-DNA**: nøytral tittel · utfall · stille meta · detaljlinjer (`ssResultRows` /
`NewsBoard.resultRows`, tvillinger). Tennis-tittelen er bevisst **alfabetisk**
(«Alexander Zverev – Casper Ruud»), aldri «vinner – taper» — raden skal ikke
spoile det utfallet den er i ferd med å maskere. Rekkefølgen er en per-sport
**round robin** (`interleaveBySport` / `ssInterleaveBySport`): hver sport får ETT
svar før noen sport får to, ellers presser en travel fotballhelg golf/F1 ut av den
cappede seksjonen. Kun `status: "final"` golf teller som resultat (en pågående
ledertavle hører til Uka).

**2 · Målscorere med minutt** («8' Kristian Eriksen (Lyn)»). Web går gjennom
`escapeHtml` som alt annet data (klientregelen — egen XSS-test). Detaljlinjene er
cappet på 5 + «+N til», ellers blir en 10-måls VM-kamp én vegg (5 er gulvet fordi
en golf-rad må få plass til topp-3 PLUSS begge nordmennene).

**3 · iOS: `standings.json` inn i `SyncClient.defaultFilesOfInterest`** +
`DataStore.loadStandings()` + ny **TABELL-flate** i event-detalj
(`EventStandingsSection`): ligatabell / golf-ledertavle / F1-VM-stilling. Ren
byggelogikk (`StandingsTable`) er skilt fra visningen og fixture-testet mot en
innsjekket `standings.json`. **Ærlig gate:** tabellen vises KUN når den faktisk ER
dette eventets tabell — en OBOS-kamp får ikke Premier League-toppen servert som sin
egen (samme regel som web-detaljarkets `footballStanding`); fotballtabellen tar
alltid med BEGGE lagene som spiller (et lag på 14.-plass er nettopp det tappet
spurte om), golfen tar alltid med de sporede nordmennene.

**4 · Cap beholdt (ro):** 5 rader per seksjon, resten bak «Vis alle» — `<details>`
på web, en stille knapp på iOS. Ingenting droppes.

### Spoilervernet (hellig — utvidet, ikke svekket)

Alt nytt resultatinnhold ligger bak SAMME skjold:
- `NewsResultRow.spoilerSensitive` maskerer nå både **utfallet OG detaljlinjene**
  (hver eneste av dem røper resultatet) gjennom ÉN felles gate i raden
  (`outcomeVisible`), så en ny detaljlinje aldri kan lekke forbi skjoldet.
- Avsløringen finnes også når utfallet KUN bor i detaljlinjene (ellers ville
  skjoldet skjult dem uten vei tilbake).
- TABELL-seksjonen er resultat-avledet og er derfor maskert bak «Vis tabell» når
  `row.spoilerSafe` er false — samme mekanisme som arkets egen RESULTAT-seksjon.
- Titlene er outcome-nøytrale, så selve raden spoiler ikke før skjoldet rekker det.

### Ikke-mål (respektert)

Ingen nye fetchere. Ingen live-oppdatering av tabeller (statisk pipeline-kadens er
kadensen — seksjonen leser cachen én gang når arket vises). Ingen endring i
feed-predikatene (gylne vektorer urørt). Entitetssiden (WP-170) urørt.

### Naboer

`EventDetailSheet.swift` (WP-182s fil) er rørt **minimalt**: ett kallsted
(`EventStandingsSection(row: row)`) etter RESULTAT-seksjonen — all logikk, lasting
og spoilermaskering bor i den NYE fila. `docs/css/cards.css` (WP-185) er **ikke**
rørt: radene gjenbruker eksisterende klasser (`.rs-row`/`.rs-meta`/`.rs-score`) og
disclosuren gjenbruker `.fremover`-mønsteret.

### Aksept-bevis

- **Web:** `npx vitest run --maxWorkers=1` → **64 filer / 1028 tester grønne**
  (etter rebase på main med WP-185 inne). Nye tester: `tests/news-web.test.js`
  (rad-DNA per sport, målscorer-linjer, tennis-nøytral tittel, detalj-cap,
  interleave, tomsikkerhet) + `tests/dashboard-cards.test.js` (golf/F1 synlig på
  tavla, cap + «Vis alle»-disclosure, XSS-escaping av alle datastrenger).
- **iOS:** full unit-suite `xcodebuild test -scheme Sportivista` → **700 passed,
  0 failed, 2 skipped** (kjøretid i suiten ~150 s, dvs. uendret fra baseline —
  ingen at-skala-regresjon). Nye tester: `StandingsTableTests` (9) mot innsjekket
  fixture + 8 nye i `NewsBoardTests`.
- **Gylne feed-vektorer:** `FeedVectorTests` grønn — kompilerings-/matching-
  semantikken er urørt.
- **4 schemes bygger:** `Sportivista` (via test), `SportivistaWidgetExtension`,
  `SportivistaUITests`, `SportivistaDeviceDev` (generic/iOS).
- **Skjermbilder (mørk + lys, 2 per flate):** web Nyheter-tavlas RESULTAT (golf +
  F1 + fotball med målscorere + «Vis alle 11») og iOS Nyheter-tavla (fire sporter
  interleavet) + iOS event-detaljens TABELL (3M Open-ledertavla med Kristoffer
  Ventura uthevet på 135.-plass). Verifisert i simulator (iPhone 17, iOS 26.5) og
  i Playwright; ikke innsjekket (repoet har ingen bevis-mappe).

**Merknad om flakiness:** tre tidlige fullsuite-kjøringer feilet hver gang på en
FORSKJELLIG lang test («Test crashed with signal kill») mens flere xcodebuild-
agenter kjørte parallelt på samme Mac; hver av dem er grønn isolert, en baseline-
kjøring på urørt `origin/main` viste samme bilde, og de tre siste fullkjøringene av
denne grenen er grønne. Ikke en regresjon fra denne pakken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
