### PR TITLE
fix: gjenopprett fotball-fetcheren, fang frosne kilder, gjør produktet synlig for visual-QA

### DIFF
--- a/.claude/skills/norwegian-rights/SKILL.md
+++ b/.claude/skills/norwegian-rights/SKILL.md
@@ -38,7 +38,8 @@ known URL per broadcaster and won't clobber it with the generic landing.
 ## Football
 - Premier League → **TV 2 Play / TV 2 Sport Premium** [solid]
 - La Liga → **TV 2 Play** [solid] (TV 2 renewed the Norwegian rights through summer 2030 — NTB press release kommunikasjon.ntb.no/pressemelding/18978442; the Disney+/ESPN shift is DK/SE/FI/IS only, not Norway; verified 2026-07-18)
-- Champions League / Europa League → **TV 2 Play** [solid]
+- Champions League → **TV 2 Play** [solid]
+- Europa League + Conference League → **Viaplay** [solid] (UEFA-klubbrettighetene i Norge t.o.m. 2030/31: kun CL er TV 2s — presse.viaplaygroup.no + tvkampen.com; verifisert 2026-07-27. Viaplay/TV 2-fellesavtalen gjør enkeltkamper også tilgjengelige på TV 2 Play, og norske klubbers tidlige kvalikkamper kan ha egne fri-sublisenser, f.eks. VG TV. Speiler `scripts/lib/norwegian-rights.js`, som ble rettet i #417)
 - OBOS-ligaen + Eliteserien → **TV 2 Play** [solid]
 - FIFA World Cup 2026 → **NRK + TV 2** (shared, per-match split) [verify per match]
 - Cross-check every football entry against `docs/data/tv-listings.json` when present.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Two kinds of scheduled work:
 - `scripts/fetch-tvkampen.js` → `tv-listings.json` — Norwegian TV/streaming **ground truth** for football (tvkampen.com, today+2 days; lib: `scripts/lib/tvkampen-scraper.js`)
 - `scripts/build-events.js` → `events.json` — **preserves `source: "ai-research"` events** from the previous build (dedupe key `sport|title|time`), publishes `tracked.json` to `docs/data/`
 - `scripts/validate-events.js` — schema + AI-research contract (high confidence ⇒ 2+ evidence URLs; warns on near-term events missing streaming)
-- `scripts/detect-coverage-gaps.js` → `coverage-gaps.json` — recall watch (mechanical, recall-biased; agents triage + cross-check the web). Three signals: **entity gaps** (tracked entity in RSS headlines with no upcoming event, or one only far out while the news says imminent — "i dag"/"denne helgen"), **sport gaps** (a followed sport is imminent in the news but absent from the board soon — the ESPN-blind-spot catcher, e.g. F1 weekends ESPN mis-dates to Friday), and **source anomalies** (a fetcher's own file is missing/empty/dropping events *and the board lacks that sport* — coverage-first, so AI-research-filled sports like chess/cycling don't false-flag)
+- `scripts/detect-coverage-gaps.js` → `coverage-gaps.json` — recall watch (mechanical, recall-biased; agents triage + cross-check the web). Three signals: **entity gaps** (tracked entity in RSS headlines with no upcoming event, or one only far out while the news says imminent — "i dag"/"denne helgen"), **sport gaps** (a followed sport is imminent in the news but absent from the board soon — the ESPN-blind-spot catcher, e.g. F1 weekends ESPN mis-dates to Friday), and **source anomalies** (a fetcher's own file is missing/empty/dropping events *and the board lacks that sport* — coverage-first, so AI-research-filled sports like chess/cycling don't false-flag). One anomaly deliberately ESCAPES the coverage-first gate: **`stale-retained`** (high) — `retainLastGood` re-serves the last good file when a fetch comes back empty and stamps `_retained.consecutiveRetains`, and nothing used to read that stamp, so a dead fetcher stayed invisible as long as something else covered the sport (football.json sat frozen on the 19 July World Cup final for 137 runs while research hand-filled Eliteserien). A fetcher that has stopped producing is broken whether or not the board hides it
 - `scripts/aggregate-calibration.js` → `calibration.json` — mechanical per-source trust stats from `calibration-ledger.jsonl` (180-day window, reliability withheld under 5 checks)
 - `scripts/build-ics.js` — calendar export
 - Commits `docs/data/` directly to main, then — only when data changed — **auto-publishes** by calling `preview-deploy.yml` via `workflow_call`. (A `GITHUB_TOKEN` push can't *trigger* a workflow, so the pipeline invokes the deploy directly instead of relying on `preview-deploy`'s `push` trigger; no PAT needed. `preview-deploy` keeps `concurrency: pages-deploy`, which `workflow_call` honors, so a called deploy still serialises with merge-triggered ones — never two Pages deploys at once.)
@@ -297,7 +297,7 @@ matrisen per flate). Les den relevante FØR du planlegger/bygger.
 - `npm run build` — fetch data + build events + calendar
 - `npm run build:events` / `npm run validate:data` / `npm run build:calendar`
 - `npm run fetch:results`
-- `npm test` — vitest, 44 focused files (648 tests), a few seconds
+- `npm test` — vitest, 74 focused files (1218 tests), a few seconds
 - `npm run screenshot` — Playwright dashboard screenshot (`node scripts/screenshot.js out.png --width=1280 --full-page`)
 
 ## Conventions
@@ -310,9 +310,9 @@ matrisen per flate). Les den relevante FØR du planlegger/bygger.
 
 ## Testing
 
-`tests/` — 44 files / 648 tests, all fast and network-free:
+`tests/` — 74 files / 1218 tests, all fast and network-free:
 - Pipeline: `build-events`, `build-events-schema`, `build-events-degrade` (WP-94 degrade-gracefully gate), `events-schema`, `validate-events`, `build-ics`, `build-entities`, `build-manifest`, `news` (news.json pointer build), `detect-coverage-gaps`, `aggregate-calibration`, `integration-pipeline` (spawn scripts against temp `SPORTSYNC_DATA_DIR`/`SPORTSYNC_CONFIG_DIR`)
