### PR TITLE
WP-190: G1 gjort målbar — personvernerklæring + privacy manifest + ærlig port

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -400,7 +400,10 @@ verdi + chevron trailing). Grupper:
   «Slutt å følge», + **Legg til**-søk mot entitets-indeksen med Følg-knapper)
   · Sett opp på nytt.
 - **DATA OM MEG:** Hva jeg vet om deg (n) · Det jeg ikke forsto (n) · Del profil (QR).
-- **APP:** Varsel før start (leadMinutes) · Utseende (tema) · Nullstill.
+- **APP:** Varsel før start (leadMinutes) · Utseende (tema) · Merker og kilder ·
+  **Personvern** (WP-190 — én rolig rad som åpner `sportivista.com/personvern.html`
+  i Safari; erklæringen bor på nett fordi den må være offentlig lesbar og finnes i
+  ÉN versjon, aldri som modal ved oppstart) · Nullstill.
 - **FOT:** «BYGG <sha> · dato · SISTE / NYERE FINNES» (dempet).
 - **DEBUG (kun DEBUG-bygg):** Eval · Telemetri (MetricKit).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2355,7 +2355,7 @@ men si det ærlig).
 
 | WP | Tittel | Fase | Avhenger av | Status |
 |---|---|---|---|---|
-| WP-190 | G1 gjort målbar: personvernerklæring + privacy manifest + ekstern TestFlight + målemetode | 0M | — | planlagt |
+| WP-190 | G1 gjort målbar: personvernerklæring + privacy manifest + ekstern TestFlight + målemetode | 0M | — | 🔬 branch wp-190-g1-malbar — personvernerklæring (`docs/personvern.html`, ugatet, lenket fra web-foten + Deg › Personvern), `PrivacyInfo.xcprivacy` for app (UserDefaults/CA92.1) + widget (tom, verifisert), G1 omdefinert til et etterprøvbart ASC+dagbok-kriterium med eier-sjekkliste. Beta App Review-innsendingen står igjen som eier-handling |
 | WP-191 | 💰 Juridisk fundament: enhet, Apple-org, varemerke (menneskeoppgave, sekvensert) | 0M | — | planlagt |
 | WP-192 | Kilde-/hosting-risiko sekvensert FØR vekst (WP-20/21-rekkefølgen pinnet) | 0M | — | planlagt |
 
@@ -2372,6 +2372,11 @@ App Store Connect/TestFlight-metrikker (sessions/installs — IKKE D7-kohorter)
 — eier velger (b-beslutningen over). **Aksept:** Beta App Review godkjent;
 personvernsiden live; privacy manifest bygger; G1-teksten i denne planen
 oppdatert med valgt instrument.
+**Levert 22.07 (branch `wp-190-g1-malbar`):** (1) + (2) + (4) er gjort — se
+`## 🚪 GATE G1` for det valgte instrumentet, hva det IKKE måler, og den
+nummererte eier-sjekklista. (3) **ekstern testergruppe + Beta App Review-
+innsending er per definisjon en eier-handling** (Apple-konto-tilgang) og står
+som punkt 4 i den sjekklista — agenten forbereder, eieren sender.
 
 ### WP-191 · 💰 Juridisk fundament (menneskeoppgave — planen sekvenserer)
 **Innhold (sjekkliste for eier, med bistand):** (0) **KLUBBEMBLEMENE — avklares her**
@@ -2417,9 +2422,90 @@ ingen kodeendring utover ev. kommentarer.
 
 ## 🚪 GATE G1 · Lakmustesten (dossier P500 Fase 0)
 
-Etter ~4 uker TestFlight: åpner folk appen daglig uten push-mas? D7-retention?
 **Beslutning (menneske):** gå til Fase 1, forbli hobbyprodukt, eller avvikle app-sporet.
 Alt under denne linjen er skisse som re-planlegges ved gaten.
