### PR TITLE
fix(ios): gjør AgendaReloadConcurrencyTests deterministisk under last

### DIFF
--- a/ios/Sportivista/Agenda/AgendaViewModel.swift
+++ b/ios/Sportivista/Agenda/AgendaViewModel.swift
@@ -823,14 +823,33 @@ final class AgendaViewModel {
 /// trap for a recorder, so a test can drive the pipeline on the main thread and
 /// assert the guard fired (see AgendaReloadConcurrencyTests). Compiled to a
 /// no-op in release.
+///
+/// The recorder is installed **per thread**, not process-globally. A violation
+/// can only be observed on the thread that is violating (the guard early-returns
+/// off-main), so thread scope is exactly the right scope — and it makes the two
+/// recording tests (AgendaReloadConcurrencyTests + NewsModelTests) incapable of
+/// clobbering each other's recorded state or of flipping each other back into
+/// trapping mode, whatever else is in flight on other threads. The earlier
+/// design used two process-global `nonisolated(unsafe) static var`s (a shared
+/// `violations` array + a shared trap/record mode flag), which any concurrently
+/// running recorder could reset out from under the one being asserted on.
 enum MainThreadGuard {
     #if DEBUG
-    /// Recorded violations while `recordViolationsForTesting` is active. Guarded
-    /// by "only writes when already on the main thread" (see `assertOffMain`), so
-    /// there is no cross-thread access in practice.
-    nonisolated(unsafe) static var violations: [String] = []
-    /// When true (the default), a violation traps; a test flips it to record.
-    nonisolated(unsafe) static var trapsInsteadOfRecording = true
+    /// The violations recorded by ONE `recordViolationsForTesting` call. A
+    /// reference type so the installed recorder and the caller see the same box.
+    /// Only ever touched from the thread it is installed on.
+    final class Recorder {
+        fileprivate(set) var violations: [String] = []
+    }
+
+    /// `threadDictionary` key for the recorder currently installed on this
+    /// thread. Absent (the normal case, and always in the app) ⇒ violations trap.
+    private static let recorderKey = "app.sportivista.MainThreadGuard.recorder"
+
+    /// The recorder installed on the CURRENT thread, if any.
+    private static var currentRecorder: Recorder? {
+        Thread.current.threadDictionary[recorderKey] as? Recorder
+    }
     #endif
 
     /// Trip if called on the main thread. `label` is an autoclosure so building
@@ -839,27 +858,29 @@ enum MainThreadGuard {
         #if DEBUG
         guard Thread.isMainThread else { return }
         let message = "WP-60: \(label()) ran on the main thread — decode/compile must stay off the main actor"
-        if trapsInsteadOfRecording {
-            assertionFailure(message)
+        if let recorder = currentRecorder {
+            recorder.violations.append(message)
         } else {
-            violations.append(message)
+            assertionFailure(message)
         }
         #endif
     }
 
     #if DEBUG
-    /// Run `body` with the guard recording (not trapping) and return whatever it
-    /// recorded, restoring the previous mode afterwards. For tests only.
+    /// Run `body` with the guard recording (not trapping) ON THIS THREAD and
+    /// return what it recorded, restoring any previously installed recorder
+    /// afterwards (so nesting works). For tests only.
+    ///
+    /// `body` must run its violating work synchronously on the calling thread —
+    /// which is the whole point: the returned violations are the ones THIS body
+    /// caused, never a neighbouring test's.
     static func recordViolationsForTesting(_ body: () -> Void) -> [String] {
-        let previous = trapsInsteadOfRecording
-        trapsInsteadOfRecording = false
-        violations = []
-        defer {
-            violations = []
-            trapsInsteadOfRecording = previous
-        }
+        let recorder = Recorder()
+        let previous = Thread.current.threadDictionary[recorderKey]
+        Thread.current.threadDictionary[recorderKey] = recorder
+        defer { Thread.current.threadDictionary[recorderKey] = previous }
         body()
-        return violations
+        return recorder.violations
     }
     #endif
 }

--- a/ios/SportivistaTests/AgendaReloadConcurrencyTests.swift
+++ b/ios/SportivistaTests/AgendaReloadConcurrencyTests.swift
@@ -51,10 +51,26 @@ final class AgendaReloadConcurrencyTests: XCTestCase {
 
     // MARK: - Coalescing
 
+    /// The precondition every coalescing assertion below rests on: a burst fired
+    /// from synchronous `@MainActor` code holds the main actor for its whole
+    /// duration, so the reload `Task { @MainActor in … }` cannot have STARTED —
+    /// let alone finished — while the burst is being fired. That is an actor
+    /// guarantee, not a timing hope, and asserting it turns "the in-flight reload
+    /// might already have finished under load" from an unstated assumption into a
+    /// checked, self-describing one: if it ever breaks, this line fails and names
+    /// the reason instead of leaving a bare `== 2` mismatch to interpret.
+    private func assertBurstWasAtomic(_ vm: AgendaViewModel, since before: Int,
+                                      file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(vm.recompileCount - before, 0,
+                       "precondition: the burst held the main actor throughout, so no recompile has begun yet",
+                       file: file, line: line)
+    }
+
     func test_singleReload_isOneRecompile() async throws {
         let vm = makeVM(cache: try tempCacheWithFixtures(), profileStore: tempProfileStore())
 
         vm.reloadFromCache(now: iso(now))
+        assertBurstWasAtomic(vm, since: 0)
         await vm.awaitReloadsQuiescent()
 
         XCTAssertEqual(vm.recompileCount, 1, "a single reload recompiles exactly once")
@@ -70,6 +86,7 @@ final class AgendaReloadConcurrencyTests: XCTestCase {
         // more when done", so the whole burst is ≤2 compiles, never N.
         let before = vm.recompileCount
         for _ in 0..<8 { vm.reloadFromCache(now: iso(now)) }
+        assertBurstWasAtomic(vm, since: before)
         await vm.awaitReloadsQuiescent()
 
         XCTAssertLessThanOrEqual(vm.recompileCount - before, 2, "N rapid reloads ⇒ ≤2 recompiles")
@@ -97,6 +114,7 @@ final class AgendaReloadConcurrencyTests: XCTestCase {
         try profileStore.save(InterestProfile(rules: []))  // latest state: empty
         vm.reloadFromCache(now: iso(now))                  // coalesced
         vm.reloadFromCache(now: iso(now))                  // coalesced
+        assertBurstWasAtomic(vm, since: before)
         await vm.awaitReloadsQuiescent()
 
         XCTAssertEqual(vm.recompileCount - before, 2, "the burst still coalesced to two recompiles")
@@ -112,13 +130,41 @@ final class AgendaReloadConcurrencyTests: XCTestCase {
         // This test method runs on the main thread, so invoking the synchronous
         // pipeline directly here is exactly the regression the guard must catch.
         // `recordViolationsForTesting` swaps the trap for a recorder so we can
-        // assert it fired without a (unsupported) death test.
+        // assert it fired without a (unsupported) death test. The recorder is
+        // installed on THIS thread only, so what comes back is what this body
+        // caused — NewsModelTests' identical guard test cannot reset it (nor can
+        // anything else in flight) between the call and the assertion.
         let violations = MainThreadGuard.recordViolationsForTesting {
             _ = AgendaViewModel.computeReloadSync(
                 now: iso(now), dataStore: dataStore, profileStore: profileStore, cachedIndex: nil)
         }
 
         XCTAssertFalse(violations.isEmpty, "decode/compile on the main thread must trip the WP-60 guard")
+        // …and it is OUR pipeline that tripped it, not some neighbouring one.
+        XCTAssertTrue(violations.contains { $0.contains("AgendaViewModel reload") },
+                      "the recorded violation is the agenda reload pipeline's own")
+    }
+
+    /// The recorder must be scoped to ONE `recordViolationsForTesting` call, so a
+    /// second guard test (NewsModelTests has one) can neither see this one's
+    /// violations nor clear them. Nesting is the sharpest form of that: the inner
+    /// recorder captures only the inner violation, and the outer one is intact
+    /// afterwards. The process-global recorder this replaced failed both halves.
+    func test_guardRecorder_isScopedToOneRecordingCall() throws {
+        var inner: [String] = []
+        let outer = MainThreadGuard.recordViolationsForTesting {
+            MainThreadGuard.assertOffMain("outer pipeline")
+            inner = MainThreadGuard.recordViolationsForTesting {
+                MainThreadGuard.assertOffMain("inner pipeline")
+            }
+            MainThreadGuard.assertOffMain("outer pipeline, after the nested recorder")
+        }
+
+        XCTAssertEqual(inner.count, 1, "the nested recorder sees only its own violation")
+        XCTAssertTrue(inner[0].contains("inner pipeline"))
+        XCTAssertEqual(outer.count, 2, "the outer recorder keeps its own violations across the nested one")
+        XCTAssertTrue(outer.allSatisfy { $0.contains("outer pipeline") },
+                      "and none of the inner recorder's leaked into it")
     }
 
     func test_computeReload_runsOffMain_withoutTripping() async throws {


### PR DESCRIPTION
WP-60-klassen `AgendaReloadConcurrencyTests` feilet tilfeldig i fulle kjøringer (observert 22.07 under WP-180: to kjøringer på rad, **ulike metoder** hver gang), men besto isolert både med og uten arbeidstre-endringene. Altså last-/timing-følsomhet, ikke en regresjon — flere xcodebuild-agenter kjørte på samme Mac.

Dette er verdt å fikse fordi `ios-tests` er porten de selv-fiksende løkkene venter på i `scripts/merge-gate.js`: en flaky klasse får hver iOS-PR til å se rød ut på slump.

## Rotårsak

`MainThreadGuard`-opptakeren var **prosess-global**: to `nonisolated(unsafe) static var` (`violations`-arrayet + `trapsInsteadOfRecording`-flagget) delt av hele testprosessen. To testklasser bruker `recordViolationsForTesting` — denne og `NewsModelTests` — og begges nullstilling (ved inngang **og** i `defer`) kunne tørke arrayet den andre var i ferd med å asserte på, eller vippe den tilbake til trap-modus midt i kroppen.

## Fiks

**Opptakeren er nå per tråd** (`Thread.threadDictionary`, med nøsting-trygg lagre/gjenopprett). Et brudd kan bare observeres på tråden som bryter — vakten returnerer tidlig off-main — så trådscope er nøyaktig riktig scope, og de to guard-testene kan ikke lenger røre hverandres tilstand. Ingenting utenfor vakten refererte de gamle statiske variablene.

**Den underforståtte antakelsen er nå en assertert forutsetning.** Den eksakte `== 2`-forventningen er beholdt (den *er* beviset på coalescing), men hver burst sjekker nå `recompileCount - before == 0` rett etter at den er fyrt, via `assertBurstWasAtomic`. En burst fyrt fra synkron `@MainActor`-kode holder main-aktøren hele veien, så reload-`Task`-en kan ikke ha startet — en aktørgaranti, ikke et timing-håp. Ryker den noen gang (f.eks. hvis et suspenderingspunkt sniker seg inn i `reloadFromCache`), navngir feilen grunnen i stedet for å etterlate et bart tallavvik å tolke.

**Ingen sleeps, ingen løsnede grenser, ingen svekkede assertions.** Guard-testen sjekker i tillegg at bruddet er *vårt* (meldingsinnhold), og en ny `test_guardRecorder_isScopedToOneRecordingCall` pinner isolasjons-semantikken fiksen innfører.

## Verifisering

Alt kjørt med 10 mettende CPU-prosesser i bakgrunnen, pluss en annen agents `xcodebuild` på samme maskin:

- **Klassen 10/10 ganger** på den rebasede koden (og 10/10 på pre-rebase-koden før det)
- **Full `SportivistaTests`-suite grønn** (`Test Suite 'All tests' passed`) — dekker `NewsModelTests`, den andre brukeren av opptakeren
- `npm test`: 64 filer / 1017 tester grønne

🤖 Generated with [Claude Code](https://claude.com/claude-code)