-- Fetchers: `fetch-results`, `fetch-results-golden` (byte-identical output freeze), `fetch-rss`, `fetch-standings`, `f1-fetcher`, `esports`, `golf`
+- Fetchers: `fetch-results`, `fetch-results-golden` (byte-identical output freeze), `fetch-rss`, `fetch-standings`, `f1-fetcher`, `esports`, `golf`, `football-fetcher` (coverage is the CATALOG's call, not the owner's follow list — plus the ESPN→Norwegian club naming)
 - Libs: `helpers`, `event-normalizer`, `response-validator`, `llm-client` (mocked fetch), `tvkampen-scraper`, `pgatour-scraper`, `norwegian-rights`, `usage`, `usage-gate` (freshness-aware skip logic), `escalate-research` (scout/coverage-critic dispatch), `app-version` (iOS «har jeg siste?» half), `asc-api` (App Store Connect release-lane client), `readme-status`, `merge-gate`, `apply-follow-request`
 - Client: `dashboard-cards` — loaded via `tests/helpers/load-client.js` (vm sandbox, no jsdom); `feed-vectors` (golden personalisation vectors, see `tests/fixtures/feed-vectors/DIVERGENCES.md`)
 - Coherence: `agent-prompts` (prompt contracts match client renderers; scans every `scripts/agents/*.md` for skill references), `workflows` (YAML references existing files), `interests-schema`, `tracked-schema`, `catalog-schema` (the AI-managed coverage compass), `design-tokens` (`design/tokens.json` locks shipped CSS/Swift reality), `ios-dynamic-type-gate` (HIG gate: no isolated `.system(size:)` in `ios/Sportivista/`), `hooks` (the safety hooks)

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,485 @@
+# COMMERCIAL.md — veien til et kommersielt Sportivista
+
+Strategi- og sekvenseringsdokumentet for kommersialisering. `PLAN.md` er fortsatt
+arbeidspakke-backloggen; dette dokumentet er *hvorfor og i hvilken rekkefølge*.
+WP-tabellene nederst er skrevet i PLAN.md-format og kan limes inn der.
+
+Utarbeidet 29.07.2026 fra åtte uavhengige analyser (marked, enhetsøkonomi, produkt,
+juss, visjon, vekst, avrisikering, lansering). Påstander merket **[verifisert]** er
+sjekket direkte i koden; resten er analyse med kilder, og de juridiske punktene er
+risikokartlegging som må bekreftes av norsk advokat.
+
+---
+
+## 1 · Visjonen
+
+**Hit-tesen:** Sportivista er appen du drar frem når noen i rommet spør *«når begynner
+det — og hvor ser vi det?»*, og du svarer på to sekunder for hvilken som helst sport,
+med kanal du kan stole på.
+
+Det avgjørende er at øyeblikket er **sosialt**. Spørsmålet stilles høyt, i et rom, og
+demonstrasjonen *er* anbefalingen — du viser skjermen idet du svarer. Det er derfor
+dette kan spres uten budsjett.
+
+**Kategorien:** ikke «sportsapp» — der vinner FotMob på dybde og Apple Sports på
+distribusjon. Sportivista er **den personlige sende-planen**: arvtakeren til TV-guiden,
+som døde med lineær-TV uten at noen bygde erstatningen for sport spredt over syv
+tjenester. Kategorifamilien er kalender/agenda, ikke match-center. Ro-kontrakten i
+DESIGN.md er ikke en begrensning på visjonen — den er kategoriens definisjon. En agenda
+som maser er en dårlig agenda.
+
+**Du konkurrerer på LAGET, ikke på sporten** (eier-beslutning 29.07). Dette er den
+presise formen på posisjonen, og den avgjør en strid som ellers går i sirkel:
+
+> **FotMob eier kampen. Sportivista eier uka — for alle sporter, inkludert fotball og F1.**
+
+En adversarisk analyserunde 29.07 anbefalte det motsatte: å droppe fotball og F1 fra
+verdiløftet og bli «spesialist på langhalen», med utlenking til FotMob for de store
+idrettene. **Det er forkastet**, og begrunnelsen er verdt å skrive ned, fordi feilen er
+lett å gjøre igjen: analysen blandet sammen *hva vi er differensiert på* med *hva vi må
+inneholde*.
+
+- Differensieringen er langhalen. Verdien er **unionen**. I det øyeblikket brukeren må
+  åpne FotMob for Brann-kampen, har agendaen sluttet å være deres agenda — og da er hele
+  premisset borte.
+- Halen er grunnen til at noen **kommer** (ingen andre sier når sjakken går). De store
+  idrettene er grunnen til at de **blir**, fordi det er de som gir appen noe å si nesten
+  hver dag. Å kutte fotball er å bytte bort det daglige for det distinkte.
+- Det sparer heller ingenting: fotball er den billigste sporten å dekke godt — flest
+  kilder, mest struktur. `catalog.json` har alt tatt avgjørelsen (`football` og `f1` er
+  tier1, dekket wholesale).
+
+**Langhalen er derfor beviset, ikke omfanget.** Hvem som helst kan liste
+Premier League-runden. At tavla *også* vet når sjakken går, når Uno-X sykler og når
+skiskytingen sendes, er det som gjør fullstendighets-løftet troverdig. Halen beviser
+påstanden; de store idrettene gjør at påstanden betyr noe daglig.
+
+Det som overlever av kritikken, og som står: **vi hevder aldri å slå FotMob på
+fotballdybde.** Oppstilling, xG, direktestatistikk, spillerbørs — den kampen tas ikke, og
+match-center bygges ikke. Det er en påstand om lag, ikke om sport.
+
+**Vollgraven:** funksjoner kan kopieres, forretningsstrukturen kan ikke. FotMob lever av
+annonser og engasjement — de kan ikke bygge ro uten å rive egen inntekt. En redaksjon
+som dekker langhalen (sjakk, sykkel, vintersport, CS2) koster normalt årsverk; her
+koster den nær null. Parret med null datainnsamling er posisjonen **en redaksjon som
+aldri sover, for en bruker vi aldri overvåker**. Det paret er strukturelt ukopierbart
+for en annonsefinansiert aktør.
+
+**Løftet har en pris:** «Hele sporten» betyr at hvert dekningshull nå er merkeskade.
+Coverage-loopene er merkevarearbeid, ikke bare QA.
+
+---
+
+## 2 · Dommen — hva dette kan og ikke kan bli
+
+Vær ærlig om taket før pengene brukes.
+
+- **Markedet:** realistisk 500–3 000 betalende i Norge. Det er **ikke et selskap**.
+- **Trusselen:** FotMob (norsk, gratis, 20 mill. brukere) har allerede norsk TV-guide
+  med kanal per kamp. Apple Sports er gratis i 170+ land. «Hvor ser jeg det» er en
+  funksjon hos de største, ikke en vollgrav i seg selv.
+- **Apple-muren finnes ikke — korrigert 29.07.** En tidligere versjon av dette dokumentet
+  antok at Apple *strukturelt ikke kan* levere norske rettighetsdata. Det er feil:
+  **Gracenote (Nielsen) selger ferdigpakket «where to watch» for 50+ land**, normalisert,
+  med dyplenker — Apple trenger ikke forhandle med NRK, TV 2 og Viaplay hver for seg. Og
+  Apple Sports dekker allerede ecuadoriansk Serie A og 2. Bundesliga, så terskelen er
+  ikke folketall. Riktig formulering er mye svakere: **Apple har ikke *prioritert*
+  småmarkeds-europeisk sport** — hver vertikal de har lagt til er en amerikansk
+  kommersiell eiendom. Det er en prioritering, ikke en mur. **Varselsignalet er ikke at
+  de tar Eliteserien, men at de legger til sin første ikke-amerikanske vertikal.**
+- **Det som likevel står:** tverrsnittet. Ingen andre gir deg skiskyting *og* sjakk *og*
+  sykkel *og* fotballen i én rolig agenda med verifisert norsk kanal. 68 av 72 events
+  kommer fra AI-research — dekningen er ekte.
+- **Men løftet er ikke innfridd ennå. [verifisert 29.07]** 46 av 47 strømme-oppføringer
+  på tavla peker på en **generisk landingsside** (26 × `play.tv2.no/sport`,
+  7 × `viaplay.no/no-no/sport`); bare 7 er dyplenker. Produktet sier «TV 2 Play» og sender
+  deg til TV 2 Plays sportsforside. Det er et *rettighetskart*, ikke et svar på «hvor ser
+  jeg det» — og et rettighetskart er nøyaktig det enhver språkmodell produserer gratis.
+  Dette er produktgapet, uavhengig av hvilke sporter som dekkes, og det er spor E som
+  lukker det.
+
+**Konklusjon: dette er en solid biinntekt og et uvanlig godt produkt, ikke en exit.**
+Blir det en hit, er neste steg Norden — Sverige og Danmark har samme rettighetskaos, og
+arkitekturen gjør ekspansjon nesten gratis. Det må sies høyt før pengene brukes, ikke
+oppdages etterpå.
+
+---
+
+## 3 · Regnestykket
+
+Modellen er **freemium på iOS**: gratis katalogtavle (wedgen demonstreres), betalt
+personalisering. Grensen faller sammen med arkitekturens egen søm — server = dekning,
+enhet = presisjon.
+
+**Pris: 39 kr/mnd · 349 kr/år · 1 mnd prøve.** Referansen er FotMob-tieren, ikke
+strømmetjenestene. Netto etter MVA og Apples 15 %: **26,50 kr/mnd**.
+
+**Løpende kostnad etter at alt er gjort lovlig (anslag):**
+
+| Post | Kost/mnd |
+|---|---|
+| Anthropic API (batch −50 %, caching, tiering; rå målt kost er ~1 050 $/mnd, se PLAN.md:2603) | 2 800–4 700 kr |
+| Datakilder (API-Football $19 + TheSportsDB $9 + Jolpica gratis) | ~350 kr |
+| Cloudflare Workers + R2 | ~100 kr |
+| EPG-avtale (NRK gratis; øvrige kanaler ukjent) | 0–3 000 kr |
+| **Sum** | **~4 500–6 500 kr** |
+
+**Break-even: ~170–250 betalende.** Mot et tak på 500–3 000. Marginen er reell, men
+tynn — og hele regnestykket forutsetter at API-kosten faktisk lar seg ingeniøre ned fra
+den målte råkosten. Det er den viktigste økonomiske antakelsen i dokumentet.
+
+Engangskost for å bli lovlig: **~25–80 000 kr** (ENK 2 181 kr eller AS 36 825 kr,
+Apple $99, advokat 15–40 000 kr).
+
+**Billigste lovlige minimum for første krone:** ENK + Apple org + `logoPolicy:
+free-only` + ESPN ut + tvkampen av + Cloudflare + API-nøkkel for agentene + malbaserte
+vilkår med tydelig datafeil-forbehold, med full advokatpakke utsatt til man har
+betalende brukere. **~5 000 kr engangs + ~4 500 kr/mnd.**
+
+---
+
+## 4 · Fem spor
+
+Sporene går parallelt. Spor B er på kritisk sti mot lansering; **spor E er det som
+avgjør om produktet i det hele tatt har et fundament å stå på.**
+
+### Spor A · Produkt (WP-200–207)
+
+Det som må være sant før en fremmed kan bruke dette.
+
+Den viktigste enkeltoppgaven er **WP-200**. **[verifisert]** Profilen former ikke tavla
+i dag, og det er *to* lekkasjer, ikke én:
+
+- `docs/js/profile-sync.js:276` returnerer `followBroadly: null` →
+  `docs/js/lens.js:149` faller tilbake til default-lista med ni sporter.
+  iOS: `EffectiveInterests.swift:73` sender `base.followBroadly` urørt videre.
+- `docs/js/lens.js:158` og `ios/Sportivista/Feed/FeedCompiler.swift:112` slipper
+  **alt** norsk / favoritt / `importance ≥ 4` gjennom uansett profil.
+
+Følgen: en som velger kun «Formel 1» i onboardingen får golf, sykkel og skiskyting.
+Onboardingen lover «velg det du bryr deg om»; tavla svarer med eierens sportsunivers.
+Hit-tesen forutsetter at dette er fikset — den er ikke sann før det.
+
+Verste kombinasjon: velger man kun «Vintersport» (`StarterPacks.swift:147–148`) former
+valget ingenting **og** det valgte er tomt til november.
+
+### Spor B · Juss og infrastruktur (WP-210–220) — kritisk sti
+
+Nullinfrastruktur er i dag null *egen* infrastruktur. Den lånte er lånt på
+forbrukervilkår som ikke tillater kommersiell drift, og må kjøpes fri før første krone:
+
+- **ESPN** — Disneys vilkår forbyr automatisert henting og kommersiell bruk. Apples
+  guideline 5.2.2 kan kreve dokumentert tillatelse som aldri vil finnes. Dette er den
+  ene risikoen som kan drepe alt.
+- **GitHub Pages + Claude Max** — begge forbrukervilkår. De ni agentene som genererer
+  produktdataene kjører på en konsument-OAuth-token.
+- **tvkampen-skrapingen** — trolig sui generis databasevern (åvl. § 24), og de er en
+  direkte konkurrent med egne apper.
+
+Men **erstatningen er ikke å kjøpe en annen aggregator** — se spor E. Der det finnes
+åpne, uttrykkelig tillatte kilder brukes de: Jolpica (F1) er gratis og Apache 2.0, og
+NRK gir eksplisitt tillatelse til EPG-bruk hos tredjepart.
+Terminlister som *fakta* er ikke opphavsrettsbeskyttet — eksponeringen ligger i
+hentemåten, ikke i dataene.
+
+### Spor E · Datainnhentingen (WP-240–245) — det egentlige produktet
+
+Dette sporet er lagt til etter eierens innvending 29.07, og det korrigerer en feil i
+den opprinnelige analysen: den grep etter «kjøp en datakilde» som det trygge svaret.
+Det konsederer stille feil premiss — det behandler AI-innhentingen som *risikoen* og
+betalt data som *fiksen*, når det motsatte er sant.
+
+**Argumentet, presist.** Tre uavhengige ting blandes ofte sammen:
+
+1. **Opphavsrett i faktaene** — ingen. EU-domstolen (Football Dataco, C-604/10) slo
+   fast at terminlister mangler den kreative friheten opphavsrett krever.
+2. **Sui generis databasevern** — fester seg til investering i å *samle, verifisere og
+   presentere*, ikke i å *skape* (Fixtures Marketing-sakene). Organet som **lager**
+   kampprogrammet har derfor svakt vern over det; en aggregator som samler og
+   verifiserer har et sterkere krav.
+3. **Kontrakt og tilgang** — uavhengig av opphavsrett. Det er dette ESPN faktisk er.
+
+Konsekvensen er at **«gå til den som skaper faktumet» er både det juridisk sterkeste
+og det mest nøyaktige trekket samtidig.** Den trygge sonen, presist: fakta per event,
+fra organet som skaper eller offisielt publiserer dem, i det volumet en journalist
+ville tatt, presentert redaksjonelt med attribusjon — ikke systematisk replikering av
+noens kuraterte samling.
+
+Ærlig forbehold: primærkilde betyr ikke automatisk tillatt. `fotball.no` forbyr selv
+roboter uten avtale, så NFF-avtalen (WP-211) består.
+
+**Vi gjør ikke dette ennå. [verifisert]** Evidensen på en faktisk Tour de
+France-etappe på tavla i dag:
+
+| Kilde | Type |
+|---|---|
+| `en.wikipedia.org` | encyklopedi — og eneste `verificationSource` |
+| `cyclingstage.com` | aggregator, reliability **0,53** i egen kalibreringsledger |
+| `velo.outsideonline.com` | magasin |
+| `idlprocycling.com` | aggregator |
+| `hjelp.tv2.no` | TV 2s egen side — den eneste primærkilden |
+
+`letour.fr` — A.S.O., som faktisk lager ruta og starttidene — er ikke sitert i det hele
+tatt. Research-laget siterer det som er *praktisk*, ikke det som er *autoritativt*. Det
+er samtidig den svakeste juridiske posisjonen, den svakeste datakvaliteten, og
+fikserbart.
+
+**Det som må bygges:**
+
+- **WP-240 · Kilderegister med rettslig grunnlag** (`scripts/config/sources.json`,
+  schema-validert). Per kilde: hvem publiserer, hva de er autoritative for, rolle
+  (primær / offisiell kringkaster / forbund / aggregator / encyklopedi), hva vilkårene
+  sier om automatisert tilgang, robots-status, attribusjonskrav, sist gjennomgått.
+  Dette gjør den juridiske posisjonen **etterprøvbar i stedet for påstått** — og det er
+  nøyaktig artefaktet man legger frem for Apple under guideline 5.2.2 og for advokaten
+  i WP-220.
+- **WP-241 · Autoritetskart per konkurranse.** For hver dekket konkurranse: hvem lager
+  *tidspunktet* (arrangør, liga, forbund) og hvem lager *kanalen* (kringkasteren selv).
+  To ulike kilder per event, som svarer nøyaktig til produktets to kjernefelt.
+- **WP-242 · Proveniens per FAKTUM, ikke per event.** Dagens `evidence: [urls]` er en
+  flat liste for hele eventet. Erstattes med per-felt: `{ time: {sourceId, url,
+  retrievedAt, basis}, streaming: {...} }`. Da kan `validate-events.js` håndheve
+  kontrakten mekanisk: **høy tillit krever primær eller offisiell basis for tid, og
+  kringkasterens egen kilde for kanal.** Dette er den høyeste enkeltgevinsten — det
+  gjør en myk redaksjonell norm til en validert kontrakt, i samme form som dagens
+  «høy tillit ⇒ 2+ evidens-URL-er», bare skjerpet fra *hvor mange* lenker til *hva
+  slags* kilde.
+- **WP-243 · Dekningskontrakt per konkurranse.** I dag er research opportunistisk
+  hullfylling. For å være primærkilde trengs en garanti: hver konkurranse har en
+  navngitt autoritet og en frist («Eliteserien runde N komplett 10 dager ut»), med
+  målbar dekningsgrad. Det er dette som lar oss droppe leverandørene helt, og det
+  mater G2-porten.
+- **WP-244 · Høflighetslaget.** Betingede forespørsler (ETag / If-Modified-Since),
+  caching, takt per vert, ærlig User-Agent med kontaktadresse, robots.txt respektert.
+  Billig, og konverterer «skraper» til «veloppdragen leser» både teknisk og optisk.
+- **WP-245 · Kalibreringen styrer kildevalget hardt.** `calibration.json` og
+  `source-quirks` finnes og virker allerede, men mater ikke kildevalget bindende. En
+  kilde på 0,53 skal mekanisk aldri kunne stå som eneste grunnlag.
+- **WP-246 · Kanalen skal peke på kampen, ikke på forsiden.** Det verifiserte funnet fra
+  29.07: 46 av 47 strømme-oppføringer er landingssider. Kontrakten blir **dyplenke med
+  tidsstempel og kilde, eller «ikke bekreftet» i klartekst** — aldri en forside som
+  utgir seg for å være et svar. Tavla blir ærligere og tynnere før den blir bedre, og
+  det er riktig rekkefølge. Dette er den mest direkte oversettelsen av spor E til noe
+  brukeren faktisk ser.
+
+**Hvorfor dette er selve løftet, ikke infrastruktur under det:** «hele sporten» er et
+bredere løfte etter at fotball og F1 ble værende i omfanget (§ 1) — ikke et smalere.
+Bredden gjør per-event-proveniens mer nødvendig, ikke mindre: jo flere sporter tavla
+hevder å dekke, jo billigere er det å avsløre at dekningen er et rettighetskart.
+
+**Ærlig caveat om endringsloggen.** En «3 endringer siden i går»-linje er foreslått som
+den synlige kvitteringen for at vi fører protokoll. Historikken sier at den blir stille:
+**4 rettelser på 60 sjekker over 8 verify-kjøringer**, og null i de tre siste. Det er
+ærlig og passer ro-kontrakten — «ingenting har flyttet seg siden 05:30» er et gyldig
+svar — men som *betalt* funksjon alene bærer den ikke. Bygg den som tillitsmarkør, ikke
+som bærebjelke.
+
+**Hva det endrer:** WP-210 (API-Football) og WP-213 (TheSportsDB) faller fra fundament
+til **reservekilde og korroborering**. Det sparer ~350 kr/mnd, men viktigere: produktet
+bygges ikke på noen andres database.
+
+**Ærlige risikoer ved denne strategien:**
+
+1. **Korrektheten blir helt vår.** Ingen leverandør-SLA å peke på når en betalende
+   kunde får feil kanal. Kalibreringsledgeren (121 sjekker) tyder på at det virker —
+   og leverandører tar også feil, de gir bare noen å skylde på.
+2. **AI-kosten går OPP, ikke ned.** Research som primærkilde er mer arbeid enn research
+   som hullfylling. Det motvirker delvis de sparte ~350 kr/mnd. Nettoeffekten er trolig
+   fortsatt gunstig, men den må modelleres, ikke antas.
+3. **Avtalesporet forsvinner ikke helt** — fotball.no krever fortsatt NFF-avtale.
+
+### Spor C · Vekst (WP-230–233)
+
+Kaldstarten skjer i navngitte rom, ikke i en kampanje. **Nisje først: vintersport**
+(skiskyting + langrenn) — størst smerte (rettighetene er spredt over NRK/TV 2/MAX),
+størst publikum av nisjene, og sesongen starter akkurat når sporene A og B er ferdige.
+
+Den ene vekstmekanismen som betyr noe: **offentlige event-sider**. **[verifisert]** I
+dag lander enhver delt lenke på `<body class="gated">` i `docs/index.html:45`, og
+WP-182-delekortene er bygget mot en vegg. Det finnes ett statisk `og-default.png` for
+hele siden og ingen per-event-side. Uten dette er all deling og SEO død; med det blir
+hvert «hvor ser jeg rennet»-svar en landingsside.
+
+### Spor D · Kvalitet (WP-205)
+
+Når folk betaler, blir feil kampstart eller feil kanal en reklamasjon. Målingen finnes
+allerede: `port-report.json` (fire porter, 14-dagers vindu) og `calibration.json` (121
+sjekker over 180 dager, per-kilde reliability). **[verifisert]**
+
+Akseptabel feilrate for et betalt produkt: **≤3 % tid/kanal-korrigeringer på
+<72t-events over rullerende 28 dager, og null feil oppdaget etter avspark.**
+
+---
+
+## 5 · Kalenderen
+
+Én tidslinje som forener sporene. Den ene faste ytre rammen er den norske
+vintersesongen — den kan ikke flyttes, så alt annet planlegges rundt den.
+
+| Når | Hva |
+|---|---|
+| **Aug 2026** | Spor A bølge 1 (WP-200, WP-201). Spor B starter samtidig: enhet (WP-217) og D-U-N-S (WP-218) har ~30 dagers ledetid — start dag 1. Be om NRK-API-nøkkel. |
+| **Sept 2026** | Spor A bølge 2 (WP-202, WP-203). **App-transfer (WP-219) FØR eksterne testere** — Apple krever at alle TestFlight-bygg og -testere fjernes først, så dette må skje før G1, ikke midt i. |
+| **Medio sept – medio okt** | **G1-vinduet** med 5 eksterne testere. Kildeexit (WP-210–214) og infrastruktur (WP-215/216) bygges parallelt. |
+| **Okt 2026** | Spor B ferdig: hosting migrert, ESPN ute, agentene på API-nøkkel. Advokatrunden (WP-220) løper parallelt. WP-230 (event-sider) bygges. |
+| **Uke 48 · 23.–29. nov 2026** | **OFFENTLIG GRATIS LANSERING.** Verdenscupåpningen i skiskyting og langrenn. Facebook-miljøene, kode24-pitch, r/norge. 18 ukers sesong foran seg. |
+| **Des 2026 – jan 2027** | Sesongen ER testen. Betalingsmuren (WP-204) bygges mens brukerne kommer. Tour de Ski og hoppuka gir ukentlige delingsmomenter. |
+| **Feb 2027** | Ski-VM-vinduet: **betalingsmuren slås på**, pressefremstøt nr. 2. |
+
+**Hvorfor uke 48 og ikke en lukket beta:** en marslansering får seks uker sesong;
+november får atten. Den lukkede 25-personers betaen ville brent nettopp den uken som er
+verdt mest. Sesongen er en bedre test enn en testgruppe — og gratis-lanseringen *er*
+betaen, med portene målt på ekte brukere.
+
+---
+
+## 6 · Portene
+
+G1 er allerede definert og bindende i `PLAN.md:2424` — den beholdes som den er.
+G2 og G3 bygger videre i samme ånd: ASC-metrikker og strukturert dagbok, ingen telemetri.
+
+**G0 · Antakelsen bak alt sammen (august, koster ingenting).** Produktet er formet av én
+person som er *flersport-fan*, og det er en legitim metode — den som kjenner smerten ekte
+bygger ofte det riktige. Risikoen er smalere enn «tar eieren feil»: den er om det finnes
+**nok** nordmenn som følger fire–fem sporter på tvers, eller om de fleste egentlig følger
+én og skummer resten. For en enkeltsport-fan er Sportivista tynn uansett hvor god den er.
+
+Test: **fem samtaler** med norske sykkel-, sjakk- og skifans. Ikke «finnes jobben», men:
+
+> *«Hvor mange sporter følger du faktisk — og irriterer fragmenteringen deg nok til at du
+> ville byttet app?»*
+
+Dette er den ene antakelsen hele forretningen står på, og den er billig å sjekke. Nevner
+ingen av de fem fragmenteringen uoppfordret, bør planen re-planlegges før noe bygges.
+
+- **G1 · intern → offentlig** (medio okt): WP-200–203 merget og vektorene bit-like;
+  ≥5 eksterne testere; ≥3 med sessions ≥5 av siste 7 dager; ≥3 av 5 svarer 4–5 på
+  «hvor lei deg blir du om den forsvinner»; 0 uløste krasj-klynger; port-report
+  near-term-feilrate ≤5 %.
+- **G2 · gratis → betalt** (jan 2027): ≥600 installasjoner etter to sesongtopper;
+  ≥150 ukentlig aktive; ≥5 sier eksplisitt ja til 39 kr/mnd; port-report over 28 dager:
+  coverage grønn ≥25/28 dager, near-term-feilrate ≤3 %, **null** kanal-feil oppdaget
+  etter avspark; spor B fullført.
+- **G3 · betalt lansering GO** (feb 2027): G2-tallene holdt i et nytt 28-dagers vindu;
+  StoreKit-sandbox-matrisen 100 % grønn; ≥5 testere gjennom kjøpsflyten uten
+  friksjonsfunn; App Review godkjent med IAP; reklamasjonsrutine definert
+  (feil kanal → rettelse og svar <24t).
+
+**Stopp-signalet:** færre enn 100 ukentlig aktive etter VM-uka i mars 2027. Da er to
+sesongtopper og presse brukt uten feste → tilbake til hobbyprodukt, som er et helt
+ærverdig utfall.
+
+---
+
+## 7 · Arbeidspakkene
+
+Nummerblokkene er adskilt så sporene kan gå parallelt uten kollisjon. WP-192 er
+høyeste nummer i bruk i dag.
+
+### Spor A · Produkt (FASE 1A)
+
+| WP | Tittel | Fase | Avhenger av | Størrelse | Status |
+|---|---|---|---|---|---|
+| WP-200 | Profilen former tavla (begge flater) + vektor-refrys | 1A | — | STOR, 2–3 uker | planlagt |
+| WP-201 | Ungate web-forsmaken | 1A | — | LITEN, ~1 uke | planlagt |
+| WP-202 | Onboarding selger ritualet: brief + varsel-priming + widget | 1A | WP-200 | MEDIUM, 1–2 uker | planlagt |
+| WP-203 | Sesongærlighet i startpakker og tomtilstand | 1A | WP-200 | LITEN, 2–4 kvelder | planlagt |
+| WP-204 | StoreKit-betalingsmur (Sportivista+) | 1A | WP-200, WP-202 | STOR, 3–4 uker | planlagt |
+| WP-205 | Reklamasjonsvakten: verifiseringskjeden på betalt nivå | 1A | — | MEDIUM, 1–2 uker + 28d måling | planlagt |
+| WP-206 | Web-entitlement + delekort-landing | 1A | WP-201, WP-204 | LITEN–MEDIUM, ~1 uke | planlagt |
+| WP-207 | App Store-innsendingspakken (IAP-review) | 1A | WP-204, WP-205 | MEDIUM, 1–2 uker | planlagt |
+
+**WP-200 i detalj:** ikke-tom profil ⇒ `followBroadly` avledes av profilen
+(sport-entiteter → bredde; lag/utøver/turnering → entity-gate i sin sport), og regel (3)
+sport-scopes. Tom profil ⇒ dagens katalogtavle byte-identisk. Filer: `profile-sync.js`,
+`lens.js`, `EffectiveInterests.swift`, `FeedCompiler.swift`, `lens-config.json`. **De 14
+gyldne vektorene re-fryses på begge flater** og `DIVERGENCES.md` oppdateres — det er
+halve jobben.
+
+**Betalingsgrensen (WP-204):** *gratis* = katalogtavla (når · hva · hvor), brief-linja,
+«Dette dekker vi», resultater, nyheter, assistentens spørrearm, delekort. *Betalt* =
+profil som former tavla, alle varsler, personlig widget, iCloud-synk, assistentens
+mutasjonsarm. Håndhevelse: iOS via StoreKit 2-entitlement (hard); web via
+entitlement-flagg i CloudKit-snapshot (mykt, omgåelig i devtools — akseptert, fordi
+dataene uansett er offentlige og betalingsflaten er iOS).
+
+### Spor B · Juss og infrastruktur
+
+| WP | Tittel | Type | Avhenger av | Kost |
+|---|---|---|---|---|
+| WP-210 | Fotball internasjonalt: API-Football erstatter ESPN | KODE | — | ~200–400 kr/mnd |
+| WP-211 | Fotball norsk: avtale med NFF/Fotballdata | AVTALE | — | ukjent |
+| WP-212 | F1: Jolpica (Apache 2.0) erstatter ESPN | KODE | — | 0–50 kr/mnd |
+| WP-213 | Golf/tennis/øvrig: TheSportsDB + AI-research mot offisielle kilder | KODE | — | ~100 kr/mnd |
+| WP-214 | Rettighetsdata: NRK PSAPI + EPG-avtaler erstatter tvkampen-skraping | KODE + AVTALE | — | 0–3 000 kr/mnd |
+| WP-215 | Pages → Cloudflare Workers/R2 + proxy for live-polling | KODE | — | ~100 kr/mnd |
+| WP-216 | Claude Max → Anthropic API (batch, caching, tiering) | KODE | — | 2 800–4 700 kr/mnd |
+| WP-217 | Juridisk enhet (ENK først, AS ved reell ansvarseksponering) | MENNESKE | — | 2 181 / 36 825 kr |
+| WP-218 | D-U-N-S + Apple org-konto | MENNESKE | WP-217 | $99/år |
+| WP-219 | App-transfer — **før eksterne testere** | MENNESKE | WP-218 | — |
+| WP-220 | Vilkår, personvern v2, ansvarsfraskrivelse — én advokatrunde | MENNESKE | WP-217 | 15–40 000 kr |
+
+Kritisk sti: WP-217 → WP-218 → WP-219 → WP-220, med kode-WPene parallelt.
+Flaskehalsen er D-U-N-S-ledetid og advokat, ikke koding. Realistisk 6–10 uker.
+
+### Spor C · Vekst
+
+| WP | Tittel | Avhenger av |
+|---|---|---|
+| WP-230 | Offentlige event-sider `/e/<id>` med ekte OG-metadata | WP-201, WP-215 |
+| WP-231 | ASO-pakke: norske nisjesøkeord, skjermbilder, tekst | WP-207 |
+| WP-232 | Lanseringskampanje uke 48 (Facebook-miljøene, r/norge) | WP-230 |
+| WP-233 | Pressefremstøt: kode24/NRKbeta — «AI-agenter drifter en sportstjeneste uten servere» | WP-232 |
+
+### Spor E · Datainnhentingen
+
+| WP | Tittel | Avhenger av |
+|---|---|---|
+| WP-240 | Kilderegister med rettslig grunnlag (`sources.json` + schema) | — |
+| WP-241 | Autoritetskart: hvem skaper tidspunktet, hvem skaper kanalen | WP-240 |
+| WP-242 | Proveniens per faktum + validator-kontrakt på kildetype | WP-240, WP-241 |
+| WP-243 | Dekningskontrakt per konkurranse med målbar dekningsgrad | WP-241 |
+| WP-244 | Høflighetslaget: ETag, caching, takt, User-Agent, robots | — |
+| WP-245 | Kalibreringen styrer kildevalget bindende | WP-242 |
+| WP-246 | Kanalen peker på kampen: dyplenke + kilde, ellers «ikke bekreftet» | WP-242 |
+
+Rekkefølge: WP-240 → WP-241 → WP-242 er kjernen; WP-244 kan gjøres når som helst og
+bør gjøres tidlig fordi den er billig. WP-242 er den høyeste enkeltgevinsten.
+
+---
+
+## 8 · Hva vi ikke bygger
+
+- **Egen konto- eller betalingsbackend** — bryter nullinfrastruktur. StoreKit og
+  brukerens egen iCloud dekker alt.
+- **Telemetri og D7-kohorter** — bruker opp tillitskapitalen produktet posisjoneres på.
+  Portene måles med ASC-metrikker og dagbok.
+- **Sanntids målpush og Live Activities** — allerede riktig fravalgt.
+- **Android** — PWA-stopgap står; Fase 3-valg.
+- **Live-score-dybde, tropp, statistikk** — FotMobs voll. Deep-link til spesialisten er
+  strategien, og entitetssidens «MER»-seksjon gjør det allerede.
+- **Web-LLM-assistent** — spiken konkluderte; `assistant.js` er nok.
+- **Hard web-DRM** — dataene er offentlige. Obfuskering er teater.
+- **Mer agent-maskineri eller høyere kadens** — kvoten er allerede presset.
+- **Uendelig nyhetsstrøm eller kortvegger** — bryter ro-kontrakten.
+- **Betalt annonsering, influencere, LinkedIn** — null budsjett, lav LTV.
+
+---
+
+## 9 · Det som må avgjøres først
+
+Én beslutning styrer alt annet: **kommer du deg av ESPN og tvkampen, over på kilder du
+har lov til å bruke kommersielt?**
+
+Svaret er ikke å kjøpe seg til en annen aggregator. Det er **spor E**: gjøre
+AI-innhentingen god nok til at den *er* primærkilden — fakta per event, hentet fra
+organet som skaper dem, med etterprøvbar proveniens per faktum. Det er samtidig den
+sterkeste juridiske posisjonen, den beste datakvaliteten og den eneste vollgraven en
+annonsefinansiert konkurrent ikke kan kopiere uten å rive sin egen forretningsmodell.
+
+De tre tingene faller sammen i ett arbeidsstykke. Det er derfor spor E er planens
+tyngdepunkt, ikke et vedlegg til det.
+
+Får du det til, er resten tempo og utholdenhet. Får du det ikke til, er den betalte
+veien stengt — og «et subsidiert hobbyprosjekt av uvanlig høy kvalitet» er et ærlig og
+godt svar, så lenge det velges med åpne øyne.