+
+### Porten, omdefinert til det som faktisk kan måles (WP-190, 22.07.2026)
+
+Den opprinnelige formuleringen — «etter ~4 uker TestFlight: **D7-retention?**» —
+er **ikke målbar for dette produktet**, og det er ikke en instrumenterings-mangel
+som kan tettes. Tre grunner, i rekkefølge:
+
+1. **Vi har ingen retensjonsdata og skal ikke ha det.** D7-retention forutsetter
+   at man kan følge SAMME bruker over syv dager. Det krever en bruker-id og et
+   telemetri-endepunkt — nøyaktig **B.3** i «BRUKERDATA → PRODUKTFORBEDRING»,
+   som er merket *siste utvei* fordi den bruker opp «dine data rører aldri
+   serveren vår» — tillitskapitalen produktet posisjoneres på. Å måle G1 med
+   telemetri ville koste mer enn porten er verdt.
+2. **App Store Connect gir ikke kohorter for TestFlight.** ASC viser installs,
+   sessions, crashes og «Testers» per bygg. Det er *volum*, ikke *retensjon*:
+   ingen D1/D7/D30-kurve, ingen per-tester-tidsserie du kan dele i kohorter.
+3. **N er encifret.** Med en håndfull testere er enhver prosentsats støy. En
+   D7-prosent av 6 personer er teater, ikke en beslutning.
+
+**Den nye porten (BINDENDE — dette er kriteriet G1 måles mot):**
+
+> **G1 er bestått når, ved slutten av uke 4 med minst 5 eksterne TestFlight-testere:**
+> **(a) ≥ 3 testere har hatt sessions i minst 5 av de 7 siste dagene** (ASC →
+> TestFlight → Sessions, avlest per bygg og notert ukentlig i dagboken),
+> **(b) ≥ 3 av 5 svarer 4 eller 5 på «Hvor lei deg ville du blitt om Sportivista**
+> **forsvant i morgen?» (1–5)** i uke-4-spørsmålet, og
+> **(c) 0 uløste krasj-klynger** i ASC over de to siste ukene.
+>
+> Bestått ⇒ Fase 1. Delvis (a eller b, ikke begge) ⇒ forleng med 4 uker og
+> flere testere FØR beslutningen tas — ikke «bestått med forbehold».
+> Ikke bestått ⇒ hobbyprodukt eller avvikling, etter eierens valg.
+
+**Instrumentet — to deler, ingen ny kode, ingen telemetri:**
+
+- **Del 1 · ASC/TestFlight-metrikker (mekanisk, grovt).** Installs, sessions,
+  crashes per bygg, avlest i App Store Connect. Måler *at* appen brukes og *at*
+  den ikke krasjer. Kan ikke svare på hvem, hvor ofte per person, eller hvorfor.
+- **Del 2 · Strukturert testerdagbok (kvalitativ, men fastspikret).** Samme fire
+  spørsmål til hver tester i uke 1, 2 og 4 — samme ordlyd hver gang, svar
+  noteres ordrett, ikke oppsummert:
+  1. «Når åpnet du den sist, og hva så du etter?»
+  2. «Hva var feil eller manglet — tid, kanal, eller noe som ikke var der?»
+  3. «Hvor lei deg ville du blitt om den forsvant i morgen? (1–5)»
+  4. «Har du fortalt noen om den? Hvem, og hva sa du?»
+  Spørsmål 3 er porten (b); spørsmål 2 mater dekningsløkkene; spørsmål 4 er det
+  eneste ærlige spredningssignalet på denne skalaen.
+
+**Hva instrumentet IKKE kan svare på (skriv det ned, ikke lat som):**
+ekte D1/D7/D30-retensjon · hvilke skjermer folk faktisk bruker · hvor de faller
+av i onboarding · om varsler blir åpnet · om en tester sluttet fordi appen var
+dårlig eller fordi sesongen var død. Del 2 er selvrapportert og har både
+høflighets-skjevhet (testerne kjenner eieren) og et utvalg på 5–10 personer —
+den *beskriver*, den beviser ikke. Porten er derfor bevisst satt som et
+**gulv man enten passerer eller ikke**, ikke som en presisjonsmåling. Trenger
+Fase 1 ekte produktanalyse senere, er det en egen, bevisst B.2/B.3-beslutning
+(opt-in, dokumentert i `docs/personvern.html` FØR den slås på) — ikke noe som
+smugles inn under G1.
+
+### Hva som gjenstår som EIER-HANDLING før klokka på de 4 ukene kan starte
+
+WP-190 har levert forutsetningene (personvernerklæring + privacy manifest +
+porten definert). Resten er handlinger bare eieren kan gjøre — i denne rekkefølgen:
+
+1. **Les gjennom `docs/personvern.html`** og bekreft at den stemmer med det du
+   mener produktet er. Bytt ev. kontakt-e-posten til en du vil ha offentlig.
+   (Anbefalt: ta den samme runden med advokat som WP-191-punktene, inkl.
+   klubbemblem-spørsmålet — én gjennomgang, ikke tre.)
+2. **App Store Connect → App Privacy:** sett personvern-URL til
+   `https://sportivista.com/personvern.html` og fyll «nutrition labels» som
+   **Data Not Collected** (utkastet ligger i WP-190s PR-beskrivelse).
+3. **Verifiser at neste TestFlight-bygg bærer privacy-manifestene** — last opp
+   via release-lanen og sjekk at ASC ikke flagger manglende manifest.
+4. **Opprett en ekstern testergruppe** i TestFlight («Uke 1–4») og send bygget
+   til **Beta App Review**. Dette er innsendingen agenten ikke gjør.
+5. **Verv 5–10 testere** som faktisk følger norsk sport (ikke bare venner som
+   sier ja). Under 5 er porten ikke målbar — da forlenges vervingen, ikke porten.
+6. **Start dagboken** (ett dokument, én seksjon per tester): noter startdato,
+   still de fire spørsmålene i uke 1, 2 og 4, skriv svarene ordrett.
+7. **Les av ASC ukentlig** (installs/sessions/crashes per bygg) og skriv tallet
+   inn i samme dokument samme dag — ASC-vinduer ruller, tall du ikke noterte er borte.
+8. **Ved slutten av uke 4: avgjør mot (a)/(b)/(c) over**, og skriv beslutningen
+   + begrunnelsen inn i denne seksjonen. Porten er ikke bestått før den er skrevet ned.
 
 ---
 

--- a/docs/activity.html
+++ b/docs/activity.html
@@ -114,6 +114,7 @@
 
 	<footer class="site-footer wrap">
 		<a class="back-link" href="./">← oversikten</a>
+		<a href="personvern.html" class="footer-alt">Personvern</a>
 	</footer>
 
 	<!-- Whole-web-behind-login: CloudKit JS + the shared gate (gate-boot.js). -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,6 +170,7 @@
 		<a href="webcal://sportivista.com/data/events.ics" title="Abonner — native påminnelser på mobil før varsel-eventene (ett trykk på iOS/Android)">Abonner i kalender</a>
 		<a href="data/events.ics" download class="footer-alt" title="Last ned .ics (engangsimport, f.eks. på desktop)">last ned</a>
 		<a href="activity.html" class="footer-alt" title="Hva automatikken har gjort — forbedringer og endringer">Aktivitet</a>
+		<a href="personvern.html" class="footer-alt" title="Hva som lagres, hvor det bor, og hva som aldri sendes til oss">Personvern</a>
 		<a id="app-promo-link" class="footer-alt footer-app" href="#" hidden title="Sportivista som iPhone-app — varsler, widget og assistent på lomma">Få iPhone-appen</a>
 		<span id="footer-stale" class="footer-stale" hidden></span>
 		<span id="footer-usage" class="footer-usage" hidden></span>

