### PR TITLE
WP-244: Høflighetslaget — betingede forespørsler, takt per vert, ærlig UA og robots.txt

### DIFF
--- a/scripts/lib/api-client.js
+++ b/scripts/lib/api-client.js
@@ -1,9 +1,111 @@
 import https from "https";
 import zlib from "zlib";
 
+/**
+ * Høflighetslaget (WP-244)
+ * ------------------------
+ * `APIClient` er ikke en skraper — den skal oppføre seg som en veloppdragen,
+ * identifiserbar leser hos tredjeparts-kilder:
+ *
+ *   1. Betingede forespørsler (ETag / Last-Modified → If-None-Match /
+ *      If-Modified-Since). Et `304 Not Modified` returnerer cachet innhold
+ *      uten ny nedlasting og uten ny parsing.
+ *   2. Takt per VERT, håndhevet inne i klienten (ikke i fetcherne), og delt
+ *      på tvers av alle klient-instanser i prosessen — fetcherne kjøres i
+ *      parallell (`Promise.allSettled` i scripts/fetch/index.js), så per-
+ *      instans-takt ville ikke hindret at én vert ble hamret.
+ *   3. Ærlig, sporbar User-Agent med kontakt-URL.
+ *   4. robots.txt hentes og caches per vert, og `Disallow` respekteres for
+ *      stiene vi faktisk henter. Feiler robots-henting → fail-open.
+ *
+ * Kontrakten mot fetcherne er uendret: `fetchJSON(url, options)` returnerer
+ * fortsatt parset JSON og kaster ved feil.
+ */
+
+/**
+ * Ærlig identitet: navngir prosjektet og gir en kontaktvei som faktisk går til
+ * et menneske. Kilder som lurer på hvem vi er skal kunne finne oss på ett søk.
+ */
+export const USER_AGENT =
+	"Sportivista/2.0 (+https://sportivista.com; kontakt: https://github.com/CHaerem/sportivista/issues)";
+
+/** Produkt-tokenet robots.txt-grupper matches mot (RFC 9309 «product token»). */
+export const USER_AGENT_TOKEN = "Sportivista";
+
+/** Default minste avstand mellom to forespørsler til SAMME vert. */
+export const DEFAULT_HOST_INTERVAL_MS = 250;
+
+/** Hvor lenge en robots.txt gjenbrukes før den hentes på nytt. */
+const ROBOTS_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Vert-spesifikk policy — kildens EGNE publiserte vilkår, der de finnes.
+ *
+ * `robotsExempt` er ikke en snarvei rundt robots.txt: den dekker stier der
+ * kilden selv publiserer API-vilkår som uttrykkelig tillater programmatisk
+ * bruk. robots.txt regulerer crawlere; et dokumentert API regulerer API-
+ * klienter, og vi er det siste. Unntaket betales med kildens egen, strengere
+ * takt (`intervalMs`).
+ */
+const HOST_POLICY = {
+	"lichess.org": {
+		// Lichess driver et offentlig, dokumentert API (https://lichess.org/api)
+		// som er ment for programmatisk bruk. robots.txt har `Disallow: /api/`
+		// — rettet mot søkemotorer som ellers ville indeksert API-svar, ikke mot
+		// API-klienter. Vi holder en konservativ takt på 1 req/s; sjakk-fetcheren
+		// gjør én forespørsel per kjøring.
+		intervalMs: 1000,
+		robotsExempt: [/^\/api\//],
+		reason: "Lichess' offentlige API (https://lichess.org/api)"
+	},
+	"liquipedia.net": {
+		// Liquipedias API-vilkår: «action=parse» ≤ 1 request / 30 sekunder,
+		// egen identifiserende User-Agent med kontaktinfo, og gzip.
+		// https://liquipedia.net/api-terms-of-use
+		intervalMs: 30000,
+		// robots.txt har `Disallow: /<wiki>/api.php` for crawlere, mens API-
+		// vilkårene over eksplisitt beskriver hvordan man SKAL bruke nettopp
+		// den stien. Esports-fetcheren gjør én parse-forespørsel per kjøring.
+		robotsExempt: [/^\/[^/]+\/api\.php$/],
+		reason: "Liquipedia API Terms of Use (https://liquipedia.net/api-terms-of-use)"
+	}
+};
+
+/**
+ * Delt tilstand PER VERT for hele prosessen: takt-kø, robots-cache og
+ * crawl-delay. Delt fordi høflighet er en egenskap ved verten, ikke ved
+ * hvilken klient-instans som tilfeldigvis ringer.
+ */
+const hostRegistry = new Map();
+
+function hostState(host) {
+	let state = hostRegistry.get(host);
+	if (!state) {
+		state = { nextSlot: 0, robots: null, robotsPromise: null, crawlDelayMs: 0, exemptLogged: false };
+		hostRegistry.set(host, state);
+	}
+	return state;
+}
+
+/** Nullstill delt vert-tilstand (takt-kø + robots-cache). Brukes av tester. */
+export function resetPolitenessState() {
+	hostRegistry.clear();
+}
+
+/** Kastes når robots.txt forbyr stien. Egen type så den ikke drukner i vanlige feil. */
+export class RobotsDisallowedError extends Error {
+	constructor(url, rule) {
+		super(`robots.txt disallows ${url}${rule ? ` (Disallow: ${rule})` : ""}`);
+		this.name = "RobotsDisallowedError";
+		this.url = url;
+		this.rule = rule;
+	}
+}
+
 /** Decompress a response body Buffer per its Content-Encoding (identity → unchanged). */
 function decodeBody(buffer, contentEncoding) {
 	const enc = (contentEncoding || "").toLowerCase();
+	if (!buffer.length) return buffer;
 	try {
 		if (enc === "gzip") return zlib.gunzipSync(buffer);
 		if (enc === "deflate") return zlib.inflateSync(buffer);
@@ -14,10 +116,113 @@ function decodeBody(buffer, contentEncoding) {
 	return buffer;
 }
 
+// --- robots.txt ---------------------------------------------------------
+
+/**
+ * Parse robots.txt til grupper. Sammenhengende `User-agent:`-linjer deler
+ * regelsett (RFC 9309). Kommentarer og ukjente felt ignoreres.
+ * @returns {Array<{agents: string[], rules: Array<{allow: boolean, path: string}>, crawlDelay: number|null}>}
+ */
+export function parseRobots(text) {
+	const groups = [];
+	let current = null;
+	let inAgentRun = false;
+
+	for (const rawLine of String(text || "").split(/\r?\n/)) {
+		const line = rawLine.replace(/#.*$/, "").trim();
+		if (!line) continue;
+
+		const sep = line.indexOf(":");
+		if (sep < 0) continue;
+
+		const field = line.slice(0, sep).trim().toLowerCase();
+		const value = line.slice(sep + 1).trim();
+
+		if (field === "user-agent") {
+			if (!inAgentRun || !current) {
+				current = { agents: [], rules: [], crawlDelay: null };
+				groups.push(current);
+				inAgentRun = true;
+			}
+			current.agents.push(value.toLowerCase());
+			continue;
+		}
+
+		if (!current) continue; // regel før noen user-agent — ignorer
+		inAgentRun = false;
+
+		if (field === "allow" || field === "disallow") {
+			current.rules.push({ allow: field === "allow", path: value });
+		} else if (field === "crawl-delay") {
+			const seconds = Number.parseFloat(value);
+			if (Number.isFinite(seconds) && seconds > 0) current.crawlDelay = seconds;
+		}
+	}
+
+	return groups;
+}
+
+/**
+ * Velg reglene som gjelder for vårt produkt-token: en eksakt gruppe hvis den
+ * finnes, ellers `*`. Ingen treff → tom liste (alt tillatt).
+ */
+export function rulesForAgent(groups, token = USER_AGENT_TOKEN) {
+	const wanted = String(token || "").toLowerCase();
+	const exact = groups.filter(g => g.agents.includes(wanted));
+	const matched = exact.length > 0 ? exact : groups.filter(g => g.agents.includes("*"));
+	return {
+		rules: matched.flatMap(g => g.rules),
+		crawlDelay: matched.reduce((max, g) => Math.max(max, g.crawlDelay || 0), 0) || null
+	};
+}
+
+/** robots-sti-mønster → RegExp. Støtter `*` (jokertegn) og `$` (slutt-anker). */
+function robotsPathRegex(pattern) {
+	let body = pattern;
+	let anchorEnd = false;
+	if (body.endsWith("$")) {
+		anchorEnd = true;
+		body = body.slice(0, -1);
+	}
+	const escaped = body
+		.split("*")
+		.map(part => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+		.join(".*");
+	return new RegExp(`^${escaped}${anchorEnd ? "$" : ""}`);
+}
+
+/**
+ * Avgjør om `target` (pathname + search) er tillatt.
+ * Mest spesifikke (lengste) mønster vinner; ved lik lengde vinner Allow.
+ */
+export function robotsVerdict(rules, target) {
+	let best = null;
+
+	for (const rule of rules) {
+		if (!rule.path) continue; // tom `Disallow:` betyr «alt tillatt»
+		let regex;
+		try {
+			regex = robotsPathRegex(rule.path);
+		} catch {
+			continue; // ulovlig mønster — ignorer heller enn å felle henting
+		}
+		if (!regex.test(target)) continue;
+
+		const length = rule.path.replace(/\$$/, "").length;
+		if (!best || length > best.length || (length === best.length && rule.allow)) {
+			best = { length, rule };
+		}
+	}
+
+	return best ? { allowed: best.rule.allow, rule: best.rule.path } : { allowed: true, rule: null };
+}
+
+// --- klienten -----------------------------------------------------------
+
 export class APIClient {
 	constructor(options = {}) {
 		this.defaultHeaders = {
-			"User-Agent": options.userAgent || "SportSync/2.0",
+			"User-Agent": options.userAgent || USER_AGENT,
 			...options.headers
 		};
 		this.retries = options.retries ?? 2;
@@ -25,25 +230,72 @@ export class APIClient {
 		this.timeout = options.timeout ?? 10000;
 		this.cache = new Map();
 		this.cacheTimeout = options.cacheTimeout ?? 60000;
+
+		// Takt per vert
+		this.minHostIntervalMs = options.minHostIntervalMs ?? DEFAULT_HOST_INTERVAL_MS;
+		this.hostIntervals = options.hostIntervals || {};
+
+		// robots.txt
+		this.respectRobots = options.respectRobots !== false;
+		this.robotsAgent = options.robotsAgent || USER_AGENT_TOKEN;
+		this.robotsTimeout = options.robotsTimeout ?? 4000;
+
+		// Enkel, ærlig regnskapsføring — hva sparte vi kilden for?
+		this.stats = { requests: 0, cacheHits: 0, notModified: 0, robotsBlocked: 0, throttledMs: 0 };
 	}
 
 	async fetchJSON(url, options = {}) {
 		const cacheKey = url;
 		const cached = this.cache.get(cacheKey);
-		
+
 		if (cached && Date.now() - cached.timestamp < this.cacheTimeout) {
+			this.stats.cacheHits++;
 			return cached.data;
 		}
 
 		const headers = { ...this.defaultHeaders, ...options.headers };
+
+		// Betinget forespørsel: la kilden svare «uendret» i stedet for å sende
+		// hele kroppen på nytt.
+		if (cached?.etag) headers["If-None-Match"] = cached.etag;
+		if (cached?.lastModified) headers["If-Modified-Since"] = cached.lastModified;
+
 		const retries = options.retries ?? this.retries;
 		const retryDelay = options.retryDelay ?? this.retryDelay;
 
 		try {
-			const data = await this.makeRequest(url, { headers, retries, retryDelay });
-			this.cache.set(cacheKey, { data, timestamp: Date.now() });
+			const response = await this.request(url, { headers, retries, retryDelay, timeout: options.timeout });
+
+			if (response.statusCode === 304 && cached) {
+				// Uendret: gjenbruk cachet objekt — ingen ny parsing, ingen ny nedlasting.
+				cached.timestamp = Date.now();
+				if (response.headers.etag) cached.etag = response.headers.etag;
+				this.stats.notModified++;
+				return cached.data;
+			}
+
+			if (response.statusCode >= 400) {
+				throw new Error(`HTTP ${response.statusCode}: ${response.body.substring(0, 100)}`);
+			}
+
+			let data;
+			try {
+				data = JSON.parse(response.body);
+			} catch {
+				throw new Error(`Invalid JSON response from ${url}`);
+			}
+
+			this.cache.set(cacheKey, {
+				data,
+				timestamp: Date.now(),
+				etag: response.headers.etag || null,
+				lastModified: response.headers["last-modified"] || null
+			});
 			return data;
 		} catch (error) {
+			// Et robots-avslag skal være entydig og synlig — ikke maskeres av
+			// et gammelt cachet svar.
+			if (error instanceof RobotsDisallowedError) throw error;
 			if (cached) {
 				console.warn(`Using stale cache for ${url} due to error:`, error.message);
 				return cached.data;
@@ -52,72 +304,218 @@ export class APIClient {
 		}
 	}
 
-	makeRequest(url, options) {
+	/**
+	 * Bakoverkompatibel lav-nivå-inngang: parset JSON, kaster på HTTP ≥ 400.
+	 * Går gjennom robots-sjekk og takt som alt annet.
+	 */
+	async makeRequest(url, options = {}) {
+		const response = await this.request(url, options);
+		if (response.statusCode >= 400) {
+			throw new Error(`HTTP ${response.statusCode}: ${response.body.substring(0, 100)}`);
+		}
+		try {
+			return JSON.parse(response.body);
+		} catch {
+			throw new Error(`Invalid JSON response from ${url}`);
+		}
+	}
+
+	/**
+	 * Én logisk forespørsel: robots-sjekk → takt per vert → HTTP med retry.
+	 * @returns {Promise<{statusCode: number, headers: object, body: string}>}
+	 */
+	async request(url, options = {}) {
+		await this.assertRobotsAllows(url);
+		await this.takeHostSlot(url);
+		return this.requestWithRetry(url, options);
+	}
+
+	async requestWithRetry(url, options) {
+		const retries = options.retries ?? this.retries;
+		const retryDelay = options.retryDelay ?? this.retryDelay;
+
+		const retry = async () => {
+			await this.delay(retryDelay);
+			await this.takeHostSlot(url); // en ny forespørsel er en ny forespørsel
+			return this.requestWithRetry(url, { ...options, retries: retries - 1, retryDelay: retryDelay * 2 });
+		};
+
+		let response;
+		try {
+			response = await this.requestOnce(url, options);
+		} catch (error) {
+			if (retries > 0) return retry();
+			throw error;
+		}
+
+		if (response.statusCode >= 500 && retries > 0) return retry();
+		return response;
+	}
+
+	/** Rå HTTPS-forespørsel — ingen retry, ingen cache, ingen takt. */
+	requestOnce(url, options = {}) {
 		return new Promise((resolve, reject) => {
 			// Advertise gzip so APIs that require it (e.g. Liquipedia returns 406
 			// otherwise) work; caller headers can still override.
-			const headers = { "Accept-Encoding": "gzip, deflate, br", ...options.headers };
+			const headers = {
+				"Accept-Encoding": "gzip, deflate, br",
+				...this.defaultHeaders,
+				...options.headers
+			};
+			const timeout = options.timeout ?? this.timeout;
+			let settled = false;
+			const finish = (fn, value) => {
+				if (settled) return;
+				settled = true;
+				fn(value);
+			};
+
+			this.stats.requests++;
+
 			const request = https.get(url, { headers }, (response) => {
 				const chunks = [];
-
 				response.on("data", chunk => chunks.push(chunk));
-
-				response.on("end", async () => {
-					if (response.statusCode >= 500 && options.retries > 0) {
-						await this.delay(options.retryDelay);
-						try {
-							const result = await this.makeRequest(url, {
-								...options,
-								retries: options.retries - 1,
-								retryDelay: options.retryDelay * 2
-							});
-							resolve(result);
-						} catch (error) {
-							reject(error);
-						}
-						return;
-					}
-
+				response.on("end", () => {
 					// Collect as bytes and decompress — string concat corrupts both
 					// gzipped bodies and multibyte UTF-8 split across chunk boundaries.
-					const body = decodeBody(Buffer.concat(chunks), response.headers["content-encoding"]).toString("utf8");
-
-					if (response.statusCode >= 400) {
-						reject(new Error(`HTTP ${response.statusCode}: ${body.substring(0, 100)}`));
-						return;
-					}
-
-					try {
-						resolve(JSON.parse(body));
-					} catch (error) {
-						reject(new Error(`Invalid JSON response from ${url}`));
-					}
+					const body = decodeBody(
+						Buffer.concat(chunks),
+						response.headers["content-encoding"]
+					).toString("utf8");
+					finish(resolve, {
+						statusCode: response.statusCode,
+						headers: response.headers || {},
+						body
+					});
 				});
+				response.on("error", error => finish(reject, error));
 			});
 
-			request.on("error", async (error) => {
-				if (options.retries > 0) {
-					await this.delay(options.retryDelay);
-					try {
-						const result = await this.makeRequest(url, {
-							...options,
-							retries: options.retries - 1,
-							retryDelay: options.retryDelay * 2
-						});
-						resolve(result);
-					} catch (retryError) {
-						reject(retryError);
-					}
-				} else {
-					reject(error);
-				}
-			});
-
-			request.setTimeout(this.timeout, () => {
+			request.on("error", error => finish(reject, error));
+			request.setTimeout(timeout, () => {
 				request.destroy();
-				reject(new Error(`Request timeout after ${this.timeout}ms`));
+				finish(reject, new Error(`Request timeout after ${timeout}ms`));
 			});
 		});
+	}
+
+	// --- takt per vert ---
+
+	/** Gjeldende minsteavstand for verten: policy/konfig, hevet av crawl-delay. */
+	hostInterval(host) {
+		const configured =
+			this.hostIntervals[host] ??
+			HOST_POLICY[host]?.intervalMs ??
+			this.minHostIntervalMs;
+		const crawlDelay = hostRegistry.get(host)?.crawlDelayMs || 0;
+		return Math.max(configured, crawlDelay);
+	}
+
+	/**
+	 * Reserver neste ledige tidsluke hos verten og vent på den.
+	 * Reservasjonen skjer synkront (ingen await før `nextSlot` settes), så
+	 * parallelle kall køes riktig i stedet for å kappes om samme luke.
+	 */
+	async takeHostSlot(url) {
+		let host;
+		try {
+			host = new URL(url).host;
+		} catch {
+			return 0;
+		}
+
+		const interval = this.hostInterval(host);
+		if (interval <= 0) return 0;
+
+		const state = hostState(host);
+		const now = Date.now();
+		const start = Math.max(now, state.nextSlot);
+		state.nextSlot = start + interval;
+
+		const wait = start - now;
+		if (wait > 0) {
+			this.stats.throttledMs += wait;
+			await this.delay(wait);
+		}
+		return wait;
+	}
+
+	// --- robots.txt ---
+
+	/** Kaster `RobotsDisallowedError` hvis robots.txt forbyr stien. */
+	async assertRobotsAllows(url) {
+		if (!this.respectRobots) return;
+
+		let target;
+		try {
+			target = new URL(url);
+		} catch {
+			return; // ugyldig URL — la HTTP-laget feile på vanlig vis
+		}
+		if (target.protocol !== "https:") return;
+
+		const policy = HOST_POLICY[target.hostname];
+		if (policy?.robotsExempt?.some(pattern => pattern.test(target.pathname))) {
+			const state = hostState(target.host);
+			if (!state.exemptLogged) {
+				state.exemptLogged = true;
+				console.log(`robots: ${target.hostname}${target.pathname} dekkes av kildens egne API-vilkår — ${policy.reason}`);
+			}
+			return;
+		}
+
+		const robots = await this.loadRobots(target);
+		if (!robots || robots.groups.length === 0) return; // fail-open
+
+		const { rules } = rulesForAgent(robots.groups, this.robotsAgent);
+		const verdict = robotsVerdict(rules, `${target.pathname}${target.search}`);
+		if (!verdict.allowed) {
+			this.stats.robotsBlocked++;
+			console.warn(`robots.txt hos ${target.host} forbyr ${target.pathname} (Disallow: ${verdict.rule}) — hopper over`);
+			throw new RobotsDisallowedError(url, verdict.rule);
+		}
+	}
+
+	/** Hent + cache robots.txt per vert. Én henting per vert per prosess. */
+	loadRobots(target) {
+		const state = hostState(target.host);
+		if (state.robots && Date.now() - state.robots.fetchedAt < ROBOTS_TTL_MS) {
+			return Promise.resolve(state.robots);
+		}
+		if (!state.robotsPromise) {
+			state.robotsPromise = this.fetchRobots(target, state).finally(() => {
+				state.robotsPromise = null;
+			});
+		}
+		return state.robotsPromise;
+	}
+
+	async fetchRobots(target, state) {
+		const url = `${target.protocol}//${target.host}/robots.txt`;
+		let groups = [];
+
+		try {
+			// Bevisst UTENOM takt-køen: robots.txt er én liten forespørsel per
+			// vert per prosess, og det er filen som gir oss lov til resten. Å la
+			// den bruke en tidsluke ville forsinket den ekte forespørselen.
+			const response = await this.requestOnce(url, {
+				headers: { Accept: "text/plain" },
+				timeout: this.robotsTimeout
+			});
+			if (response.statusCode >= 200 && response.statusCode < 300 && response.body) {
+				groups = parseRobots(response.body);
+			}
+			// 4xx/5xx (ESPN svarer f.eks. 403 på /robots.txt) → ingen regler → fail-open.
+		} catch (error) {
+			// Nett-feil/timeout skal ALDRI felle pipelinen — vi henter som før.
+			console.warn(`robots.txt kunne ikke hentes fra ${target.host} (${error.message}) — fortsetter`);
+			groups = [];
+		}
+
+		const { crawlDelay } = rulesForAgent(groups, this.robotsAgent);
+		state.crawlDelayMs = crawlDelay ? crawlDelay * 1000 : 0;
+		state.robots = { groups, fetchedAt: Date.now() };
+		return state.robots;
 	}
 
 	delay(ms) {

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -1,0 +1,441 @@
+// api-client.js: høflighetslaget (WP-244) — betingede forespørsler, takt per
+// vert, ærlig User-Agent og robots.txt. Alt nettverk er mocket; ingen test her
+// rører et ekte nett.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+// Fake HTTPS-transport. `vi.hoisted` fordi vi.mock-fabrikken heises over importene.
+const net = vi.hoisted(() => ({ route: null, log: [] }));
+
+vi.mock("https", () => {
+	const get = (url, opts, cb) => {
+		const request = new EventEmitter();
+		request.setTimeout = () => {};
+		request.destroy = () => {};
+		net.log.push({ url, headers: opts.headers || {}, at: Date.now() });
+
+		queueMicrotask(() => {
+			const result = net.route(url, opts);
+			if (!result) {
+				request.emit("error", new Error(`ingen rute for ${url}`));
+				return;
+			}
+			if (result.networkError) {
+				request.emit("error", new Error(result.networkError));
+				return;
+			}
+			const response = new EventEmitter();
+			response.statusCode = result.status ?? 200;
+			response.headers = result.headers ?? {};
+			cb(response);
+			if (result.body) response.emit("data", Buffer.from(result.body));
+			response.emit("end");
+		});
+
+		return request;
+	};
+	return { default: { get }, get };
+});
+
+const {
+	APIClient,
+	RobotsDisallowedError,
+	USER_AGENT,
+	parseRobots,
+	rulesForAgent,
+	robotsVerdict,
+	resetPolitenessState,
+} = await import("../scripts/lib/api-client.js");
+
+/** Sett ruteren: fn(url, opts) → { status, headers, body } | { networkError } */
+function serve(fn) {
+	net.route = fn;
+}
+
+const dataRequests = () => net.log.filter(r => !r.url.endsWith("/robots.txt"));
+const robotsRequests = () => net.log.filter(r => r.url.endsWith("/robots.txt"));
+
+/** Standardrute: robots.txt finnes ikke, alt annet er tom JSON. */
+function serveOpen(extra = {}) {
+	serve((url) => {
+		if (url.endsWith("/robots.txt")) return { status: 404, body: "" };
+		return { status: 200, headers: extra.headers || {}, body: extra.body ?? '{"ok":true}' };
+	});
+}
+
+beforeEach(() => {
+	resetPolitenessState();
+	net.log.length = 0;
+	net.route = () => ({ status: 404, body: "" });
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+	vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+// --- 3. Ærlig User-Agent ------------------------------------------------
+
+describe("User-Agent", () => {
+	it("sender en ærlig, sporbar UA på både data- og robots-forespørsler", async () => {
+		serveOpen();
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		await client.fetchJSON("https://example.test/data.json");
+
+		expect(USER_AGENT).toMatch(/^Sportivista\//);
+		expect(USER_AGENT).toMatch(/https:\/\//); // kontakt-URL, ikke bare et navn
+		for (const request of net.log) {
+			expect(request.headers["User-Agent"]).toBe(USER_AGENT);
+		}
+	});
+
+	it("lar kalleren overstyre UA per forespørsel (fetcher-kontrakten er uendret)", async () => {
+		serveOpen();
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		await client.fetchJSON("https://example.test/data.json", { headers: { "User-Agent": "Egen/1.0" } });
+		expect(dataRequests()[0].headers["User-Agent"]).toBe("Egen/1.0");
+	});
+});
+
+// --- 1. Betingede forespørsler ------------------------------------------
+
+describe("betingede forespørsler", () => {
+	it("sender If-None-Match og gjenbruker cachet svar på 304", async () => {
+		let calls = 0;
+		serve((url, opts) => {
+			if (url.endsWith("/robots.txt")) return { status: 404, body: "" };
+			calls++;
+			if (calls === 1) {
+				return { status: 200, headers: { etag: 'W/"v1"' }, body: '{"n":1}' };
+			}
+			// Betinget: kilden slipper å sende kroppen på nytt.
+			expect(opts.headers["If-None-Match"]).toBe('W/"v1"');
+			return { status: 304, headers: { etag: 'W/"v1"' }, body: "" };
+		});
+
+		const client = new APIClient({ minHostIntervalMs: 0, cacheTimeout: 0 });
+		const first = await client.fetchJSON("https://example.test/data.json");
+		const second = await client.fetchJSON("https://example.test/data.json");
+
+		expect(first).toEqual({ n: 1 });
+		expect(second).toBe(first); // samme objekt ⇒ ingen ny parsing
+		expect(client.stats.notModified).toBe(1);
+		expect(calls).toBe(2);
+	});
+
+	it("sender If-Modified-Since når kilden bare ga Last-Modified", async () => {
+		const lastModified = "Wed, 29 Jul 2026 06:00:00 GMT";
+		let calls = 0;
+		serve((url, opts) => {
+			if (url.endsWith("/robots.txt")) return { status: 404, body: "" };
+			calls++;
+			if (calls === 1) return { status: 200, headers: { "last-modified": lastModified }, body: '{"n":1}' };
+			expect(opts.headers["If-Modified-Since"]).toBe(lastModified);
+			return { status: 304, body: "" };
+		});
+
+		const client = new APIClient({ minHostIntervalMs: 0, cacheTimeout: 0 });
+		await client.fetchJSON("https://example.test/data.json");
+		const second = await client.fetchJSON("https://example.test/data.json");
+		expect(second).toEqual({ n: 1 });
+		expect(client.stats.notModified).toBe(1);
+	});
+
+	it("treffer cachen uten nettverk innenfor cacheTimeout", async () => {
+		serveOpen({ body: '{"n":1}' });
+		const client = new APIClient({ minHostIntervalMs: 0, cacheTimeout: 60000 });
+		await client.fetchJSON("https://example.test/data.json");
+		await client.fetchJSON("https://example.test/data.json");
+		expect(dataRequests()).toHaveLength(1);
+		expect(client.stats.cacheHits).toBe(1);
+	});
+
+	it("faller tilbake på gammelt cachet svar når kilden feiler", async () => {
+		let calls = 0;
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 404, body: "" };
+			calls++;
+			return calls === 1 ? { status: 200, body: '{"n":1}' } : { status: 500, body: "boom" };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0, cacheTimeout: 0, retries: 0 });
+		await client.fetchJSON("https://example.test/data.json");
+		expect(await client.fetchJSON("https://example.test/data.json")).toEqual({ n: 1 });
+	});
+});
+
+// --- 2. Takt per vert ---------------------------------------------------
+
+describe("takt per vert", () => {
+	it("serialiserer parallelle forespørsler til samme vert", async () => {
+		serveOpen();
+		const client = new APIClient({ minHostIntervalMs: 60 });
+
+		await Promise.all([
+			client.fetchJSON("https://example.test/a.json"),
+			client.fetchJSON("https://example.test/b.json"),
+			client.fetchJSON("https://example.test/c.json"),
+		]);
+
+		const times = dataRequests().map(r => r.at);
+		expect(times).toHaveLength(3);
+		expect(times[1] - times[0]).toBeGreaterThanOrEqual(50);
+		expect(times[2] - times[1]).toBeGreaterThanOrEqual(50);
+		expect(client.stats.throttledMs).toBeGreaterThan(0);
+	});
+
+	it("deler takten mellom klient-instanser (fetcherne kjører parallelt)", async () => {
+		serveOpen();
+		const a = new APIClient({ minHostIntervalMs: 60 });
+		const b = new APIClient({ minHostIntervalMs: 60 });
+
+		await Promise.all([
+			a.fetchJSON("https://example.test/a.json"),
+			b.fetchJSON("https://example.test/b.json"),
+		]);
+
+		const times = dataRequests().map(r => r.at);
+		expect(times[1] - times[0]).toBeGreaterThanOrEqual(50);
+	});
+
+	it("køer ikke ulike verter bak hverandre", async () => {
+		serveOpen();
+		const client = new APIClient({ minHostIntervalMs: 400 });
+		const started = Date.now();
+		await Promise.all([
+			client.fetchJSON("https://en.test/a.json"),
+			client.fetchJSON("https://to.test/a.json"),
+		]);
+		expect(Date.now() - started).toBeLessThan(300);
+	});
+
+	it("lar takten settes per vert", async () => {
+		serveOpen();
+		const client = new APIClient({ minHostIntervalMs: 0, hostIntervals: { "treg.test": 60 } });
+		await client.fetchJSON("https://treg.test/a.json");
+		await client.fetchJSON("https://treg.test/b.json");
+		const times = dataRequests().map(r => r.at);
+		expect(times[1] - times[0]).toBeGreaterThanOrEqual(50);
+	});
+
+	it("hever takten når robots.txt oppgir Crawl-delay", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nCrawl-delay: 0.06\n" };
+			return { status: 200, body: "{}" };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		await client.fetchJSON("https://example.test/a.json");
+		await client.fetchJSON("https://example.test/b.json");
+		const times = dataRequests().map(r => r.at);
+		expect(times[1] - times[0]).toBeGreaterThanOrEqual(50);
+	});
+});
+
+// --- 4. robots.txt ------------------------------------------------------
+
+describe("robots.txt", () => {
+	it("blokkerer en sti som er Disallow-et, uten å sende forespørselen", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nDisallow: /privat/\n" };
+			return { status: 200, body: "{}" };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+
+		await expect(client.fetchJSON("https://example.test/privat/data.json")).rejects.toBeInstanceOf(RobotsDisallowedError);
+		expect(dataRequests()).toHaveLength(0);
+		expect(client.stats.robotsBlocked).toBe(1);
+	});
+
+	it("slipper gjennom stier som ikke er blokkert", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nDisallow: /privat/\n" };
+			return { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		expect(await client.fetchJSON("https://example.test/apent/data.json")).toEqual({ ok: true });
+	});
+
+	it("gir ikke gammelt cachet innhold når robots blokkerer", async () => {
+		let robots = "User-agent: *\nDisallow:\n";
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: robots };
+			return { status: 200, body: '{"n":1}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0, cacheTimeout: 0 });
+		await client.fetchJSON("https://example.test/data.json");
+
+		resetPolitenessState(); // kilden endrer robots.txt
+		robots = "User-agent: *\nDisallow: /data.json\n";
+		await expect(client.fetchJSON("https://example.test/data.json")).rejects.toBeInstanceOf(RobotsDisallowedError);
+	});
+
+	it("fail-open når robots.txt feiler på nettverket", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { networkError: "ECONNRESET" };
+			return { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		expect(await client.fetchJSON("https://example.test/data.json")).toEqual({ ok: true });
+	});
+
+	it("fail-open når robots.txt svarer 403 (som ESPN gjør)", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 403, body: "<html>403</html>" };
+			return { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		expect(await client.fetchJSON("https://site.api.espn.test/scoreboard")).toEqual({ ok: true });
+	});
+
+	it("henter robots.txt bare én gang per vert, også ved parallelle kall", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nDisallow:\n" };
+			return { status: 200, body: "{}" };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0 });
+		await Promise.all([
+			client.fetchJSON("https://example.test/a.json"),
+			client.fetchJSON("https://example.test/b.json"),
+		]);
+		await client.fetchJSON("https://example.test/c.json");
+		expect(robotsRequests()).toHaveLength(1);
+	});
+
+	it("kan slås av eksplisitt", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nDisallow: /\n" };
+			return { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0, respectRobots: false });
+		expect(await client.fetchJSON("https://example.test/data.json")).toEqual({ ok: true });
+		expect(robotsRequests()).toHaveLength(0);
+	});
+});
+
+// --- Kildenes egne API-vilkår ------------------------------------------
+
+describe("dokumenterte API-vilkår slår crawler-robots", () => {
+	it("henter Liquipedias api.php selv om robots.txt Disallow-er den for crawlere", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 200, body: "User-agent: *\nDisallow: /counterstrike/api.php\n" };
+			return { status: 200, body: '{"parse":{}}' };
+		});
+		const client = new APIClient();
+		const data = await client.fetchJSON("https://liquipedia.net/counterstrike/api.php?action=parse&page=Liquipedia:Matches");
+		expect(data).toEqual({ parse: {} });
+		expect(client.stats.robotsBlocked).toBe(0);
+	});
+
+	it("henter Lichess' /api/ selv om robots.txt Disallow-er den for crawlere", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) {
+				return { status: 200, body: "User-agent: *\nAllow: /\nDisallow: /api/\nDisallow: /study/search\n" };
+			}
+			return { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient();
+		expect(await client.fetchJSON("https://lichess.org/api/broadcast/top")).toEqual({ ok: true });
+	});
+
+	it("unntaket gjelder bare de dokumenterte stiene — resten av verten er fortsatt bundet", async () => {
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) {
+				return { status: 200, body: "User-agent: *\nAllow: /\nDisallow: /api/\nDisallow: /study/search\n" };
+			}
+			return { status: 200, body: "{}" };
+		});
+		const client = new APIClient();
+		await expect(client.fetchJSON("https://lichess.org/study/search?q=x")).rejects.toBeInstanceOf(RobotsDisallowedError);
+	});
+});
+
+// --- robots-parsing (ren logikk) ---------------------------------------
+
+describe("parseRobots / rulesForAgent / robotsVerdict", () => {
+	const ROBOTS = `# kommentar
+User-agent: GPTBot
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: *
+Allow: /
+Disallow: /privat/
+Disallow: /*.pdf$
+Crawl-delay: 2
+
+User-agent: Sportivista
+Disallow: /bare-for-oss/
+`;
+
+	it("grupperer sammenhengende User-agent-linjer og leser Crawl-delay", () => {
+		const groups = parseRobots(ROBOTS);
+		expect(groups).toHaveLength(3);
+		expect(groups[0].agents).toEqual(["gptbot", "claudebot"]);
+		expect(groups[1].crawlDelay).toBe(2);
+	});
+
+	it("velger vår egen gruppe når den finnes, ellers *", () => {
+		const groups = parseRobots(ROBOTS);
+		expect(rulesForAgent(groups, "Sportivista").rules).toEqual([{ allow: false, path: "/bare-for-oss/" }]);
+		expect(rulesForAgent(groups, "AnnenLeser").rules.map(r => r.path)).toEqual(["/", "/privat/", "/*.pdf$"]);
+	});
+
+	it("arver ikke reglene til bots vi ikke er", () => {
+		const groups = parseRobots(ROBOTS);
+		const { rules } = rulesForAgent(groups, "Sportivista");
+		expect(robotsVerdict(rules, "/hva-som-helst").allowed).toBe(true);
+	});
+
+	it("lar lengste treff vinne, og Allow vinne ved lik lengde", () => {
+		const rules = [
+			{ allow: true, path: "/" },
+			{ allow: false, path: "/api/" },
+			{ allow: true, path: "/api/offentlig/" },
+		];
+		expect(robotsVerdict(rules, "/api/data").allowed).toBe(false);
+		expect(robotsVerdict(rules, "/api/offentlig/data").allowed).toBe(true);
+		expect(robotsVerdict(rules, "/annet").allowed).toBe(true);
+		expect(robotsVerdict([{ allow: true, path: "/x" }, { allow: false, path: "/x" }], "/x").allowed).toBe(true);
+	});
+
+	it("støtter * og $ i mønstre", () => {
+		const { rules } = rulesForAgent(parseRobots(ROBOTS), "AnnenLeser");
+		expect(robotsVerdict(rules, "/doc/rapport.pdf").allowed).toBe(false);
+		expect(robotsVerdict(rules, "/doc/rapport.pdf?v=2").allowed).toBe(true); // $ = slutt
+	});
+
+	it("tolker tom Disallow som «alt tillatt»", () => {
+		const { rules } = rulesForAgent(parseRobots("User-agent: *\nDisallow:\n"), "Sportivista");
+		expect(robotsVerdict(rules, "/hva-som-helst").allowed).toBe(true);
+	});
+
+	it("tåler tomt/ugyldig innhold", () => {
+		expect(parseRobots("")).toEqual([]);
+		expect(parseRobots(null)).toEqual([]);
+		expect(parseRobots("Disallow: /uten-agent\n")).toEqual([]);
+	});
+});
+
+// --- uendret grunnatferd ------------------------------------------------
+
+describe("retry og feilhåndtering (uendret kontrakt)", () => {
+	it("prøver på nytt ved 5xx og lykkes", async () => {
+		let calls = 0;
+		serve((url) => {
+			if (url.endsWith("/robots.txt")) return { status: 404, body: "" };
+			calls++;
+			return calls === 1 ? { status: 503, body: "nei" } : { status: 200, body: '{"ok":true}' };
+		});
+		const client = new APIClient({ minHostIntervalMs: 0, retries: 1, retryDelay: 1 });
+		expect(await client.fetchJSON("https://example.test/data.json")).toEqual({ ok: true });
+		expect(calls).toBe(2);
+	});
+
+	it("kaster på ugyldig JSON", async () => {
+		serve((url) => (url.endsWith("/robots.txt") ? { status: 404, body: "" } : { status: 200, body: "ikke json" }));
+		const client = new APIClient({ minHostIntervalMs: 0, retries: 0 });
+		await expect(client.fetchJSON("https://example.test/data.json")).rejects.toThrow(/Invalid JSON/);
+	});
+
+	it("kaster på 4xx", async () => {
+		serve((url) => (url.endsWith("/robots.txt") ? { status: 404, body: "" } : { status: 404, body: "borte" }));
+		const client = new APIClient({ minHostIntervalMs: 0, retries: 0 });
+		await expect(client.fetchJSON("https://example.test/data.json")).rejects.toThrow(/HTTP 404/);
+	});
+});


