### PR TITLE
WP-246: kanalen skal peke på kampen, ikke på forsiden

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -245,6 +245,12 @@ Native `List`, inset-gruppert per dag. Bindende semantikk (uendret fra v2):
   oppdatering (kadens 60 s). Spoilervern vinner: en skjermet entitet/sport får
   ALDRI stillingen påtvunget (`spoilerSafe`), akkurat som RESULTAT i detaljarket.
 - **Kanal:** `secondaryLabel` i meta-linjen; ukjent = «–». Krymper aldri tittelen.
+  **Lenkeløftet (WP-246):** kanalNAVNET er alltid sant og vises alltid, men bare en
+  URL som peker på selve sendingen (`urlKind: "deep"`) får se ut som en lenke. En
+  forside/seksjon (`urlKind: "landing"`) vises som ren tekst — ingen understrek,
+  ingen tapp, ingen varselikon; detaljarket sier stille «(ingen direkte lenke)».
+  En forside som utgir seg for å være svaret på «hvor ser jeg det» er et brudd på
+  Grunnlov 3.
 - **Varsel:** `bell.fill` (amber) trailing KUN når raden armerer en påminnelse.
 - **AI-funn:** `info.circle` trailing; tapp på raden åpner detalj med kilder.
 - **Disclosure:** native chevron (`List` gir den) — trykkbarhet er tydelig,

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -343,11 +343,16 @@ class Dashboard {
 		return `<span class="ev-meta">${parts.join('<span class="ev-sep"> · </span>')}</span>`;
 	}
 
-	/** A channel is tappable when it has a URL — but a TENTATIVE (shared-rights)
-	 *  entry only links to a tvkampen match GUIDE, never to one broadcaster (which
-	 *  would mislead when it might be the other). */
+	/** A channel is tappable when its URL points at the BROADCAST — but a TENTATIVE
+	 *  (shared-rights) entry only links to a tvkampen match GUIDE, never to one
+	 *  broadcaster (which would mislead when it might be the other).
+	 *  WP-246: a `landing` URL (the service's front page / sport section) is not an
+	 *  answer to «hvor ser jeg det» — it is the rights map wearing a link's clothes.
+	 *  The channel NAME stays (it is true and useful); the link goes. Entries without
+	 *  `urlKind` (older payloads) keep the previous behaviour. */
 	streamLink(s) {
-		return !!(s && s.url && (!s.tentative || /tvkampen\.com/.test(s.url)));
+		if (!s || !s.url || s.urlKind === 'landing') return false;
+		return !s.tentative || /tvkampen\.com/.test(s.url);
 	}
 
 	/** Where to watch — quiet, honest. First 1–2 Norwegian channels; faint dash if unknown. */