--- a/docs/personvern.html
+++ b/docs/personvern.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="nb">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+	<meta name="description" content="Personvern i Sportivista — hva som lagres, hvor det bor, og hva som aldri sendes til oss.">
+	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+	<meta name="theme-color" content="#F2F2F7" media="(prefers-color-scheme: light)">
+	<link rel="icon" type="image/png" href="favicon.png">
+	<title>Sportivista · Personvern</title>
+	<!-- Link preview (WP-182) — same checked-in static card as index.html. -->
+	<meta property="og:type" content="website">
+	<meta property="og:site_name" content="Sportivista">
+	<meta property="og:locale" content="nb_NO">
+	<meta property="og:url" content="https://sportivista.com/personvern.html">
+	<meta property="og:title" content="Sportivista · Personvern">
+	<meta property="og:description" content="Personvern i Sportivista — hva som lagres, hvor det bor, og hva som aldri sendes til oss.">
+	<meta property="og:image" content="https://sportivista.com/og/og-default.png">
+	<meta property="og:image:type" content="image/png">
+	<meta property="og:image:width" content="1200">
+	<meta property="og:image:height" content="630">
+	<meta property="og:image:alt" content="Sportivista — svart kort med ordmerket, amber kolon og en tidskolonne.">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:title" content="Sportivista · Personvern">
+	<meta name="twitter:description" content="Personvern i Sportivista — hva som lagres, hvor det bor, og hva som aldri sendes til oss.">
+	<meta name="twitter:image" content="https://sportivista.com/og/og-default.png">
+	<meta name="twitter:image:alt" content="Sportivista — svart kort med ordmerket, amber kolon og en tidskolonne.">
+	<!-- Apply the chosen theme before paint (no flash of wrong theme); js/theme.js owns the toggle. -->
+	<script>try { var t = localStorage.getItem('ss-theme'); if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t; } catch (e) {}</script>
+	<link rel="stylesheet" href="css/base.css">
+	<link rel="stylesheet" href="css/layout.css">
+	<style>
+		/* Personvern — a reading page. Same calm tokens as the rest of the site; the
+		   only local rules are prose rhythm (the agenda's CSS is row-shaped and has
+		   nothing to say about running text). Never a legal wall: short sections,
+		   one idea each, plain Norwegian. */
+		.pv-lead { color: var(--fg-2); font-size: 0.95rem; line-height: 1.6; margin: 0 0 10px; max-width: 62ch; }
+		.pv-updated { color: var(--fg-3); font-size: 0.8rem; margin: 0 0 30px; }
+
+		.pv-summary { border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; margin: 0 0 34px; }
+		.pv-summary h2 { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--fg-3); font-weight: 600; margin: 0 0 10px; }
+		.pv-summary ul { margin: 0; padding: 0 0 0 18px; }
+		.pv-summary li { color: var(--fg); font-size: 0.92rem; line-height: 1.55; margin: 0 0 6px; }
+		.pv-summary li:last-child { margin-bottom: 0; }
+
+		.pv-section { margin: 0 0 32px; max-width: 62ch; }
+		.pv-section > h2 {
+			font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.12em;
+			color: var(--fg-3); font-weight: 600; margin: 0 0 12px; padding-bottom: 6px;
+			border-bottom: 1px solid var(--line);
+		}
+		.pv-section p { color: var(--fg-2); font-size: 0.92rem; line-height: 1.6; margin: 0 0 12px; }
+		.pv-section p:last-child { margin-bottom: 0; }
+		.pv-section strong { color: var(--fg); font-weight: 600; }
+		.pv-section ul { margin: 0 0 12px; padding: 0 0 0 18px; }
+		.pv-section li { color: var(--fg-2); font-size: 0.92rem; line-height: 1.6; margin: 0 0 7px; }
+		.pv-section a { color: var(--fg-2); }
+		.pv-section a:hover { color: var(--accent); }
+		.pv-key { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.86em; color: var(--fg); }
+		.pv-note { color: var(--fg-3); font-size: 0.85rem; line-height: 1.55; }
+	</style>
+</head>
+<!-- NB: denne siden står BEVISST UTENFOR innloggings-gaten (ingen `body.gated`,
+     ingen gate-boot.js). En personvernerklæring må være offentlig lesbar — både
+     for App Store-gjennomgangen og for den som vurderer å ta appen i bruk. Den
+     laster derfor heller ingen CloudKit-JS: siden gjør null nettverkskall utover
+     å hente sine egne CSS-filer fra samme opphav. -->
+<body>
+	<header class="masthead">
+		<div class="wrap masthead-inner">
+			<div class="mast-row mast-row-top">
+				<span class="wordmark-lockup"><span class="wordmark">Sportivista</span><span class="wordmark-colon" aria-hidden="true">:</span></span>
+				<button class="theme-toggle" id="theme-toggle" title="Bytt tema" aria-label="Bytt tema">◐</button>
+			</div>
+			<div class="mast-row mast-row-sub">
+				<p class="mast-date">Personvern</p>
+			</div>
+		</div>
+	</header>
+
+	<main class="wrap">
+		<p class="pv-lead">
+			Sportivista er bygget rundt ett valg: <strong>det vi vet om deg, vet vi ikke.</strong>
+			Profilen din — hva du følger, hva assistenten husker — ligger på enheten din og i
+			<strong>din egen private iCloud</strong>. Det finnes ingen Sportivista-server som
+			kan lese den, fordi det ikke finnes noen Sportivista-server i det hele tatt.
+			Under står det presist hva det betyr, og like presist hva det <em>ikke</em> betyr.
+		</p>
+		<p class="pv-updated">Sist oppdatert 22.07.2026 · gjelder iPhone-appen og sportivista.com</p>
+
+		<div class="pv-summary">
+			<h2>Kort fortalt</h2>
+			<ul>
+				<li>Vi har ingen brukerkonto, ingen database og ingen server som lagrer noe om deg.</li>
+				<li>Profilen din bor på enheten og i din egen private iCloud. Vi har ikke tilgang.</li>
+				<li>Ingen analyseverktøy, ingen sporings-SDK-er, ingen annonser, ingen datasalg.</li>
+				<li>Assistenten kjører på enheten din. Det du skriver til den forlater ikke telefonen.</li>
+				<li>Men: å hente data over nett betyr at leverandørene i mellomleddet (Apple, GitHub, og på nettsiden ESPN) ser IP-adressen din. Det står forklart under.</li>
+			</ul>
+		</div>
+
+		<section class="pv-section">
+			<h2>Hvem er ansvarlig</h2>
+			<p>
+				Sportivista drives i dag av en privatperson, Christopher Hærem, som et
+				personlig prosjekt. Han er behandlingsansvarlig for de få personopplysningene
+				som i det hele tatt oppstår. Kontakt:
+				<a href="mailto:chris.haerem@gmail.com">chris.haerem@gmail.com</a>, eller en
+				<a href="https://github.com/CHaerem/sportivista/issues" target="_blank" rel="noopener">sak i det offentlige kodelageret</a>
+				(husk at en sak der er synlig for alle).
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Profilen din</h2>
+			<p>Profilen er alt som gjør tavla til <em>din</em>:</p>
+			<ul>
+				<li>hvilke lag, utøvere og turneringer du følger (og hva du har sluttet å følge),</li>
+				<li>preferanser du har satt — varsel før start, tema, hvilke resultater du vil ha varsel om,</li>
+				<li>korte notater assistenten husker fordi du ba den om det («ikke vis resultater før jeg har sett kampen»),</li>
+				<li>enkle tellere for hva du åpner, som brukes til å løfte det du engasjerer deg i litt høyere i lista.</li>
+			</ul>
+			<p>
+				På iPhone lagres dette i appens eget område på enheten, og synkroniseres —
+				hvis du er logget inn med Apple-ID-en din — til <strong>din egen private
+				CloudKit-database</strong> hos Apple. Det er din iCloud, innenfor din
+				lagringskvote. Apple flytter bytene mellom dine egne enheter; vi ser dem aldri.
+			</p>
+			<p>
+				Profilen lagres som <strong>klartekst</strong> i din private iCloud — den er
+				ikke ende-til-ende-kryptert. Det er et bevisst valg: en følgeliste for sport er
+				lite sensitiv, og klartekst er det som gjør at din <em>egen</em> nettleser-
+				innlogging kan lese den. Personverngrensen som faktisk betyr noe — at dataene
+				bare finnes i din private konto, aldri hos oss — er den samme uansett.
+			</p>
+			<p>
+				På nettsiden lagres profilen i nettleserens <span class="pv-key">localStorage</span>
+				under nøklene <span class="pv-key">ss-profile</span>,
+				<span class="pv-key">ss-device-id</span> (en tilfeldig enhets-ID som bare brukes
+				til å slå sammen profiler fra flere enheter), <span class="pv-key">ss-theme</span>,
+				<span class="pv-key">ss-install-hint</span> og <span class="pv-key">ss-app-promo</span>.
+				Ingen av dem sendes til oss.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Innlogging med Apple</h2>
+			<p>
+				Nettsiden bruker <strong>Logg inn med Apple</strong> via Apples CloudKit JS.
+				Innloggingen skjer hos Apple; vi ser hverken passordet ditt, Apple-ID-en din
+				eller e-postadressen din. Det eneste innloggingen gir oss er ingenting — den
+				gir <em>deg</em> tilgang til din egen private iCloud-database fra nettleseren.
+				Apples CloudKit-bibliotek lagrer sin egen økt-nøkkel i nettleseren din for å
+				holde deg innlogget.
+			</p>
+			<p class="pv-note">
+				Web-API-nøkkelen som ligger i nettsidens kode er offentlig og opphavs-låst
+				(det er slik CloudKit JS er designet) — den gir ingen tilgang til noens data.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Assistenten</h2>
+			<p>
+				Assistenten i iPhone-appen kjører på Apples <strong>on-device-språkmodell</strong>
+				(Apple Intelligence). Det du skriver, og svaret du får, blir behandlet på
+				telefonen din og sendes ikke til oss eller til noen skytjeneste av oss.
+			</p>
+			<p>
+				Appen fører en lokal logg over ytringer den <em>ikke forsto</em> («Det jeg ikke
+				forsto» under Deg), slik at du kan se den. Den ligger bare på enheten. Den
+				forlater telefonen kun hvis du selv trykker del og selv velger hvor den skal.
+			</p>
+			<p>
+				Assistenten på nettsiden er en enklere, regelbasert variant. Den bruker ingen
+				språkmodell og gjør ingen nettverkskall.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Ytelsesmålinger på enheten</h2>
+			<p>
+				Appen abonnerer på iOS' innebygde <strong>MetricKit</strong> og lagrer et lite,
+				anonymt sammendrag av oppstartstider og «heng» <em>lokalt på enheten</em>. Det
+				finnes ingen nettverkskode i den delen av appen — sammendraget sendes ingen
+				steder. Eksportknappen som finnes for dette er kun med i utviklerbygg, ikke i
+				appen du laster ned.
+			</p>
+			<p>
+				Uavhengig av oss: hvis du har slått på <em>«Del med apputviklere»</em> i iOS'
+				personverninnstillinger, sender Apple aggregerte krasj- og ytelsesrapporter til
+				utviklere. Det er Apples kanal, ikke vår, og du styrer den i Innstillinger →
+				Personvern og sikkerhet → Analyse og forbedringer.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Hva enheten din faktisk kontakter</h2>
+			<p>
+				Vi samler ikke inn noe — men å hente data over internett er ikke usynlig. Dette
+				er hele lista over hvem som kan se at nettopp din enhet var i kontakt (typisk
+				IP-adresse og tidspunkt i deres egne serverlogger):
+			</p>
+			<ul>
+				<li>
+					<strong>sportivista.com</strong> — sportsdataene (kamper, tider, kanaler) er
+					statiske filer som hostes på <strong>GitHub Pages</strong>. GitHub er vår
+					infrastrukturleverandør og fører sine egne tilgangslogger. Vi har ikke
+					tilgang til dem, og vi setter ingen sporings-informasjonskapsler.
+				</li>
+				<li>
+					<strong>Apple</strong> (<span class="pv-key">cdn.apple-cloudkit.com</span> og
+					iCloud-endepunktene) — innlogging og profilsynk.
+				</li>
+				<li>
+					<strong>ESPN</strong> (<span class="pv-key">site.api.espn.com</span>) — kun på
+					<em>nettsiden</em>: live stillinger hentes direkte fra nettleseren din, så ESPN
+					ser IP-adressen din. <strong>iPhone-appen gjør ingen slike kall.</strong>
+				</li>
+				<li>
+					<strong>Kringkastere og kilder</strong> — først når du selv trykker på en lenke
+					ut (NRK, TV 2 Play, Viaplay, og lignende). Da gjelder deres personvernregler.
+				</li>
+			</ul>
+			<p>
+				Klubbmerker og ikoner er <strong>innebygget i appen og nettsiden</strong>; det
+				gjøres aldri en bilde-forespørsel til en tredjepart for å tegne en rad.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Varsler</h2>
+			<p>
+				Varsler før start og resultatvarsler planlegges <strong>lokalt på enheten</strong>
+				ut fra det du følger. Appen registrerer seg ikke for push fra en server — det
+				finnes ingen push-server, og vi vet ikke om eller når du fikk et varsel.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Når du ber om ny dekning — dette blir offentlig</h2>
+			<p>
+				Både appen og nettsiden har en frivillig «be om dekning»-funksjon. Den
+				<strong>åpner et forslag i det offentlige kodelageret på GitHub som du selv
+				sender inn</strong>. Vi poster aldri noe på dine vegne.
+			</p>
+			<p>
+				Forslaget inneholder kun navnet på det du ønsker dekket og eventuelt hvilken
+				sport — aldri profilen din, følgelista di eller noe om enheten. Men vær klar
+				over at <strong>saken er offentlig og knyttes til GitHub-kontoen din</strong>,
+				med GitHubs egne personvernregler. Vil du ikke det, la være å sende den.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Informasjonskapsler</h2>
+			<p>
+				Vi setter ingen informasjonskapsler og bruker ingen analyseverktøy — derfor er
+				det heller ingen samtykkebanner her. Apples CloudKit kan sette sine egne for å
+				holde deg innlogget, og nettleserens <span class="pv-key">localStorage</span>
+				brukes til profilen og temavalget ditt, som beskrevet over.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Barn</h2>
+			<p>
+				Sportivista er ikke rettet mot barn, og vi samler ikke inn opplysninger for å
+				identifisere noen — heller ikke alder.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Rettighetene dine</h2>
+			<p>
+				Personvernforordningen (GDPR) gir deg rett til innsyn, retting, sletting og
+				dataportabilitet. Her er den praktiske konsekvensen: <strong>vi har ingenting å
+				gi deg innsyn i eller slette, fordi vi ikke har dataene.</strong> Du har dem selv,
+				og du kan gjøre alt selv:
+			</p>
+			<ul>
+				<li><strong>Se</strong> hva appen vet om deg: Deg → «Hva jeg vet om deg».</li>
+				<li><strong>Ta med deg</strong> profilen: Deg → «Del profil» gir deg hele profilen som en kode/QR.</li>
+				<li><strong>Slette</strong> alt i appen: Deg → «Nullstill».</li>
+				<li><strong>Slette</strong> iCloud-kopien: Innstillinger → Apple-ID → iCloud → administrer lagring → Sportivista.</li>
+				<li><strong>Slette</strong> nettleser-profilen: tøm nettstedsdata for sportivista.com.</li>
+			</ul>
+			<p>
+				Har du likevel et spørsmål eller en klage, ta kontakt (over). Du kan også klage
+				til <a href="https://www.datatilsynet.no" target="_blank" rel="noopener">Datatilsynet</a>.
+			</p>
+		</section>
+
+		<section class="pv-section">
+			<h2>Hvis dette endrer seg</h2>
+			<p>
+				«Ingen server» er et arkitekturvalg, ikke bare et løfte — og valget kan i
+				prinsippet endres senere (for eksempel hvis Sportivista en dag trenger en
+				egen tjeneste for å levere data raskt nok). Hvis det skjer, blir denne siden
+				oppdatert <em>før</em> endringen tas i bruk, og datoen øverst forteller deg
+				når. Historikken for hver eneste endring i denne teksten er offentlig i
+				kodelageret.
+			</p>
+			<p class="pv-note">
+				Denne erklæringen beskriver programvaren slik den faktisk er bygget i dag.
+				Den er skrevet for å være etterprøvbar mot koden, ikke for å love mer enn
+				den kan holde.
+			</p>
+		</section>
+
+		<p class="pv-note"><a class="back-link" href="./">← tilbake til oversikten</a></p>
+	</main>
+
+	<footer class="site-footer wrap">
+		<a class="back-link" href="./">← oversikten</a>
+	</footer>
+
+	<!-- Kun tema-toggelen. Ingen CloudKit, ingen gate, ingen datalasting: siden skal
+	     kunne leses av hvem som helst, også før innlogging. -->
+	<script src="js/theme.js"></script>
+</body>
+</html>