--- a/docs/index.html
+++ b/docs/index.html
@@ -236,7 +236,14 @@
 		window.ssBootGate = function (dashboard) {
 			const tokenSet = window.SPORTIVISTA_ICLOUD && window.SPORTIVISTA_ICLOUD.apiToken;
 			if (!window.ssICloud || typeof ssICloud.gate !== 'function' || !tokenSet) {
-				dashboard.init(); // no gate configured → open (local dev / stripped build)
+				// No gate configured → open (local dev / stripped build / the visual-QA
+				// harness, which serves a tokenless icloud-config.js because the real web
+				// token is origin-locked and 127.0.0.1 can never authenticate). `gated` is
+				// baked into <body> in the markup, so this path MUST take it off itself —
+				// only reveal() did, which meant the documented "open" path still rendered
+				// a blank page and visual-qa photographed the sign-in card for weeks.
+				document.body.classList.remove('gated');
+				dashboard.init();
 				return;
 			}
 			let tries = 0;

--- a/scripts/detect-coverage-gaps.js
+++ b/scripts/detect-coverage-gaps.js
@@ -38,6 +38,15 @@ export const UPCOMING_DAYS = 14;
 export const EXPECTED_SPORT_FILES = ["football", "golf", "tennis", "f1", "chess", "esports", "cycling"];
 
 /**
+ * How long a source file may be served from `retainLastGood` retention before we call
+ * the fetcher broken. A day or two of retention is ordinary (a between-rounds lull, a
+ * transient upstream blip); a week is a dead fetcher nobody noticed. Deliberately well
+ * under retainLastGood's own 14-day `maxAgeDays`, so the fetcher is flagged while the
+ * file still has content — not only once retention expires and the sport falls off.
+ */
+export const STALE_RETAIN_DAYS = 3;
+
+/**
  * Followed sports keyed by distinctive news terms → the sport key used in events.json.
  * Kept small and specific on purpose: this is a recall net, not a taxonomy. "winter"
  * has no fetcher/sport key, so it flags whenever winter sport is imminent in the news
@@ -182,6 +191,10 @@ export function detectGaps({ rss, events, interests, tracked, now = Date.now() }
  * name why (fetcher missing / empty / dropping events). `sources` maps sport key →
  * parsed data file (or null if absent).
  *
+ * ONE signal deliberately escapes the coverage-first gate: `stale-retained`. See the
+ * comment at its check — a fetcher frozen on retained data is broken even when the
+ * board looks complete, and coverage-first is precisely what hid it for 137 runs.
+ *
  * WP-110: the "dropped-in-build" (high) signal is CATALOG-GATED with the SAME
  * `isCovered` build-events.js uses. Entity-gated sports (chess/esports) are covered
  * only through the named catalog long-tail, so a minor open with a lone club player
@@ -197,9 +210,36 @@ export function detectSourceAnomalies({ sources, events, now = Date.now(), isCov
 	const anomalies = [];
 	for (const sport of EXPECTED_SPORT_FILES) {
 		const onBoard = countSportEventsWithin(events, sport, now, UPCOMING_DAYS);
+		const data = sources?.[sport];
+
+		// Chronic retention — DELIBERATELY checked BEFORE the coverage-first gate below.
+		// `retainLastGood` keeps the last non-empty file when a fetch comes back empty and
+		// stamps `_retained`, but nothing ever read that stamp. So a dead fetcher stayed
+		// invisible for as long as SOMETHING else covered the sport: football.json sat
+		// frozen on the 19 July World Cup final for 137 consecutive runs while the board
+		// looked healthy, because the research agent was hand-filling Eliteserien rounds
+		// as `source: "ai-research"`. Coverage-first is right for the signals below (an
+		// empty chess file is normal — chess has no API), but it is exactly wrong here:
+		// a fetcher that has stopped producing is broken whether or not the board hides it.
+		const retained = data?._retained;
+		if (retained) {
+			const since = Date.parse(retained.lastFreshFetch || retained.since || "");
+			const staleDays = Number.isFinite(since) ? Math.floor((now - since) / MS_PER_DAY) : null;
+			if (staleDays != null && staleDays >= STALE_RETAIN_DAYS) {
+				anomalies.push({
+					sport,
+					issue: "stale-retained",
+					detail: `docs/data/${sport}.json has been served from retention for ${retained.consecutiveRetains || "?"} consecutive run(s) — no fresh fetch in ${staleDays} day(s). The fetcher is producing nothing; the file only looks current because retainLastGood re-writes the last good copy${onBoard > 0 ? ", and the board hides it because another source covers this sport" : ""}.`,
+					consecutiveRetains: retained.consecutiveRetains || null,
+					staleDays,
+					severity: "high",
+					detectedAt: iso(now),
+				});
+			}
+		}
+
 		if (onBoard > 0) continue; // covered by some source — not a coverage problem
 
-		const data = sources?.[sport];
 		if (data == null) {
 			anomalies.push({ sport, issue: "file-missing", detail: `docs/data/${sport}.json is absent and no ${sport} events on the board — fetcher may have failed`, severity: "medium", detectedAt: iso(now) });
 			continue;
@@ -421,7 +461,7 @@ function main() {
 		anomalyCount: anomalies.length,
 		gaps: allGaps,
 		anomalies,
-		note: "Recall-biased mechanical detection — the coverage-critic and research agents triage these and cross-check the web. gaps: entity/sport in the news but missing or not imminent on the board (kind entity/sport), or a tracked.json reason that claims an upcoming event the board lacks (kind tracked-claim, RSS-independent). anomalies: a fetcher's own data looks unreliable. demand: distinct entities users publicly asked us to cover (open coverage-request issues), anonymous name+sport only — the research agent prioritises these when widening the catalog.",
+		note: "Recall-biased mechanical detection — the coverage-critic and research agents triage these and cross-check the web. gaps: entity/sport in the news but missing or not imminent on the board (kind entity/sport), or a tracked.json reason that claims an upcoming event the board lacks (kind tracked-claim, RSS-independent). anomalies: a fetcher's own data looks unreliable — including `stale-retained`, a fetcher frozen on retainLastGood retention, which is reported even when the board looks covered. demand: distinct entities users publicly asked us to cover (open coverage-request issues), anonymous name+sport only — the research agent prioritises these when widening the catalog.",
 	};
 	if (demand != null) out.demand = demand;
 	writeJsonPretty(path.join(dataDir, "coverage-gaps.json"), out);

--- a/scripts/fetch/football.js
+++ b/scripts/fetch/football.js
@@ -14,6 +14,58 @@ const catalog = readJsonIfExists(path.join(__dirname, "..", "config", "catalog.j
 const interests = readJsonIfExists(path.join(__dirname, "..", "config", "interests.json")) || {};
 const FAVORITE_TEAMS = catalog.tier2?.teams || interests.alwaysTrack?.teams || ["Barcelona", "Liverpool", "Lyn"];
 
+// ESPN club names for the Norwegian leagues, mapped to what a Norwegian reader
+// actually calls the club. Only clubs where ESPN differs are listed — anything
+// unmapped passes through untouched, so a promoted club is never mangled, just
+// left as ESPN spells it. Derived from ESPN's own nor.1 `teams` endpoint (its 16
+// `displayName`s), not guessed. NB: ESPN's per-event `name` ("Hamarkameratene at
+// Valerenga") is ASCII-folded even where `team.displayName` has the diacritics
+// right ("Vålerenga") — which is why we rebuild the title from the team names
+// instead of trusting `event.name`.
+const ESPN_CLUB_NB = {
+	"Hamarkameratene": "HamKam",
+	"Bodo/Glimt": "Bodø/Glimt",
+	"Lillestrom": "Lillestrøm",
+	"Tromso": "Tromsø",
+	"SK Brann": "Brann",
+	"IK Start": "Start",
+	"Viking FK": "Viking",
+	"Kristiansund BK": "Kristiansund",
+	"Sarpsborg FK": "Sarpsborg 08",
+};
+
+/**
+ * Is this a domestic Norwegian league fixture? Matched on the tournament label rather
+ * than `leagueCode`, because EventNormalizer drops `leagueCode` and this runs after
+ * normalisation. Eliteserien and OBOS-ligaen are the two leagues sports-config fetches
+ * (nor.1 / nor.2); OBOS also arrives from fotball.no already labelled.
+ */
+export function isNorwegianLeagueEvent(e) {
+	const hay = `${e?.tournament || ""} ${e?.meta || ""} ${e?.leagueName || ""}`.toLowerCase();
+	return /eliteserien|obos/.test(hay) || String(e?.leagueCode || "").startsWith("nor");
+}
+
+export function norwegianClubName(name) {
+	const n = String(name || "").trim();
+	return ESPN_CLUB_NB[n] || n;
+}
+
+/**
+ * Rewrite an ESPN match from a Norwegian league into the board's own voice:
+ * canonical club names and the "Hjemme – Borte" title every other football row
+ * uses. Mutates in place. Without this the static fetcher emitted ESPN's English
+ * "Sandefjord at Fredrikstad" onto a Norwegian-language board — fine while the
+ * research agent was hand-filling every round, glaring once the fetcher is the
+ * one supplying rounds nobody has written by hand.
+ */
+export function norwegianiseMatch(event) {
+	if (!event?.homeTeam || !event?.awayTeam) return event;
+	event.homeTeam = norwegianClubName(event.homeTeam);
+	event.awayTeam = norwegianClubName(event.awayTeam);
+	event.title = `${event.homeTeam} – ${event.awayTeam}`;
+	return event;
+}
+
 export class FootballFetcher extends ESPNAdapter {
 	constructor() {
 		super(sportsConfig.football);
@@ -73,6 +125,7 @@ export class FootballFetcher extends ESPNAdapter {
 					// It's an ESPN event, transform it
 					const event = this.transformESPNEvent(item);
 					if (event) {
+						if (String(item.leagueCode || "").startsWith("nor")) norwegianiseMatch(event);
 						event.isFavorite = this.checkFavorite(event.homeTeam, event.awayTeam);
 						const normalized = EventNormalizer.normalize(event, this.config.sport);
 						if (normalized && EventNormalizer.validateEvent(normalized)) {
@@ -93,27 +146,35 @@ export class FootballFetcher extends ESPNAdapter {
 		return matchInterest(hay, FAVORITE_TEAMS, { sport: "football" }) != null;
 	}
 
+	/**
+	 * No coverage FILTER (see the note below) — but coverage does need an ORDER, because
+	 * `applyFilters` slices to `maxEvents` (30) right after this runs. From mid-August
+	 * the Premier League, La Liga and the Champions League are all in season at once, and
+	 * a 7-day window across seven leagues comfortably exceeds 30. Whatever falls past the
+	 * cut is decided here, so the domestic leagues must be ahead of it: a Norwegian sports
+	 * board that drops Eliteserien to make room for a midweek La Liga fixture has its
+	 * priorities inverted — and it would have failed the same silent way as the bug above,
+	 * with the file merely looking healthy. Norwegian leagues first, then the adapter's own
+	 * `focused` ordering (owner-relevant ahead of the rest) decides the remainder.
+	 */
 	applyCustomFilters(events) {
-		const filtered = [];
-		
-		for (const event of events) {
-			const isNorwegianLeague = event.leagueCode?.startsWith("nor") || 
-									  event.tournament?.includes("OBOS") ||
-									  event.tournament?.includes("Eliteserien");
-			
-			const isInternational = event.leagueCode === "fifa.world";
-			
-			if (isNorwegianLeague || isInternational) {
-				if (event.norwegian) {
-					filtered.push(event);
-				}
-			} else {
-				filtered.push(event);
-			}
-		}
-		
-		return super.applyCustomFilters(filtered);
+		const domestic = [], rest = [];
+		for (const e of events) (isNorwegianLeagueEvent(e) ? domestic : rest).push(e);
+		return [...domestic, ...super.applyCustomFilters(rest)];
 	}
+
+	// NB (WP-96): there is deliberately NO coverage filter here. This override used to
+	// keep a Norwegian-league or World Cup match ONLY when `event.norwegian` was true —
+	// and `event.norwegian` is the OWNER's precision list (sports-config `norwegian.teams`
+	// = Lyn / Norge). Lyn plays in OBOS-ligaen, so EVERY Eliteserien match failed the gate
+	// and football.json went empty; `retainLastGood` then froze the last non-empty file
+	// (the 19 July World Cup final) for 137 consecutive runs while the board looked fine
+	// because the research agent was hand-filling each round as `source: "ai-research"`.
+	//
+	// `football` is catalog tier1 — covered WHOLESALE. Coverage is the catalog's call
+	// (build-events' `isCovered`), never one person's follow list; owner precision belongs
+	// in the on-device lens (WP-131). So the fetcher keeps what it fetches and lets the
+	// adapter's `focused` mode order Norwegian-interest matches first under `maxEvents`.
 }
 
 export async function fetchFootballESPN() {

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -42,6 +42,25 @@ function startServer() {
 		const server = createServer((req, res) => {
 			// Strip query strings (dashboard uses ?t=... for cache busting)
 			const urlPath = (req.url || "/").split("?")[0];
+
+			// Serve a TOKENLESS iCloud config so the board renders for QA.
+			//
+			// The dashboard is whole-web-behind-login (eier-beslutning 21.07), and the
+			// gate's own documented escape is "no apiToken → open page (local dev /
+			// stripped build)" — see ssBootGate in index.html and gate-boot.js. This
+			// harness has to take it: the real web token is origin-locked to
+			// sportivista.com / chaerem.github.io, so a screenshot served from
+			// 127.0.0.1 can NEVER authenticate. Without this, visual-qa photographed
+			// nothing but an AUTHENTICATION_FAILED sign-in card, run after run, and
+			// could not check a single layout rule — the visual-qa → ui-fix loop was
+			// dead. The override lives HERE, in the test harness, precisely so no new
+			// bypass ships in the client: production still gates normally.
+			if (urlPath === "/js/icloud-config.js") {
+				res.writeHead(200, { "Content-Type": "text/javascript" });
+				res.end("window.SPORTIVISTA_ICLOUD = { containerIdentifier: 'iCloud.app.sportivista.ios', apiToken: '', environment: 'production', zoneName: 'SportivistaProfile' };\n");
+				return;
+			}
+
 			const safePath = path.join(docsDir, urlPath === "/" ? "index.html" : urlPath);
 			if (!safePath.startsWith(docsDir)) {
 				res.writeHead(403);

--- a/tests/detect-coverage-gaps.test.js
+++ b/tests/detect-coverage-gaps.test.js
@@ -190,6 +190,41 @@ describe("detectSourceAnomalies", () => {
 		expect(detectSourceAnomalies({ sources: healthy(), events: boardWithAll(), now: NOW })).toEqual([]);
 	});
 
+	// The football.json regression: the fetcher stopped producing on 19 July 2026 and
+	// retainLastGood re-served the last good copy 137 runs in a row. Nothing noticed,
+	// because the research agent was hand-filling Eliteserien as `source: "ai-research"`
+	// — so the board was covered and the coverage-first gate skipped the sport entirely.
+	describe("stale-retained (escapes the coverage-first gate)", () => {
+		const retainedFor = (days, runs) => {
+			const s = healthy();
+			const stamp = new Date(NOW - days * 86400000).toISOString();
+			s.football._retained = { since: stamp, consecutiveRetains: runs, lastFreshFetch: stamp };
+			return s;
+		};
+
+		it("flags a chronically retained file EVEN WHEN the board is fully covered", () => {
+			const a = detectSourceAnomalies({ sources: retainedFor(9, 137), events: boardWithAll(), now: NOW });
+			const hit = a.find((x) => x.sport === "football");
+			expect(hit).toMatchObject({ issue: "stale-retained", severity: "high", consecutiveRetains: 137, staleDays: 9 });
+			expect(hit.detail).toMatch(/137 consecutive run/);
+		});
+
+		it("stays quiet for an ordinary short retention lull", () => {
+			const a = detectSourceAnomalies({ sources: retainedFor(1, 20), events: boardWithAll(), now: NOW });
+			expect(a.find((x) => x.sport === "football")).toBeUndefined();
+		});
+
+		it("stays quiet once the fetcher produces fresh data again", () => {
+			expect(detectSourceAnomalies({ sources: healthy(), events: boardWithAll(), now: NOW })).toEqual([]);
+		});
+
+		it("survives a retention stamp with no parseable date", () => {
+			const s = healthy();
+			s.football._retained = { consecutiveRetains: 500 };
+			expect(detectSourceAnomalies({ sources: s, events: boardWithAll(), now: NOW })).toEqual([]);
+		});
+	});
+
 	it("stays quiet when the fetcher file is empty but the board is covered (AI research)", () => {
 		// chess/cycling have no API and are filled by research — an empty file is expected.
 		const s = healthy();

--- a/tests/football-fetcher.test.js
+++ b/tests/football-fetcher.test.js
@@ -1,0 +1,103 @@
+// football.js: the static Eliteserien/OBOS fetcher.
+//
+// Regression cover for the 19 July 2026 outage: `applyCustomFilters` kept a
+// Norwegian-league match ONLY when `event.norwegian` was true — and that flag is the
+// OWNER's precision list (sports-config `norwegian.teams` = Lyn / Norge). Lyn plays in
+// OBOS-ligaen, so EVERY Eliteserien match failed the gate, football.json went empty,
+// and retainLastGood froze the last good copy for 137 consecutive runs while the
+// research agent hand-filled each round. `football` is catalog tier1 — covered
+// wholesale — so coverage is the catalog's call, never one person's follow list.
+import { describe, it, expect } from "vitest";
+import { FootballFetcher, norwegianClubName, norwegianiseMatch } from "../scripts/fetch/football.js";
+
+const inDays = (d, hour = 17) => {
+	const t = new Date(Date.now() + d * 86400000);
+	t.setUTCHours(hour, 0, 0, 0);
+	return t.toISOString();
+};
+
+describe("Norwegian club naming", () => {
+	it("maps ESPN's anglicised club names to what a Norwegian reader calls them", () => {
+		expect(norwegianClubName("Bodo/Glimt")).toBe("Bodø/Glimt");
+		expect(norwegianClubName("Tromso")).toBe("Tromsø");
+		expect(norwegianClubName("Lillestrom")).toBe("Lillestrøm");
+		expect(norwegianClubName("Hamarkameratene")).toBe("HamKam");
+		expect(norwegianClubName("Sarpsborg FK")).toBe("Sarpsborg 08");
+		expect(norwegianClubName("SK Brann")).toBe("Brann");
+	});
+
+	it("passes an unmapped club through untouched (a promoted club is never mangled)", () => {
+		expect(norwegianClubName("Fredrikstad")).toBe("Fredrikstad");
+		expect(norwegianClubName("Bryne")).toBe("Bryne");
+		expect(norwegianClubName("")).toBe("");
+		expect(norwegianClubName(undefined)).toBe("");
+	});
+
+	it("rewrites the title into the board's own «Hjemme – Borte» voice", () => {
+		// ESPN's own per-event `name` is English AND ASCII-folded ("Hamarkameratene at
+		// Valerenga") even though team.displayName has the diacritics right.
+		const e = norwegianiseMatch({ title: "Hamarkameratene at Valerenga", homeTeam: "Vålerenga", awayTeam: "Hamarkameratene" });
+		expect(e.title).toBe("Vålerenga – HamKam");
+		expect(e.homeTeam).toBe("Vålerenga");
+		expect(e.awayTeam).toBe("HamKam");
+	});
+
+	it("leaves an event without both teams alone", () => {
+		const e = norwegianiseMatch({ title: "Eliteserien", homeTeam: "Molde" });
+		expect(e.title).toBe("Eliteserien");
+	});
+});
+
+describe("coverage filtering", () => {
+	const eliteserie = () => [
+		{ title: "Fredrikstad – Sandefjord", time: inDays(2), sport: "football", leagueCode: "nor.1", tournament: "Eliteserien", norwegian: false },
+		{ title: "Molde – Sarpsborg 08", time: inDays(3), sport: "football", leagueCode: "nor.1", tournament: "Eliteserien", norwegian: false },
+		{ title: "Brann – Rosenborg", time: inDays(3, 19), sport: "football", leagueCode: "nor.1", tournament: "Eliteserien", norwegian: false },
+	];
+
+	it("KEEPS Eliteserien matches that involve none of the owner's followed teams", () => {
+		// The exact bug: none of these three has `norwegian: true`, because the owner
+		// follows Lyn (OBOS) and Norge. Before the fix all three were dropped.
+		const kept = new FootballFetcher().applyFilters(eliteserie());
+		expect(kept).toHaveLength(3);
+		expect(kept.map((e) => e.title)).toContain("Brann – Rosenborg");
+	});
+
+	it("treats OBOS-ligaen as domestic too, ahead of any foreign fixture", () => {
+		const events = [
+			{ title: "Arsenal vs Chelsea", time: inDays(1), sport: "football", leagueCode: "eng.1", tournament: "Premier League", norwegian: false },
+			...eliteserie(),
+			{ title: "Lyn – Sogndal", time: inDays(1), sport: "football", leagueCode: "nor.2", tournament: "OBOS-ligaen", norwegian: true },
+		];
+		const kept = new FootballFetcher().applyFilters(events);
+		expect(kept).toHaveLength(5);
+		// The four domestic fixtures come first; the foreign one brings up the rear.
+		expect(kept.slice(0, 4).map((e) => e.title)).toContain("Lyn – Sogndal");
+		expect(kept[4].title).toBe("Arsenal vs Chelsea");
+	});
+
+	it("keeps Eliteserien ahead of foreign leagues when maxEvents has to cut", () => {
+		// From mid-August the PL, La Liga and CL are all in season, and a 7-day window
+		// over seven leagues exceeds maxEvents (30). Whatever falls past the cut is
+		// decided by this ordering — domestic must never lose its slot to a midweek
+		// foreign fixture on a Norwegian board.
+		const foreign = Array.from({ length: 40 }, (_, i) => ({
+			title: `Foreign ${i}`, time: inDays(1 + (i % 5)), sport: "football",
+			leagueCode: "eng.1", tournament: "Premier League", norwegian: false,
+		}));
+		const kept = new FootballFetcher().applyFilters([...foreign, ...eliteserie()]);
+		expect(kept).toHaveLength(30); // maxEvents
+		const titles = kept.map((e) => e.title);
+		for (const t of ["Fredrikstad – Sandefjord", "Molde – Sarpsborg 08", "Brann – Rosenborg"]) {
+			expect(titles).toContain(t);
+		}
+		expect(titles.slice(0, 3).every((t) => !t.startsWith("Foreign"))).toBe(true);
+	});
+
+	it("does not drop foreign-league matches either", () => {
+		const kept = new FootballFetcher().applyFilters([
+			{ title: "Arsenal vs Chelsea", time: inDays(4), sport: "football", leagueCode: "eng.1", tournament: "Premier League", norwegian: false },
+		]);
+		expect(kept).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Tre uavhengige feil funnet under en statusgjennomgang 29.07, alle med samme
karaktertrekk: symptomet var skjult, så ingen av de eksisterende loopene fanget dem.

## 1 · Den statiske fotball-fetcheren har vært død siden 19. juli

`football.js` droppet **alle** Eliteserie-kamper. `applyCustomFilters` beholdt bare
norske ligakamper når `event.norwegian` var sann — og det flagget er eierens
presisjonsliste (`sports-config.norwegian.teams` = Lyn / Norge). Lyn spiller i OBOS,
så hele Eliteserien strøk på porten, `football.json` ble tom, og `retainLastGood`
frøs VM-finalen fra 19. juli i **137 kjøringer på rad**.

Symptomet var skjult fordi research-agenten fylte hver runde for hånd som
`source: "ai-research"`. Tavla så riktig ut; kilden var død.

WP-96: `football` er catalog tier1 — dekning er katalogens avgjørelse, aldri én
persons følgeliste. Porten er fjernet.

Titler bygges nå fra lagnavnene i «Hjemme – Borte»-form via en klubbnavn-tabell
utledet fra ESPNs **egen** `nor.1`-teams-respons (ESPNs event-`name` er engelsk OG
ASCII-foldet der `team.displayName` har diakritikken riktig). Alle 8 titlene blir
byte-identiske med research-radene, så dedupe gir 8 rader, ikke 16 — verifisert ved
å kjøre hele bygget mot en temp-datamappe.

`applyCustomFilters` er gjeninnført med motsatt semantikk: ingen dekningsFILTER, men
en dekningsORDEN. `maxEvents` (30) kutter rett etter, og fra medio august er PL,
La Liga og CL i sesong samtidig — uten dette kunne Eliteserien blitt kuttet for en
midtukes La Liga-kamp, på en norsk tavle.

## 2 · At det kunne skje usett i 137 kjøringer

`retainLastGood` stemplet `_retained.consecutiveRetains` hele veien — ingen leste det.
Anomali-deteksjonen er coverage-first og hoppet over fotball helt, fordi tavla *så*
dekket ut.

Ny `stale-retained`-anomali som **med vilje omgår** coverage-porten: en fetcher som
har sluttet å produsere er ødelagt uansett om tavla skjuler det. Verifisert mot den
ekte frosne fila — fyrer med «137 consecutive run(s) — no fresh fetch in 9 day(s)»,
tier ved 1 dags retensjon og på fersk fil.

## 3 · visual-QA har fotografert innloggingskortet, ikke produktet

`<body class="gated">` står i markupen, og den *dokumenterte* «ingen apiToken → åpen
side»-stien fjernet den aldri — bare `reveal()` gjorde det. Dev-/stripped-stien har
rendret blank side hele tiden. Skjermbilde-harnesset serverer nå en tokenløs config
(nødvendig uansett: web-tokenet er origin-låst, så 127.0.0.1 kan aldri autentisere).
Overstyringen ligger i harnesset nettopp for at ingen ny bypass skal shippe i
klienten — produksjon gater som før.

Grenen hadde opprinnelig også en «Prøv igjen»-knapp for auth-blindveien. Den er
**droppet** — ui-fix-agenten shippet samme fiks til main mens dette pågikk, og dens
versjon er grundigere.

## 4 · Dokumentasjon

`norwegian-rights`-skillen grupperte fortsatt «Champions / Europa League → TV 2 Play»
etter at #417 rettet `norwegian-rights.js`. Begge agentene som prøvde å rette den ble
permission-nektet lokalt, så feilen har stått siden 27.07. CLAUDE.md sa 44 filer /
648 tester; reelt 74 / 1219.

`COMMERCIAL.md` er ny: kommersialiseringsplanen (visjon, regnestykke, fem spor,
kalender, porter, WP-tabeller i PLAN.md-format).

## Verifisering

- `npx vitest run --maxWorkers=1` → **74 filer / 1219 tester grønne** (11 nye regresjonstester)
- `node scripts/build-events.js && node scripts/validate-events.js` → 73 events, **0 feil**
- `node scripts/screenshot.js --width=375 --full-page` → hele tavla rendrer
- Ingen beskyttede stier berørt

🤖 Generated with [Claude Code](https://claude.com/claude-code)