### PR DESCRIPTION
## Hva

`scripts/lib/api-client.js` oppfører seg nå som en **veloppdragen, identifiserbar leser** i stedet for en anonym skraper. Bygget videre på det som allerede fantes (`this.cache`, retry med backoff, `delay`) — ingen omskriving fra bunnen.

### 1. Betingede forespørsler
`ETag` / `Last-Modified` lagres på cache-oppføringen per URL og sendes tilbake som `If-None-Match` / `If-Modified-Since`. Et `304 Not Modified` returnerer **samme objekt** fra cachen — ingen ny nedlasting, ingen ny parsing (testen sammenligner med `toBe`, ikke `toEqual`). Cache-oppføringen overlever `cacheTimeout`, så en utløpt oppføring revalideres i stedet for å hentes på nytt.

### 2. Takt per vert
Håndheves nå **inne i klienten**, ikke av fetcherne, og deles på tvers av alle `APIClient`-instanser i prosessen. Det siste er poenget: `scripts/fetch/index.js` kjører alle fetcherne i `Promise.allSettled`, og hver `BaseFetcher` lager sin egen klient — per-instans-takt ville ikke hindret at fire fetchere hamret ESPN samtidig. Tidsluken reserveres synkront (ingen `await` før `nextSlot` settes), så parallelle kall køes riktig i stedet for å kappes om samme luke.