--- a/ios/Sportivista/PrivacyInfo.xcprivacy
+++ b/ios/Sportivista/PrivacyInfo.xcprivacy
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  PrivacyInfo.xcprivacy — Sportivista (app-targetet). WP-190.
+
+  Dette er den MASKINLESBARE tvillingen til docs/personvern.html, og den skal
+  stemme verdi for verdi med hva koden faktisk gjør. Grunnlaget, verifisert i
+  koden 22.07.2026:
+
+  · NSPrivacyTracking = false. Appen har ingen analyse-/annonse-SDK-er, ber aldri
+    om App Tracking Transparency, og kobler ingenting til data fra andre selskaper.
+  · NSPrivacyTrackingDomains = tomt. Eneste utgående nettverkskall i hele
+    app-targetet er Sync/SyncClient.swift → https://sportivista.com/data/ (statiske
+    JSON-filer på GitHub Pages) pluss CloudKit-rammeverket mot BRUKERENS EGEN
+    private database. Ingen av dem er sporingsdomener.
+  · NSPrivacyCollectedDataTypes = tomt. Ingen data samles inn TIL OSS: profilen
+    ligger på enheten + i brukerens egen private CloudKit-DB (CloudKitProfileSync
+    — «aldri vår server»), MetricKit-sammendragene ligger lokalt (Perf/MetricLog,
+    ingen nettverkskode), og assistenten kjører on-device (FoundationModels).
+    Innsendte dekningsønsker (Profile/CoverageRequest) er et forhåndsutfylt
+    GitHub-issue brukeren sender SELV — ikke innsamling gjort av appen.
+  · NSPrivacyAccessedAPITypes: kun UserDefaults. Grep over ios/Sportivista viser
+    INGEN bruk av fil-tidsstempler (attributesOfItem/contentModificationDate),
+    systemoppetid, diskplass eller aktive tastaturer — de fire andre required-
+    reason-kategoriene er derfor ikke deklarert (å deklarere ubrukte grunner ville
+    vært like unøyaktig som å utelate brukte).
+
+  Grunn-koden CA92.1 = «tilgang til user defaults for å lese/skrive informasjon
+  som kun er tilgjengelig for appen selv». Det er nøyaktig bruken her: appens egne
+  preferanser via UserDefaults.standard (onboarding-flagget i OnboardingGate,
+  temavalget i ThemeOverride, varsel-innstillingene i NotificationLeadPreference /
+  ResultAlertPreference). Ingen delt app-group-suite, ingenting som leses av eller
+  om andre apper.
+-->
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/Sportivista/Profile/DegView.swift
+++ b/ios/Sportivista/Profile/DegView.swift
@@ -39,6 +39,12 @@ struct DegView: View {
     /// The published app-version truth for the «BYGG … / NYERE FINNES» foot.
     var publishedAppVersion: AppVersion? = nil
 
+    /// WP-190 — the ONE privacy policy, published at sportivista.com/personvern.html
+    /// (deliberately OUTSIDE the site's sign-in gate so it reads without an account).
+    /// Force-unwrapped: a literal, constant URL — a nil here would be a typo caught
+    /// by `PrivacyManifestTests.test_privacyPolicyURL_pointsAtThePublishedPage`.
+    static let privacyURL = URL(string: "https://sportivista.com/personvern.html")!
+
     /// The SAME @AppStorage key ContentView used for the header glyph — the
     /// theme override now lives here (DESIGN § Tema: "en enhets-
     /// preferanse under Deg › Utseende, ikke lenger en header-glyf").
@@ -172,6 +178,17 @@ struct DegView: View {
                 rowLabel("seal", "Merker og kilder", chevron: true)
             }
             .accessibilityIdentifier("deg.marks.link")
+
+            // WP-190: personvernerklæringen (docs/personvern.html) — ÉN rolig rad,
+            // aldri en modal ved oppstart. Den bor på nett fordi den må være
+            // offentlig lesbar (App Store krever en åpen URL, og den som VURDERER
+            // appen skal kunne lese den før nedlasting) — og fordi den da har én
+            // versjon, ikke to som kan drifte fra hverandre. `Link` åpner Safari;
+            // siden står utenfor innloggings-gaten, så den laster uten konto.
+            Link(destination: Self.privacyURL) {
+                rowLabel("hand.raised", "Personvern", chevron: true)
+            }
+            .accessibilityIdentifier("deg.privacy")
 
             NavigationLink {
                 ResetView(onReset: onReset, syncEnabled: syncEnabled)

--- a/ios/SportivistaTests/PrivacyManifestTests.swift
+++ b/ios/SportivistaTests/PrivacyManifestTests.swift
@@ -1,0 +1,114 @@
+//
+//  PrivacyManifestTests.swift
+//  SportivistaTests
+//
+//  WP-190 — the two artefacts that make G1 reachable at all (an app cannot get
+//  external TestFlight testers without them) are exactly the kind that rot
+//  silently: nothing at runtime reads `PrivacyInfo.xcprivacy`, and nothing at
+//  runtime notices if the privacy-policy link 404s. These tests are the guard.
+//
+//  Network-free by construction: the manifests are read from the REPO (a path
+//  relative to this file via `#filePath`, the same trick FeedVectorTests uses to
+//  reach the shared fixtures), and the policy URL is only checked for SHAPE —
+//  never fetched. A test that hit the network would be a flake, not a gate.
+//
+
+import XCTest
+
+final class PrivacyManifestTests: XCTestCase {
+
+    /// ios/ — the directory holding project.yml, derived from this file's path.
+    private var iosDir: URL {
+        URL(fileURLWithPath: #filePath)            // …/ios/SportivistaTests/PrivacyManifestTests.swift
+            .deletingLastPathComponent()           // …/ios/SportivistaTests
+            .deletingLastPathComponent()           // …/ios
+    }
+
+    private func manifest(at relativePath: String) throws -> [String: Any] {
+        let url = iosDir.appendingPathComponent(relativePath)
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        return try XCTUnwrap(plist as? [String: Any], "\(relativePath) is not a plist dictionary")
+    }
+
+    /// The reason codes declared for one required-reason API category.
+    private func reasons(_ manifest: [String: Any], category: String) -> [String]? {
+        let apis = manifest["NSPrivacyAccessedAPITypes"] as? [[String: Any]] ?? []
+        guard let entry = apis.first(where: { $0["NSPrivacyAccessedAPIType"] as? String == category })
+        else { return nil }
+        return entry["NSPrivacyAccessedAPITypeReasons"] as? [String]
+    }
+
+    // MARK: - App manifest
+
+    func test_appManifest_declaresNoTrackingAndNoCollection() throws {
+        let m = try manifest(at: "Sportivista/PrivacyInfo.xcprivacy")
+        XCTAssertEqual(m["NSPrivacyTracking"] as? Bool, false,
+                       "Sportivista har ingen sporing — flagget skal stå eksplisitt false.")
+        XCTAssertEqual((m["NSPrivacyTrackingDomains"] as? [String])?.count, 0)
+        // The whole product position: nothing is collected TO US. If a future
+        // change actually collects something, this test SHOULD fail loudly —
+        // and docs/personvern.html has to change in the same PR.
+        XCTAssertEqual((m["NSPrivacyCollectedDataTypes"] as? [[String: Any]])?.count, 0)
+    }
+
+    func test_appManifest_declaresUserDefaultsWithTheAppOwnDataReason() throws {
+        let m = try manifest(at: "Sportivista/PrivacyInfo.xcprivacy")
+        // CA92.1 = "user defaults, information accessible only to the app itself".
+        // That is exactly UserDefaults.standard for OnboardingGate/ThemeOverride/
+        // the notification preferences — no shared app-group suite.
+        XCTAssertEqual(reasons(m, category: "NSPrivacyAccessedAPICategoryUserDefaults"), ["CA92.1"])
+    }
+
+    func test_appManifest_declaresNoUnusedRequiredReasonCategories() throws {
+        let m = try manifest(at: "Sportivista/PrivacyInfo.xcprivacy")
+        // Over-declaring is as inaccurate as under-declaring. The app uses no
+        // file-timestamp / boot-time / disk-space / active-keyboard API (verified
+        // by grep over ios/Sportivista, WP-190).
+        for unused in ["NSPrivacyAccessedAPICategoryFileTimestamp",
+                       "NSPrivacyAccessedAPICategorySystemBootTime",
+                       "NSPrivacyAccessedAPICategoryDiskSpace",
+                       "NSPrivacyAccessedAPICategoryActiveKeyboards"] {
+            XCTAssertNil(reasons(m, category: unused),
+                         "\(unused) er deklarert, men ingen kode bruker den.")
+        }
+    }
+
+    // MARK: - Widget manifest
+
+    func test_widgetManifest_isTheStricterCase() throws {
+        let m = try manifest(at: "SportivistaWidget/PrivacyInfo.xcprivacy")
+        XCTAssertEqual(m["NSPrivacyTracking"] as? Bool, false)
+        XCTAssertEqual((m["NSPrivacyTrackingDomains"] as? [String])?.count, 0)
+        XCTAssertEqual((m["NSPrivacyCollectedDataTypes"] as? [[String: Any]])?.count, 0)
+        // The widget target compiles no UserDefaults/@AppStorage code at all
+        // (project.yml keeps its source list to the read half of Sync + Feed).
+        XCTAssertEqual((m["NSPrivacyAccessedAPITypes"] as? [[String: Any]])?.count, 0)
+    }
+
+    // MARK: - The human-readable twin
+
+    func test_privacyPolicyURL_pointsAtThePublishedPage() {
+        // Shape only — never fetched. The page itself lives at
+        // docs/personvern.html and is deliberately outside the sign-in gate.
+        XCTAssertEqual(DegView.privacyURL.scheme, "https")
+        XCTAssertEqual(DegView.privacyURL.host, "sportivista.com")
+        XCTAssertEqual(DegView.privacyURL.path, "/personvern.html")
+    }
+
+    func test_privacyPolicyPageExistsAndIsUngated() throws {
+        let page = iosDir
+            .deletingLastPathComponent()                 // repo root
+            .appendingPathComponent("docs/personvern.html")
+        let html = try String(contentsOf: page, encoding: .utf8)
+        // Must NOT be behind the whole-site sign-in gate: App Store review and a
+        // prospective user both have to read it without an account.
+        // Match the ACTUAL wiring, not the prose: the file's own header comment
+        // names both mechanisms in order to explain why it opts out of them.
+        XCTAssertFalse(html.contains("src=\"js/gate-boot.js\""),
+                       "Personvernsiden må stå utenfor innloggings-gaten.")
+        XCTAssertFalse(html.contains("<body class=\"gated\""),
+                       "Personvernsiden må stå utenfor innloggings-gaten.")
+        XCTAssertTrue(html.contains("<title>Sportivista · Personvern</title>"))
+    }
+}

--- a/ios/SportivistaWidget/PrivacyInfo.xcprivacy
+++ b/ios/SportivistaWidget/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  PrivacyInfo.xcprivacy — widget-utvidelsen. WP-190.
+
+  Apple krever ett manifest per bundle, og widgeten er sin egen bundle. Den er
+  et STRENGERE tilfelle enn appen, ikke et likt: targetets kildeliste i
+  ios/project.yml er bevisst kuttet til lesesiden (Models, Feed, CacheStore,
+  SyncState, DataStore, AppVersion, WidgetTimelineBuilder, WidgetResultSnapshot)
+  — SyncClient.swift er IKKE med, så widgeten har ingen nettverksdyktig kode i
+  det hele tatt.
+
+  Verifisert i koden 22.07.2026: ingen av widget-targetets kilder rører
+  UserDefaults/@AppStorage, fil-tidsstempler, systemoppetid, diskplass eller
+  aktive tastaturer. NSPrivacyAccessedAPITypes står derfor TOMT — ikke fordi det
+  ikke er sjekket, men fordi det er sjekket. Legger noen senere til en
+  UserDefaults-avhengighet her (f.eks. en delt app-group-preferanse), MÅ
+  NSPrivacyAccessedAPICategoryUserDefaults + CA92.1 inn, slik app-manifestet har.
+-->
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -53,6 +53,12 @@ targets:
     platform: iOS
     deploymentTarget: "26.0"
     sources:
+      # NB (WP-190): Sportivista/PrivacyInfo.xcprivacy — Apples privacy manifest —
+      # ligger i denne mappa og plukkes derfor opp av `path: Sportivista` og havner
+      # automatisk i Copy-Resources (verifisert i generert pbxproj). Den skal ALDRI
+      # ekskluderes: App Store-innsending krever den i bundle-roten, og
+      # docs/personvern.html er dens menneskelesbare tvilling. Widget-targetet har
+      # sin egen (SportivistaWidget/PrivacyInfo.xcprivacy) — ett manifest per bundle.
       - path: Sportivista
       # WP-69: the versioned eval corpus lives with the tests (one source of
       # truth — the CI XCTest loads it from the test bundle), but the DEBUG
@@ -150,6 +156,9 @@ targets:
     platform: iOS
     deploymentTarget: "26.0"
     sources:
+      # Inneholder widgetens EGET privacy manifest (SportivistaWidget/
+      # PrivacyInfo.xcprivacy, WP-190) — én per bundle; plukkes opp som ressurs
+      # av denne mappe-oppføringen, akkurat som app-targetets.
       - path: SportivistaWidget
       - path: Sportivista/DesignTokens.swift
       # WP-14: the widget's own timeline logic (WidgetTimelineBuilder.swift,


### PR DESCRIPTION
## WP-190 · G1 gjort målbar (FASE 0M, bølge 1)

Neste port i planen (G1) kunne ikke måles: null eksterne testere, ingen ærlig målemetode, og forutsetningene for i det hele tatt å FÅ testere (personvernerklæring + privacy manifest) manglet. Denne PR-en leverer forutsetningene og omdefinerer porten til noe etterprøvbart — **uten** å legge til telemetri, analytics eller ett eneste nytt nettverkskall (det er «siste utvei» i BRUKERDATA-seksjonen, et bevisst posisjonsvalg).

### Levert
1. **`docs/personvern.html`** — norsk tillitsdokument, rolig og lesbart (DESIGN.md-tokens), bevisst **utenfor** innloggings-gaten (må være offentlig lesbar for App Store-gjennomgangen og for den som vurderer appen). Lenket fra web-foten (`index.html` + `activity.html`) og fra **Deg › Personvern** i appen.
2. **`PrivacyInfo.xcprivacy`** for app + widget (begge targets i `project.yml`, havner i sin bundle-rot — verifisert i det bygde `.app`).
3. **`## 🚪 GATE G1`** omdefinert i PLAN.md til et konkret ASC + testerdagbok-kriterium, med ærlig liste over hva det IKKE måler + en nummerert eier-sjekkliste.
4. **`PrivacyManifestTests.swift`** — gate mot at manifestene eller personvern-lenka rotner stille.

### Påstander jeg verifiserte mot koden før jeg skrev dem
| Påstand i erklæringen | Verifisert mot |
|---|---|
| Profil i brukerens **egen private CloudKit**, plaintext (ikke E2E) | `CloudKitProfileSync.swift`-headeren + `ProfileSnapshot`/`writeSnapshot` |
| Web-profil i `localStorage` (`ss-profile`/`ss-device-id`/`ss-theme`/…) | `docs/js/profile-sync.js`, `chrome.js`, `theme.js` |
| **ESPN-polling kun på web**, ikke i appen | `docs/js/live.js` (`site.api.espn.com`); ingen `URLSession` utenfor `Sync/SyncClient.swift` i appen |
| Appens eneste utgående kall = `https://sportivista.com/data/` | `SyncClient.defaultBaseURL` |
| On-device assistent + MetricKit-sammendrag som aldri sendes | `FoundationModelsInterestAssistant`, `Perf/MetricLog.swift` (ingen nettverkskode) |
| Coverage-request er **offentlig** GitHub-issue brukeren sender selv | `Profile/CoverageRequest.swift` (WP-165) |
| Klubbmerker innebygget, aldri en bilde-request | `project.yml` `../docs/logos type: folder` |

**Overrasket meg:** `localStorage` holder mer enn profilen (`ss-install-hint`, `ss-app-promo`) — tatt med i erklæringen så lista er komplett, ikke pyntet. Og web-siden laster CloudKit-JS fra Apples CDN (`cdn.apple-cloudkit.com`) — nevnt eksplisitt under «hva enheten kontakter» i stedet for det enklere (men usanne) «vi laster ingenting eksternt».

### Required-reason-koder
- **App:** kun `NSPrivacyAccessedAPICategoryUserDefaults` → **`CA92.1`** («user defaults, kun tilgjengelig for appen selv»). Det er nøyaktig bruken: `OnboardingGate`, `ThemeOverride`, `NotificationLeadPreference`/`ResultAlertPreference` via `UserDefaults.standard` — ingen delt app-group-suite.
- **Bevisst utelatt:** FileTimestamp / SystemBootTime / DiskSpace / ActiveKeyboards. Grep over `ios/Sportivista` viser ingen bruk — å deklarere dem ville vært like unøyaktig som å utelate en brukt kode. En test håndhever fraværet.
- **Widget:** tomt `NSPrivacyAccessedAPITypes` — targetets kildeliste i `project.yml` er kuttet til lesesiden (ingen UserDefaults/@AppStorage, ingen `SyncClient`).

### App Store «privacy nutrition labels» — utkast (eier fyller i ASC)
- **Data Used to Track You:** ingen.
- **Data Linked to You:** ingen.
- **Data Not Linked to You:** ingen.
- Nettoresultat i ASC: **Data Not Collected**. (Profilen i brukerens egen iCloud + on-device MetricKit teller ikke som «collected» — den forlater aldri brukerens egen konto/enhet til oss. Ref. Apples definisjon: innsamling = overføring **av appen** vekk fra enheten til utvikleren/tredjepart, som ikke skjer her.)
- **Personvern-URL:** `https://sportivista.com/personvern.html`.

### Forslag til G1-instrument (og hva det IKKE måler)
Den gamle porten («D7-retention etter ~4 uker») er ikke målbar her: D7-kohorter krever bruker-id + telemetri-endepunkt (= B.3, siste utvei), ASC gir volum (installs/sessions/crashes) ikke kohorter, og N er encifret så prosenter er støy. **Ny port (BINDENDE, står i PLAN.md):** ved slutten av uke 4 med ≥5 testere — (a) ≥3 testere med sessions ≥5 av 7 siste dager, (b) ≥3/5 svarer 4–5 på «hvor lei deg om den forsvant?», (c) 0 uløste krasj-klynger. Instrument = ASC-metrikker + en fastspikret 4-spørsmåls testerdagbok. **Måler ikke:** ekte D1/D7/D30, hvilke skjermer som brukes, onboarding-frafall, om varsler åpnes, eller om frafall skyldtes appen vs. død sesong. Selvrapportert med høflighets-skjevhet → satt som et **gulv man passerer/ikke passerer**, ikke en presisjonsmåling.

### Eier-sjekkliste (gjenstår — står også i PLAN.md § GATE G1)
1. Les gjennom `docs/personvern.html`, bekreft/juster kontakt-e-post.
2. ASC → App Privacy: sett personvern-URL + fyll nutrition labels som Data Not Collected.
3. Verifiser at neste TestFlight-bygg bærer manifestene (release-lanen).
4. Opprett ekstern testergruppe + send til **Beta App Review** (agentens ikke-mål — eier sender).
5. Verv 5–10 testere som følger norsk sport.
6. Start dagboken, still de fire spørsmålene uke 1/2/4, noter ordrett.
7. Les av ASC ukentlig, skriv tallet inn samme dag.
8. Ved uke 4: avgjør mot (a)/(b)/(c), skriv beslutningen inn i PLAN.md.

### ⚠️ Ikke juridisk gjennomgått
Jeg er ikke advokat, og erklæringen er ikke juridisk kvalitetssikret. **Den bør leses av advokat sammen med WP-191-punktene** (juridisk enhet, varemerke, og særlig **klubbemblem**-spørsmålet) — én samlet runde i stedet for tre.

### Verifisering
- `npx vitest run --maxWorkers=1` → **1100/1100 grønn** (68 filer).
- Full iOS unit-suite (`Sportivista`-scheme) → **792 kjørt, 0 feil** (inkl. nye `PrivacyManifestTests`, 13/13 gylne feed-vektorer bit-like).
- Alle fire schemes bygger: `SportivistaWidgetExtension` ✅, `SportivistaUITests` ✅, `SportivistaDeviceDev` (generic/iOS) ✅.
- `PrivacyInfo.xcprivacy` bekreftet i bygd `Sportivista.app/` **og** `PlugIns/SportivistaWidget.appex/`.
- Skjermbilder av personvernsiden i **dark + light** (375px) — sett og verifisert: rolig, DESIGN.md-tokens, amber-kolon som eneste aksent, ingen layout-overflyt.

### Naboer
`ios/project.yml` deles med WP-170 — diffen er holdt til egne, additive oppføringer (to source-kommentarer). Ingen av WP-170/WP-162s filer er rørt. PLAN.md-statusrad = union; i tillegg redigert `## 🚪 GATE G1` (rører ingen andre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