@@ -357,8 +362,11 @@ class Dashboard {
 		const s = streams[0];
 		const p = escapeHtml(String(s.platform || s));
 		const extra = streams.length > 1 ? `<span class="ev-where-more">+${streams.length - 1}</span>` : '';
-		// Tentative (shared rights, exact channel not yet confirmed) → plain text,
-		// no link — linking to one broadcaster when it may be the other misleads.
+		// Plain text — no link — whenever the URL isn't the broadcast: a tentative
+		// (shared rights, exact channel not yet confirmed) entry, or a `landing` URL
+		// that would drop you on a service front page (WP-246). The name is still the
+		// answer to «hvor», so it stays; the absent dotted underline (.ev-where a) is
+		// the whole signal that there is nothing to tap. No icon, no badge.
 		const inner = this.streamLink(s) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : p;
 		const cls = s.tentative ? 'ev-where tentative' : 'ev-where';
 		return `<span class="${cls}">${inner}${extra}</span>`;

--- a/docs/js/detail.js
+++ b/docs/js/detail.js
@@ -127,10 +127,18 @@ Object.assign(window.Dashboard.prototype, {
 
 		const streams = Array.isArray(e.streaming) ? e.streaming : [];
 		if (streams.length) {
+			// The sheet has room to say WHY a channel isn't a link, so it does — quietly,
+			// in the muted .tbd voice already used for «(bekreftes)». WP-246: a `landing`
+			// URL points at TV 2 Play / Viaplay's front page, not at this broadcast, so we
+			// name the channel and admit the missing link instead of dressing a rights map
+			// up as an answer. No warning icon — DESIGN § Grunnlov 3 ("Ærlig innhold"),
+			// § Stemme ("Kanal ukjent", ikke "Ingen streaming!").
 			const chans = streams.map((s) => {
 				const p = escapeHtml(String(s.platform || s));
-				const label = s.tentative ? `${p} <span class="tbd">(bekreftes)</span>` : p;
-				return this.streamLink(s) ? `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>` : label;
+				if (this.streamLink(s)) return `<a href="${escapeHtml(s.url)}" target="_blank" rel="noopener">${p}</a>`;
+				if (s.tentative) return `${p} <span class="tbd">(bekreftes)</span>`;
+				if (s.urlKind === 'landing') return `${p} <span class="tbd">(ingen direkte lenke)</span>`;
+				return p;
 			}).join(' · ');
 			add('Se på', chans);
 		}

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, configDirPath, MS_PER_DAY, makeCoverageGate, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
-import { resolveStreaming } from "./lib/norwegian-rights.js";
+import { resolveStreaming, stampUrlKinds } from "./lib/norwegian-rights.js";
 import { writeManifest } from "./build-manifest.js";
 import { writePortReport } from "./build-port-report.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
@@ -476,6 +476,9 @@ function withDeepUrls(streaming, prevStreaming) {
 // rewritten, so a deeper per-event URL is never downgraded. Catches agent-set
 // URLs that bypass the rights map (e.g. a verified WC channel written as
 // "https://tv.nrk.no").
+// WP-246: BOTH sides of this table are `urlKind: "landing"` — the rewrite makes a
+// front page slightly less useless, it does NOT make it an answer to "hvor ser jeg
+// det". The clients refuse to link either as the match; only a `deep` URL is a link.
 const LANDING_UPGRADE = {
 	"https://tv.nrk.no": "https://tv.nrk.no/direkte",
 	"https://play.tv2.no": "https://play.tv2.no/sport",
@@ -528,7 +531,11 @@ for (const e of all) {
 	}
 	// Upgrade generic landing URLs to a deeper per-event URL we already knew,
 	// then lift any bare homepage to the broadcaster's sport/live section.
-	e.streaming = upgradeLanding(withDeepUrls(e.streaming, prevStreamingByKey.get(key)));
+	// stampUrlKinds LAST and unconditionally (WP-246): every rewrite above can
+	// change a URL, and `urlKind` must describe the URL that actually ships —
+	// including on preserved ai-research events whose channel came from an agent
+	// and never went through the rights map.
+	e.streaming = stampUrlKinds(upgradeLanding(withDeepUrls(e.streaming, prevStreamingByKey.get(key))));
 	if (e.sport === "football" && e.streaming !== before && e.streaming.length && tvListings.length) {
 		// count football events whose channel came from a real listing match
 		fromTv++;

--- a/scripts/config/events.schema.json
+++ b/scripts/config/events.schema.json
@@ -168,12 +168,16 @@
 	},
 	"definitions": {
 		"streamingChannel": {
-			"description": "Én visningsmulighet. platform/url er kjernefeltene; tentative markerer et uverifisert kanalgjett (f.eks. det delte \"NRK / TV 2\"-gjettet før verify løser det).",
+			"description": "Én visningsmulighet. platform/url er kjernefeltene; tentative markerer et uverifisert kanalgjett (f.eks. det delte \"NRK / TV 2\"-gjettet før verify løser det); urlKind sier hva slags URL det er (WP-246).",
 			"type": "object",
 			"properties": {
 				"platform": { "type": "string" },
 				"url": { "anyOf": [{ "type": "string" }, { "enum": [null] }] },
-				"tentative": { "type": "boolean" }
+				"tentative": { "type": "boolean" },
+				"urlKind": {
+					"enum": ["deep", "landing"],
+					"description": "WP-246 — hva URL-en faktisk peker på: \"deep\" = selve sendingen/kampen/streamen, \"landing\" = tjenestens forside eller en generisk seksjon (sport/direkte/språkkode). Settes deterministisk av classifyStreamingUrl() (scripts/lib/norwegian-rights.js) og stemples sist i build-events.js, så etiketten aldri kan drifte fra URL-en. Feltet er VALGFRITT: en oppføring uten URL (eller en URL vi ikke kan parse) har det ikke, og eldre publiserte events uten feltet forblir gyldige — klientene faller da tilbake til gammel oppførsel. Kontrakten: kun \"deep\" får presenteres som en lenke til sendingen; \"landing\" viser kanalNAVNET (som er sant og nyttig) uten lenke."
+				}
 			}
 		},
 		"norwegianPlayer": {

--- a/scripts/lib/norwegian-rights.js
+++ b/scripts/lib/norwegian-rights.js
@@ -3,17 +3,99 @@
 // broadcaster like FOX/ESPN. The verify agent refines per-event on top of this;
 // this guarantees a correct default. Mirrors .claude/skills/norwegian-rights.
 
+// ── Link honesty (WP-246): deep vs. landing ─────────────────────────────────
+//
+// A channel NAME ("TV 2 Play") is real, useful information. A channel URL that
+// points at TV 2 Play's sport section is NOT an answer to "hvor ser jeg det" —
+// it is the rights map wearing a link's clothes. Every streaming entry therefore
+// declares what KIND of URL it carries, so the clients can show the name without
+// dressing a front page up as a link to the broadcast:
+//
+//   "deep"    – points at the actual broadcast/match/stream page
+//   "landing" – the service's front page or a generic section (sport/live/locale)
+//   (absent)  – no URL at all, or a URL we can't parse
+//
+// Nothing here invents deep links; finding them per event is the research/verify
+// agents' job. This only makes the difference visible and countable.
+
+// Path segments that never identify a single broadcast: locale codes, a service's
+// own section navigation, and plain sport names. A URL whose ENTIRE path is built
+// from these is a landing page no matter which service it belongs to.
+const GENERIC_SEGMENTS = new Set([
+	// locale / site chrome
+	"no", "nb", "en", "no-no", "nb-no", "en-no", "nn-no",
+	// section navigation
+	"sport", "sports", "sporten", "direkte", "live", "tv", "kanal", "kanaler",
+	"stream", "streaming", "watch", "se", "channel", "channels", "home", "start",
+	// sport sections
+	"fotball", "football", "soccer", "golf", "pga-tour", "pgatour", "tennis",
+	"sykkel", "cycling", "ski", "langrenn", "skiskyting", "biathlon", "friidrett",
+	"athletics", "handball", "håndball", "ishockey", "hockey", "motorsport",
+	"formel-1", "formula-1", "f1", "sjakk", "chess", "esport", "esports",
+]);
+
+/**
+ * Classify a viewing URL: "deep" (the broadcast itself), "landing" (a service
+ * front page / generic section), or "" when there is nothing to classify.
+ * @param {string} url
+ * @returns {"deep"|"landing"|""}
+ */
+export function classifyStreamingUrl(url) {
+	const raw = String(url || "").trim();
+	if (!raw) return "";
+	let parsed;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		return ""; // unparseable — say nothing rather than guess
+	}
+	let segments;
+	try {
+		segments = parsed.pathname.split("/").filter(Boolean).map((s) => decodeURIComponent(s).toLowerCase());
+	} catch {
+		segments = parsed.pathname.split("/").filter(Boolean).map((s) => s.toLowerCase());
+	}
+	if (!segments.length) return "landing"; // bare origin — never a broadcast
+	if (segments.every((s) => GENERIC_SEGMENTS.has(s))) return "landing";
+	return "deep";
+}
+
+/** Stamp `urlKind` on one streaming entry (objects only; strings pass through). */
+function withUrlKind(c) {
+	if (!c || typeof c !== "object") return c;
+	const kind = classifyStreamingUrl(c.url);
+	if (!kind) {
+		if (!("urlKind" in c)) return c;
+		const { urlKind, ...rest } = c; // eslint-disable-line no-unused-vars
+		return rest; // a URL was removed — don't keep a stale claim
+	}
+	return c.urlKind === kind ? c : { ...c, urlKind: kind };
+}
+
+/**
+ * Stamp `urlKind` on every entry of a streaming array. Idempotent, and the single
+ * choke point callers use after rewriting URLs (see build-events.js) so the label
+ * can never drift from the URL it describes.
+ */
+export function stampUrlKinds(streaming) {
+	if (!Array.isArray(streaming)) return streaming;
+	return streaming.map(withUrlKind);
+}
+
 // Fallback landing URLs — the sport/live section, not the bare homepage, so a tap
 // lands closer to the broadcast and is likelier to be claimed by the app's
 // universal links (deep per-event URLs from the verify agent override these).
+// They are stamped `urlKind: "landing"` at construction: honest by default, and
+// the clients refuse to present them as a link to the match (WP-246).
+const ch = (platform, url, extra) => withUrlKind({ platform, url, ...(extra || {}) });
 const CH = {
-	viaplay: { platform: "Viaplay", url: "https://viaplay.no/no-no/sport" },
-	tv2: { platform: "TV 2 Play", url: "https://play.tv2.no/sport" },
-	nrk: { platform: "NRK", url: "https://tv.nrk.no/direkte" },
-	discovery: { platform: "Discovery+", url: "https://www.discoveryplus.no" },
-	eurosport: { platform: "Eurosport", url: "https://www.eurosport.no" },
-	hbomax: { platform: "HBO Max (Sport)", url: "https://www.hbomax.com/no/no/sports/pga-tour" },
-	max: { platform: "Max", url: "https://www.max.com" },
+	viaplay: ch("Viaplay", "https://viaplay.no/no-no/sport"),
+	tv2: ch("TV 2 Play", "https://play.tv2.no/sport"),
+	nrk: ch("NRK", "https://tv.nrk.no/direkte"),
+	discovery: ch("Discovery+", "https://www.discoveryplus.no"),
+	eurosport: ch("Eurosport", "https://www.eurosport.no"),
+	hbomax: ch("HBO Max (Sport)", "https://www.hbomax.com/no/no/sports/pga-tour"),
+	max: ch("Max", "https://www.max.com"),
 };
 
 // Anything matching this is a Norwegian service we can trust to keep as-is.
@@ -67,7 +149,7 @@ function isWorldCup(ev) {
 // Norwegian WC 2026 rights are shared by NRK + TV 2 ONLY. When we can't confirm
 // which of the two carries a specific match, this single tentative label is more
 // honest (and calmer) than two chips that read as "airs on both".
-const WC_SHARED = { platform: "NRK / TV 2", url: "https://tv.nrk.no", tentative: true };
+const WC_SHARED = ch("NRK / TV 2", "https://tv.nrk.no", { tentative: true });
 
 /** The confident Norwegian rights for an event, or [] when we shouldn't guess. */
 export function norwegianRights(ev) {
@@ -133,10 +215,10 @@ export function normalizeStreaming(ev) {
 	// esports and chess are watched on event-specific free streams (BLAST.tv /
 	// Twitch / YouTube; Lichess / Chess.com / Direktesport), not Norwegian TV —
 	// keep whatever the event/researcher supplied rather than forcing a channel.
-	if (sport === "esports" || sport === "chess") return ev.streaming || [];
+	if (sport === "esports" || sport === "chess") return stampUrlKinds(ev.streaming || []);
 	const mapped = norwegianRights(ev);
-	if (mapped.length) return mapped;
-	return (ev.streaming || []).filter((s) => NORWEGIAN_RE.test(s.platform || s));
+	if (mapped.length) return stampUrlKinds(mapped);
+	return stampUrlKinds((ev.streaming || []).filter((s) => NORWEGIAN_RE.test(s.platform || s)));
 }
 
 // ── Real Norwegian TV listings (tvkampen.com) — actual data over the static map ──
@@ -188,7 +270,7 @@ function listingStreaming(listing) {
 		const key = name.toLowerCase();
 		if (seen.has(key)) continue;
 		seen.add(key);
-		out.push({ platform: name, url: urlForChannel(name) });
+		out.push(withUrlKind({ platform: name, url: urlForChannel(name) }));
 	}
 	// tvkampen pads most listings with generic aggregators (Viaplay/Eurosport/MAX)
 	// after the real broadcaster(s), which are listed primary-first. Keep the calm
@@ -239,15 +321,15 @@ export function resolveStreaming(ev, tvListings) {
 				if (listing.url) {
 					s = s.map((c) => {
 						const isNrk = /nrk/i.test(c.platform || "") || /tv\.nrk\.no/.test(c.url || "");
-						return isNrk ? c : { ...c, url: listing.url };
+						return isNrk ? c : withUrlKind({ ...c, url: listing.url });
 					});
 				}
-				return s;
+				return stampUrlKinds(s);
 			}
 			// Listing exists but no confirmable Norwegian rights holder (e.g. only
 			// SVT): still offer the match's tvkampen page as a linkable guide so the
 			// user can at least see when & on which channel it airs.
-			if (isWorldCup(ev) && listing.url) return [{ ...WC_SHARED, url: listing.url }];
+			if (isWorldCup(ev) && listing.url) return [withUrlKind({ ...WC_SHARED, url: listing.url })];
 		}
 	}
 	return normalizeStreaming(ev);

--- a/scripts/validate-events.js
+++ b/scripts/validate-events.js
@@ -24,7 +24,7 @@ export function loadEventSchema() {
  * degraded instead of freezing the whole hourly pipeline (see build-events.js
  * for the retain-previous-good-data + build-alert.json behaviour).
  *
- * Returns { errors, streamingMissing, enrichedCount, messages } — `errors` is
+ * Returns { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages } — `errors` is
  * the hard-error count (a caller treats > 0 as "do not publish this array");
  * `messages` are the human-readable warn/violation lines, in the same wording
  * this script has always printed.
@@ -33,6 +33,7 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 	const messages = [];
 	let errors = 0;
 	let streamingMissing = 0;
+	let streamingLandingOnly = 0;
 	const cutoff = now - GRACE_WINDOW_MS; // allow tiny grace window
 	const seenKeys = new Set();
 	for (const ev of events) {
@@ -100,6 +101,17 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 				}
 			}
 		}
+		// Link-honesty signal (soft, WP-246): a near-term event whose ONLY viewing URL
+		// is a service landing page (front page / sport section) does not answer "hvor
+		// ser jeg det" — the channel name is right, but the link is the rights map, not
+		// the broadcast. Counted for EVERY source (not just ai-research: the static
+		// pipeline's rights map is where most of these come from) so the gap the
+		// research/verify agents must close is measurable instead of invisible.
+		// Warning only — a landing URL is honest once it is labelled, just not useful.
+		if (!Number.isNaN(ts) && ts > now - 4 * 60 * 60 * 1000 && ts < now + 7 * 24 * 60 * 60 * 1000) {
+			const kinds = (Array.isArray(ev.streaming) ? ev.streaming : []).map((s) => s && s.urlKind);
+			if (kinds.includes("landing") && !kinds.includes("deep")) streamingLandingOnly++;
+		}
 		// Formal schema check (scripts/config/events.schema.json) — catches shape
 		// drift (wrong types, bad enums) that the ad-hoc checks above don't cover.
 		const schemaErrors = validateAgainstSchema(ev, eventSchema, eventSchema);
@@ -119,7 +131,7 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 		}
 	}
 	const enrichedCount = events.filter((e) => e.importance != null).length;
-	return { errors, streamingMissing, enrichedCount, messages };
+	return { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages };
 }
 
 function main() {
@@ -143,10 +155,13 @@ function main() {
 		process.exit(1);
 	}
 
-	const { errors, streamingMissing, enrichedCount, messages } = validateEvents(events, eventSchema);
+	const { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages } = validateEvents(events, eventSchema);
 	for (const m of messages) console.warn(m);
 	if (streamingMissing > 0) {
 		console.warn(`Streaming info missing on ${streamingMissing} near-term AI-research event(s) — "hvor kan jeg se det" unanswered.`);
+	}
+	if (streamingLandingOnly > 0) {
+		console.warn(`Landing-page-only channel URL on ${streamingLandingOnly} near-term event(s) — the channel name is right, but the link points at a service front page, not the broadcast (WP-246).`);
 	}
 	console.log(`Validated ${events.length} events with ${errors} error(s). ${enrichedCount} enriched.`);
 	if (errors) process.exit(1);

--- a/tests/build-events.test.js
+++ b/tests/build-events.test.js
@@ -262,8 +262,9 @@ describe("build-events", () => {
 		const events = runBuild();
 		const match = events.find((e) => e.title === "Brazil vs Norway");
 		// Confirmed NRK is kept (not downgraded to the tentative NRK/TV 2 guess);
-		// the bare homepage is lifted to NRK's live section.
-		expect(match.streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no/direkte" }]);
+		// the bare homepage is lifted to NRK's live section — which is still only a
+		// LANDING page, and WP-246 says so on the entry itself.
+		expect(match.streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no/direkte", urlKind: "landing" }]);
 		expect(match.streaming.some((s) => s.tentative)).toBe(false);
 	});
 
@@ -337,14 +338,14 @@ describe("build-events", () => {
 		// WP-05: "Casper Ruud" is a real tracked athlete entity (sport tennis), so
 		// the enrichment pass stamps entityId — expected, not a regression.
 		expect(gstaad[0].norwegianPlayers).toEqual([{ name: "Casper Ruud", entityId: "casper-ruud" }]);
-		expect(gstaad[0].streaming).toEqual([{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" }]);
+		expect(gstaad[0].streaming).toEqual([{ platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" }]);
 		// And it must PERSIST: the next rebuild re-fetches the bare stub, so the
 		// grafted enrichment has to carry forward or the event vanishes an hour later.
 		const rebuilt = runBuild().filter((e) => /gstaad/i.test(e.title));
 		expect(rebuilt).toHaveLength(1);
 		expect(rebuilt[0].norwegian).toBe(true);
 		expect(rebuilt[0].norwegianPlayers).toEqual([{ name: "Casper Ruud", entityId: "casper-ruud" }]);
-		expect(rebuilt[0].streaming).toEqual([{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" }]);
+		expect(rebuilt[0].streaming).toEqual([{ platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" }]);
 	});
 
 	it("dedupes a World Cup knockout placeholder against the ai-research event, keeping the AI copy", () => {
@@ -378,7 +379,7 @@ describe("build-events", () => {
 		expect(wc).toHaveLength(1);                                   // not two rows for the final
 		expect(wc[0].title).toBe("VM-finalen 2026");                 // the human title won
 		expect(wc[0].source).toBe("ai-research");                    // the placeholder was dropped
-		expect(wc[0].streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no/direkte" }]);
+		expect(wc[0].streaming).toEqual([{ platform: "NRK", url: "https://tv.nrk.no/direkte", urlKind: "landing" }]);
 		// The placeholder team names must not leak onto the surviving event.
 		expect(wc[0].awayTeam).not.toBe("Semifinal 2 Winner");
 	});

--- a/tests/dashboard-cards.test.js
+++ b/tests/dashboard-cards.test.js
@@ -456,6 +456,51 @@ describe("whereToWatch — the core 'hvor kan jeg se det'", () => {
 	});
 });
 
+describe("WP-246 — a landing page is never presented as the match link", () => {
+	const landing = { platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" };
+	const deep = { platform: "TV 2 Play", url: "https://play.tv2.no/sport/sykkel/arctic-race-of-norway", urlKind: "deep" };
+
+	it("streamLink is false for a landing URL and true for a deep one", () => {
+		expect(dash.streamLink(landing)).toBe(false);
+		expect(dash.streamLink(deep)).toBe(true);
+	});
+	it("the row keeps the channel NAME but drops the link (the name is still true)", () => {
+		const html = dash.whereToWatch({ streaming: [landing] });
+		expect(html).toContain("TV 2 Play");        // where to watch — still answered
+		expect(html).not.toContain("<a ");           // …but nothing pretends to be the match
+		expect(html).not.toContain("play.tv2.no");   // the front page never ships as an href
+	});
+	it("a real deep link is still a link — this package removes the lie, not the links", () => {
+		const html = dash.whereToWatch({ streaming: [deep] });
+		expect(html).toContain("<a ");
+		expect(html).toContain("arctic-race-of-norway");
+	});
+	it("older payloads without urlKind keep the previous behaviour (backward compatible)", () => {
+		expect(dash.streamLink({ platform: "NRK", url: "https://tv.nrk.no" })).toBe(true);
+	});
+	it("the detail sheet says quietly why there is no link — no warning icon", () => {
+		const html = dash.eventDetail({ sport: "cycling", title: "Etappe 5", time: soon(), streaming: [landing] });
+		expect(html).toContain("Se på");
+		expect(html).toContain("TV 2 Play");
+		expect(html).toContain('<span class="tbd">(ingen direkte lenke)</span>');
+		expect(html).not.toContain('href="https://play.tv2.no/sport"');
+		expect(html).not.toMatch(/⚠|advarsel/i);
+	});
+	it("the detail sheet links a deep URL and says nothing extra", () => {
+		const html = dash.eventDetail({ sport: "cycling", title: "Etappe 5", time: soon(), streaming: [deep] });
+		expect(html).toContain('href="https://play.tv2.no/sport/sykkel/arctic-race-of-norway"');
+		expect(html).not.toContain("(ingen direkte lenke)");
+	});
+	it("a tentative channel still reads (bekreftes), not the landing note", () => {
+		const html = dash.eventDetail({
+			sport: "football", title: "Norge – Brasil", time: soon(),
+			streaming: [{ platform: "NRK / TV 2", url: "https://tv.nrk.no", tentative: true, urlKind: "landing" }],
+		});
+		expect(html).toContain("(bekreftes)");
+		expect(html).not.toContain("(ingen direkte lenke)");
+	});
+});
+
 describe("followed 'neste' index — answers 'when's X next?'", () => {
 	const inDays = (n) => new Date(Date.now() + n * 86400000).toISOString();
 

--- a/tests/norwegian-rights.test.js
+++ b/tests/norwegian-rights.test.js
@@ -183,3 +183,102 @@ describe("World Cup per-match channel resolution (English↔Norwegian nations)",
 		expect(s.map((c) => c.platform)).toEqual(["NRK / TV 2"]);
 	});
 });
+
+// ── WP-246: the channel must point at the match, not at the front page ──────
+
+import { classifyStreamingUrl, stampUrlKinds } from "../scripts/lib/norwegian-rights.js";
+
+describe("classifyStreamingUrl — deep vs. landing", () => {
+	it("classifies the rights map's own fallback URLs as landing (they are the lie WP-246 removes)", () => {
+		expect(classifyStreamingUrl("https://play.tv2.no/sport")).toBe("landing");
+		expect(classifyStreamingUrl("https://viaplay.no/no-no/sport")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.eurosport.no")).toBe("landing");
+		expect(classifyStreamingUrl("https://tv.nrk.no/direkte")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.hbomax.com/no/no/sports/pga-tour")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.max.com")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.discoveryplus.no")).toBe("landing");
+	});
+	it("a bare origin is always landing, trailing slash or not", () => {
+		expect(classifyStreamingUrl("https://play.tv2.no")).toBe("landing");
+		expect(classifyStreamingUrl("https://play.tv2.no/")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.twitch.tv/")).toBe("landing");
+	});
+	it("a generic sport SECTION is landing too — a category page is not a broadcast", () => {
+		expect(classifyStreamingUrl("https://play.tv2.no/sport/tennis")).toBe("landing");
+		expect(classifyStreamingUrl("https://www.chess.com/tv")).toBe("landing");
+	});
+	it("classifies a real per-broadcast URL as deep", () => {
+		expect(classifyStreamingUrl("https://tv.nrk.no/serie/friidrett-diamond-league")).toBe("deep");
+		expect(classifyStreamingUrl("https://tv.vg.no/video/290684/rosenborg-manchester-united")).toBe("deep");
+		expect(classifyStreamingUrl("https://play.tv2.no/sport/sykkel/arctic-race-of-norway")).toBe("deep");
+		expect(classifyStreamingUrl("https://www.tvkampen.com/kamp/liverpool-arsenal-1")).toBe("deep");
+		expect(classifyStreamingUrl("https://www.twitch.tv/STLChessClub")).toBe("deep");
+	});
+	it("says nothing when there is nothing to classify (no url / unparseable)", () => {
+		expect(classifyStreamingUrl("")).toBe("");
+		expect(classifyStreamingUrl(null)).toBe("");
+		expect(classifyStreamingUrl(undefined)).toBe("");
+		expect(classifyStreamingUrl("play.tv2.no/sport")).toBe(""); // no scheme → don't guess
+	});
+});
+
+describe("stampUrlKinds — the label can never drift from the URL", () => {
+	it("stamps landing/deep and leaves url-less entries (and plain strings) alone", () => {
+		const out = stampUrlKinds([
+			{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" },
+			{ platform: "NRK", url: "https://tv.nrk.no/serie/friidrett-nm" },
+			{ platform: "Viaplay" },
+			"Twitch",
+		]);
+		expect(out[0].urlKind).toBe("landing");
+		expect(out[1].urlKind).toBe("deep");
+		expect(out[2].urlKind).toBeUndefined(); // no url ⇒ no claim
+		expect(out[3]).toBe("Twitch");
+	});
+	it("is idempotent and re-labels when a URL is rewritten", () => {
+		const once = stampUrlKinds([{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" }]);
+		expect(stampUrlKinds(once)).toEqual(once);
+		const rewritten = stampUrlKinds([{ ...once[0], url: "https://www.tvkampen.com/kamp/x-1" }]);
+		expect(rewritten[0].urlKind).toBe("deep");
+	});
+	it("drops a stale urlKind when the url is gone", () => {
+		const out = stampUrlKinds([{ platform: "TV 2 Play", urlKind: "deep" }]);
+		expect(out[0].urlKind).toBeUndefined();
+	});
+});
+
+describe("the rights map ships its own honesty label", () => {
+	it("every mapped fallback channel is stamped landing — the map is a rights map, not a link", () => {
+		for (const ev of [
+			{ sport: "football", tournament: "Premier League" },
+			{ sport: "f1", tournament: "Belgian Grand Prix" },
+			{ sport: "golf", tournament: "PGA Tour", title: "Corales Puntacana Championship" },
+			{ sport: "cycling", tournament: "Tour de France", title: "Etappe 5" },
+		]) {
+			const s = normalizeStreaming(ev);
+			expect(s.length).toBeGreaterThan(0);
+			for (const c of s) expect(c.urlKind).toBe("landing");
+		}
+	});
+	it("the tentative WC label is landing too (tv.nrk.no is a front page)", () => {
+		const s = norwegianRights({ sport: "football", tournament: "FIFA World Cup 2026" });
+		expect(s[0].urlKind).toBe("landing");
+	});
+	it("resolveStreaming re-stamps after pointing a channel at the tvkampen match page", () => {
+		const listings = [{ homeTeam: "Liverpool", awayTeam: "Arsenal", broadcasters: ["TV 2 Play"], url: "https://www.tvkampen.com/kamp/liverpool-arsenal-1" }];
+		const s = resolveStreaming({ sport: "football", homeTeam: "Liverpool", awayTeam: "Arsenal", tournament: "Premier League" }, listings);
+		expect(s[0].url).toContain("tvkampen.com/kamp/");
+		expect(s[0].urlKind).toBe("deep"); // per-match guide, not the TV 2 front page
+	});
+	it("a WC fallback onto the tvkampen guide is deep, while the plain tentative label stays landing", () => {
+		const guide = [{ homeTeam: "Paraguay", awayTeam: "Frankrike", broadcasters: ["Svt"], url: "https://www.tvkampen.com/kamp/paraguay-frankrike-3" }];
+		const withGuide = resolveStreaming({ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Paraguay", awayTeam: "France" }, guide);
+		expect(withGuide[0].urlKind).toBe("deep");
+		const noGuide = resolveStreaming({ sport: "football", tournament: "FIFA World Cup 2026", homeTeam: "Norway", awayTeam: "Brazil" }, []);
+		expect(noGuide[0].urlKind).toBe("landing");
+	});
+	it("keeps an agent-supplied deep link on esports/chess (we never downgrade a real link)", () => {
+		const s = normalizeStreaming({ sport: "esports", streaming: [{ platform: "Twitch", url: "https://www.twitch.tv/blastpremier" }] });
+		expect(s[0].urlKind).toBe("deep");
+	});
+});

--- a/tests/validate-events.test.js
+++ b/tests/validate-events.test.js
@@ -58,3 +58,61 @@ describe("validate-events", () => {
 		).toBe(0);
 	});
 });
+
+// ── WP-246: the landing-page gap must be COUNTED, not invisible ─────────────
+
+import { validateEvents, loadEventSchema } from "../scripts/validate-events.js";
+
+describe("landing-page-only channel URLs are a counted warning (WP-246)", () => {
+	const schema = loadEventSchema();
+	const soon = new Date(Date.now() + 2 * 86400000).toISOString();
+	const farOut = new Date(Date.now() + 30 * 86400000).toISOString();
+	const check = (events) => validateEvents(events, schema);
+
+	it("counts a near-term event whose only channel URL is a service front page", () => {
+		const r = check([
+			{ sport: "football", title: "Brann – Rosenborg", time: soon, streaming: [{ platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" }] },
+		]);
+		expect(r.streamingLandingOnly).toBe(1);
+		expect(r.errors).toBe(0); // a warning, never a build-breaking error
+	});
+	it("does NOT count an event that has a real deep link alongside the landing one", () => {
+		const r = check([
+			{
+				sport: "cycling", title: "Etappe 5", time: soon,
+				streaming: [
+					{ platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" },
+					{ platform: "TV 2 Play", url: "https://play.tv2.no/sport/sykkel/arctic-race-of-norway", urlKind: "deep" },
+				],
+			},
+		]);
+		expect(r.streamingLandingOnly).toBe(0);
+	});
+	it("does NOT count a channel with no URL at all — that is a different (already honest) gap", () => {
+		const r = check([{ sport: "chess", title: "Runde 3", time: soon, streaming: [{ platform: "Chess.com" }] }]);
+		expect(r.streamingLandingOnly).toBe(0);
+	});
+	it("only looks at the near term (the next 7 days), like the streaming-missing warning", () => {
+		const r = check([
+			{ sport: "football", title: "Langt frem", time: farOut, streaming: [{ platform: "TV 2 Play", url: "https://play.tv2.no/sport", urlKind: "landing" }] },
+		]);
+		expect(r.streamingLandingOnly).toBe(0);
+	});
+	it("counts static-pipeline events too, not just ai-research (that is where most of them come from)", () => {
+		const landing = { platform: "Viaplay", url: "https://viaplay.no/no-no/sport", urlKind: "landing" };
+		const r = check([
+			{ sport: "f1", title: "Belgian GP", time: soon, streaming: [landing] },
+			{ sport: "football", title: "Brann – Molde", time: soon, streaming: [landing], source: "ai-research", confidence: "medium" },
+		]);
+		expect(r.streamingLandingOnly).toBe(2);
+		expect(r.errors).toBe(0);
+	});
+	it("accepts urlKind through the formal schema (no shape drift, backward compatible without it)", () => {
+		const r = check([
+			{ sport: "f1", title: "Med felt", time: soon, streaming: [{ platform: "Viaplay", url: "https://viaplay.no/no-no/sport", urlKind: "landing" }] },
+			{ sport: "f1", title: "Uten felt", time: soon, streaming: [{ platform: "Viaplay", url: "https://viaplay.no/no-no/sport" }] },
+		]);
+		expect(r.errors).toBe(0);
+		expect(check([{ sport: "f1", title: "Ugyldig", time: soon, streaming: [{ platform: "Viaplay", urlKind: "kanskje" }] }]).errors).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Problemet

Tavla sa «TV 2 Play» og lenket til TV 2 Plays sportsforside. Det er et **rettighetskart**, ikke et svar på «hvor ser jeg det» — og et rettighetskart er nøyaktig det enhver språkmodell produserer gratis. Dette er produktgapet.

Målt på dagens bygg (72 events, 80 strømme-oppføringer):

| | antall |
|---|---|
| oppføringer som peker på en **landingsside** | **68 av 80** (85 %) |
| oppføringer med en ekte **dyplenke** | 12 |
| events der lenken *bare* er en landingsside | 62 av 72 |
| events uten kanal i det hele tatt | 1 |

De 12 dyplenkene er de reelle: `tv.nrk.no/serie/friidrett-nm`, `tv.vg.no/video/290684/rosenborg-manchester-united`, `play.tv2.no/sport/sykkel/arctic-race-of-norway`, Twitch/Kick/YouTube-kanalene for sjakk og CS2.

## Kontrakten

**Dyplenke, eller ærlig ingen lenke — aldri en forside som utgir seg for å være et svar.**

Kanal**navnet** er fortsatt sant og nyttig, og vises alltid. Det er *lenken* som løy.

## Hva som er gjort

**1 · Lenketypen i datamodellen.** `urlKind` på strømme-oppføringen — `"deep"` (selve sendingen/kampen/streamen) eller `"landing"` (tjenestens forside eller en generisk seksjon). Feltet er **valgfritt**: en oppføring uten URL, eller en URL vi ikke kan parse, får ingen påstand, og eldre publiserte events uten feltet forblir gyldige (klienten faller da tilbake til gammel oppførsel).

Klassifiseringen (`classifyStreamingUrl()` i `scripts/lib/norwegian-rights.js`) er deterministisk og kildeuavhengig:
- bar origin (`https://www.eurosport.no`) → alltid `landing`
- hele stien bygget av generiske segmenter (språkkode, `sport`/`direkte`/`live`/`tv`, rene sportsnavn) → `landing`. Det tar `play.tv2.no/sport`, `viaplay.no/no-no/sport`, `hbomax.com/no/no/sports/pga-tour`, `play.tv2.no/sport/tennis`, `chess.com/tv`.
- alt annet med URL → `deep`

`stampUrlKinds()` er **ett choke point**, kalt SIST i `build-events.js` — etter `withDeepUrls` og `upgradeLanding`, som begge kan skrive om URL-en. Dermed kan etiketten aldri drifte fra URL-en som faktisk sendes, heller ikke på bevarte ai-research-events der kanalen kom fra en agent og aldri gikk gjennom rettighetskartet. Rettighetskartets egne fallback-URL-er (`CH`, `WC_SHARED`) stemples ved konstruksjon: ærlige som standard.

**2 · Klienten presenterer ikke lenger en landingsside som et svar.** `streamLink()` returnerer `false` for `urlKind: "landing"`.
- **Raden:** kanalnavnet står som ren tekst. Fraværet av den prikkete understreken (`.ev-where a`) er hele signalet om at det ikke er noe å trykke på. Ingen ikon, ingen badge, ingen ny farge — `cards.css` trengte ingen endring.
- **Detaljarket:** her er det plass til å si *hvorfor*, så det gjør det stille i den eksisterende dempede `.tbd`-stemmen: «TV 2 Play (ingen direkte lenke)». Samme behandling som «(bekreftes)» allerede har. En tentativ kanal leser fortsatt «(bekreftes)», ikke landings-merknaden.
- En ekte dyplenke er fortsatt en lenke — denne pakken fjerner løgnen, ikke lenkene.

**3 · Validator-signal.** `validate-events.js` teller nå «landing-only» nær-forestående events (samme 7-dagersvindu som det eksisterende streaming-varselet), for **alle kilder** — ikke bare ai-research, siden det er det statiske rettighetskartet de fleste kommer fra. Varsel, aldri feil:

```
Landing-page-only channel URL on 20 near-term event(s) — the channel name is
right, but the link points at a service front page, not the broadcast (WP-246).
```

**4 · DESIGN.md § Radens anatomi** har fått lenkeløftet skrevet ned under Kanal-punktet, så kontrakten er normativ og ikke bare kode.

## Verifisering

- `npx vitest run --maxWorkers=1` → **74 filer / 1245 tester grønne**
- `node scripts/build-events.js && node scripts/validate-events.js` → **0 feil**, 20 landingsside-varsler (forventet og ønsket — det er gapet, nå synlig)
- Nye tester: `tests/norwegian-rights.test.js` (klassifisering deep/landing, idempotent stempling, at kartet merker seg selv, at tvkampen-kamplenken blir `deep` etter omskriving), `tests/dashboard-cards.test.js` (landing → ingen `<a>`, men navnet står; deep → fortsatt lenke; bakoverkompatibelt uten feltet; detaljarkets stille merknad), `tests/validate-events.test.js` (telleren, at deep-lenke ved siden av opphever den, at fjern-events ikke telles, at `urlKind` går gjennom skjemaet og at en ugyldig verdi ikke gjør det). `tests/build-events.test.js` fikk oppdatert fire eksakt-form-assertions til den nye (riktige) formen.
- **Skjermbilde, 375 px, sett med Read:** tavla er uendret rolig — én kolonne, samme dagsgruppering, samme rytme. Kanalene («HBO Max (Sport)», «Viaplay», «TV 2 Play», «PGA Tour · HBO Max (Sport) +1») står nå som dempet ren tekst uten understrek. Det eneste synlige er at understrekene som lovet en kamplenke er borte. Ingen nye ikoner, ingen nye farger, ingen layout-forskyvning.

## Utenfor scope (bevisst)

- **Å faktisk skaffe dyplenkene** er research-/verify-agentenes jobb (WP-241/242). Denne pakken gjør løgnen umulig og gapet målbart. Tavla blir ærligere og tynnere før den blir bedre.
- **`docs/data/` er ikke committet** — den statiske pipelinen eier og bygger den hver time og stempler `urlKind` på alt ved neste kjøring. I mellomtiden beholder gamle oppføringer uten feltet dagens (uendrede) oppførsel, så ingen regresjon.
- **iOS er ikke rørt** (WP-200 eier `ios/`). `StreamingChannel` er en vanlig Swift `Codable`, så det nye feltet dekodes bort uten å knekke noe — men app/widget lenker fortsatt landingssider til noen speiler regelen. Naturlig oppfølging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