Default 250 ms, overstyrbar per vert (`hostIntervals`), og **hevet automatisk av `Crawl-delay`** i vertens robots.txt. Den eksisterende `delay(150)` i espn-adapteren er urørt — den komponerer bare med taktvakten.

### 3. Ærlig User-Agent
`Sportivista/2.0 (+https://sportivista.com; kontakt: https://github.com/CHaerem/sportivista/issues)` — navngir prosjektet og gir en kontaktvei som faktisk går til et menneske. Før: `SportSync/2.0`, uten kontakt.

### 4. robots.txt
Hentes og caches per vert (én henting per vert per prosess, også ved parallelle kall), `Disallow` respekteres for stiene vi faktisk henter. Egen parser med gruppering av sammenhengende `User-agent`-linjer, lengste-treff-vinner, `Allow` vinner ved lik lengde, og `*`/`$` i mønstre. Blokkering logges og kaster `RobotsDisallowedError` — som bevisst **ikke** faller tilbake på gammelt cachet innhold, så et avslag er entydig.

**Fail-open overalt:** nettverksfeil, timeout, 403/404 på robots.txt, tomt innhold → vi henter som før. robots skal aldri felle pipelinen. robots.txt-hentingen går bevisst utenom taktkøen (én liten forespørsel per vert, og det er filen som gir oss lov til resten).

## Det overraskende funnet

To av kildene vi allerede henter fra **forbyr stien vår i robots.txt**:

- `lichess.org/robots.txt` → `Disallow: /api/` — sjakk-fetcheren henter `/api/broadcast/top`
- `liquipedia.net/robots.txt` → `Disallow: /counterstrike/api.php` — esports-fetcheren (100 Thieves) henter nettopp den

Naiv håndheving ville altså **slått ut sjakk og CS2** i samme slengen. Begge kildene driver samtidig et offentlig, dokumentert API på nøyaktig den stien: [Liquipedias API-vilkår](https://liquipedia.net/api-terms-of-use) beskriver eksplisitt hvordan `action=parse` skal brukes (≤ 1 req / 30 s, egen UA med kontaktinfo, gzip), og [Lichess' API](https://lichess.org/api) er laget for programmatisk bruk. robots.txt regulerer crawlere; et publisert API regulerer API-klienter — og vi er det siste.

Løsningen er en liten, sitert `HOST_POLICY`-tabell i fila: unntaket er **sti-avgrenset** (regex, ikke hele verten — `lichess.org/study/search` er fortsatt blokkert, det finnes en test på det), logges én gang per kjøring, og **betales med kildens egen, strengere takt** (Liquipedia 30 s, Lichess 1 s). Begge fetcherne gjør én forespørsel per kjøring, så taktkostnaden er null i praksis. Netto er vi *mer* høflige mot disse to enn før, ikke mindre.

ESPN-vertene svarer `403` på `/robots.txt` → fail-open, uendret oppførsel.

## Tester

`tests/api-client.test.js` — 31 nye tester, alle nettverksfrie (`https` mocket via `vi.mock` + `vi.hoisted`, samme ånd som `llm-client.test.js`): 304 gir cachet svar uten reparsing, `If-Modified-Since`-varianten, takt per vert (også delt mellom instanser, og at ulike verter ikke køes), Crawl-delay hever takten, robots-Disallow blokkerer uten å sende forespørselen, fail-open ved nettverksfeil og ved 403, robots hentes én gang per vert, UA sendes (og kan overstyres per kall), API-vilkår-unntaket og dets sti-avgrensning, samt ren-logikk-tester av parser/verdict. Retry-, stale-cache- og feilkontraktene er dekket som regresjonsvern.

## Verifisering

- `npx vitest run --maxWorkers=1` → **75 filer / 1250 tester grønne**
- `node scripts/fetch/index.js` → kjørte på **20,5 s** og produserte data (golf/f1/tennis/chess/cycling friske; football og esports «retained last good» — det er kronisk og eldre enn denne branchen, `consecutiveRetains: 140` siden 19.07, ikke noe denne endringen forårsaker)
- `node scripts/build-events.js && node scripts/validate-events.js` → **73 events, 0 errors**
- **Ingen fetcher-fil endret** — `fetchJSON`-kontrakten er identisk

## Kjente begrensninger (bevisst utenfor scope)

- Betinget revalidering er **in-memory per prosess**. Ekte besparelse på tvers av kjøringer krever et lagret validator-lager (f.eks. `actions/cache` i workflowen) — `.github/workflows/**` er beskyttet sti, så det er ikke gjort her.
- Esports-fetcheren sender sin egen UA (`SportSync/2.0 (https://github.com; …)`) med en kontakt-URL som ikke peker noe sted. Den ligger i en fetcher-fil, som er ikke-mål her — bør ryddes separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
