### PR TITLE
WP-200b: koble linsa inn i web-agendaen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Two kinds of scheduled work:
 `.github/workflows/static-pipeline.yml` — hourly 05–21 UTC:
 - `scripts/fetch/index.js` — ESPN fetchers (football, golf, tennis, F1, chess, cycling) + fotball.no + **Liquipedia CS2 matches** (`esports.js`: hourly `Liquipedia:Matches`, keeps focus-team (100 Thieves) matches at any tier; the `APIClient` sends `Accept-Encoding: gzip` + decompresses, which Liquipedia requires)
 - `scripts/fetch-standings.js` → `standings.json` (PL table, golf leaderboards, F1)
-- `scripts/fetch-rss.js` → `rss-digest.json` (11 feeds)
+- `scripts/fetch-rss.js` → `rss-digest.json` (14 feeds)
 - `scripts/fetch-results.js` → `recent-results.json` (7-day history)
 - `scripts/fetch-tvkampen.js` → `tv-listings.json` — Norwegian TV/streaming **ground truth** for football (tvkampen.com, today+2 days; lib: `scripts/lib/tvkampen-scraper.js`)
 - `scripts/build-events.js` → `events.json` — **preserves `source: "ai-research"` events** from the previous build (dedupe key `sport|title|time`), publishes `tracked.json` to `docs/data/`

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -284,6 +284,25 @@ class Dashboard {
 		return ssIsMustSee(e, this.interests, this.lensConfig);
 	}
 
+	/** WP-200: the board is YOURS. Runs the events through the shipped lens —
+	 *  the same `ssIsRelevant` the golden feed-vectors freeze and the iOS agenda
+	 *  compiles from — so a profile that follows only Formel 1 gets an agenda of
+	 *  only F1, not the catalog's nine sports.
+	 *
+	 *  `this.interests` is null when there is no profile, and lens.js treats an
+	 *  ABSENT `followBroadly` as "no profile speaks" — so an empty profile
+	 *  reproduces today's catalog-wide board id-for-id. That equivalence is the
+	 *  hard contract; vectors 15/16 pin the narrowing, 01–14 pin the default.
+	 *
+	 *  NB: only what the user SEES is lensed. `_eventById` deliberately keeps the
+	 *  full set so a deep link or a series row can still resolve an event that the
+	 *  lens filtered out of the agenda. */
+	lensed(events) {
+		if (typeof ssIsRelevant !== 'function') return events; // lens.js absent → unfiltered, never blank
+		const now = Date.now();
+		return events.filter((e) => ssIsRelevant(e, this.interests, now, this.lensConfig));
+	}
+
 	/** The time cell: a HH:MM for a single-day event, or a date window
 	 *  ("13.–20. juli") that REPLACES the clock for a multi-day event — never
 	 *  both, and never duplicated in the title. */
@@ -385,7 +404,7 @@ class Dashboard {
 		// Collapse multi-stage races (e.g. Tour de France) into ONE expandable row
 		// so 20+ near-identical "Etappe N" rows don't drown the rest of the week.
 		const items = this.collapseSeries(
-			this.allEvents.filter((e) => isEventInWindow(e, start, maxHorizon)),
+			this.lensed(this.allEvents).filter((e) => isEventInWindow(e, start, maxHorizon)),
 			now
 		).sort((a, b) => new Date(a.time) - new Date(b.time));
 
@@ -463,7 +482,7 @@ class Dashboard {
 		const fwStart = now + 14 * SS_CONSTANTS.MS_PER_DAY;
 		const fwEnd = now + 42 * SS_CONSTANTS.MS_PER_DAY;
 		return this.collapseSeries(
-			this.allEvents.filter((e) => isEventInWindow(e, fwStart, fwEnd)),
+			this.lensed(this.allEvents).filter((e) => isEventInWindow(e, fwStart, fwEnd)),
 			now
 		).sort((a, b) => new Date(a.time) - new Date(b.time));
 	}

--- a/tests/agenda-lens.test.js
+++ b/tests/agenda-lens.test.js
@@ -1,0 +1,96 @@
+// WP-200b · linsa koblet inn i WEB-agendaen.
+//
+// WP-200 fikset lensa på begge flater, men web-agendaen konsumerte den ikke:
+// `agendaDayGroups()` og `forwardWindow()` bygget rett fra `this.allEvents` uten
+// `ssIsRelevant`. iOS-agendaen kompilerte allerede fra lensa, så fiksen var
+// usynlig for nøyaktig de brukerne den ble laget for — en web-profil som følger
+// kun Formel 1 fikk fortsatt golf, sykkel og skiskyting.
+//
+// Filen var eid av WP-246 i en parallell branch da WP-200 landet, så
+// innkoblingen ble en oppfølger. Denne testen pinner den.
+//
+// Kontrakten som IKKE får brytes: ingen profil (`interests = null`) ⇒ nøyaktig
+// dagens katalogbrede tavle. Det er samme garanti som vektor 01–14 fryser.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { createClientSandbox, loadClientScript } from "./helpers/load-client.js";
+
+let dash;
+
+beforeAll(() => {
+	const sandbox = createClientSandbox();
+	loadClientScript(sandbox, "shared-constants.js");
+	loadClientScript(sandbox, "lens.js");
+	loadClientScript(sandbox, "dashboard.js");
+	loadClientScript(sandbox, "live.js");
+	loadClientScript(sandbox, "detail.js");
+	loadClientScript(sandbox, "followed.js");
+	loadClientScript(sandbox, "chrome.js");
+	loadClientScript(sandbox, "news-web.js");
+	loadClientScript(sandbox, "entity-page.js");
+	dash = sandbox.window.dashboard;
+});
+
+const inDays = (d) => new Date(Date.now() + d * 86400000).toISOString();
+
+/** A board spanning four sports — the shape that made the bug visible. */
+const board = () => [
+	{ id: "f1-a", sport: "f1", title: "Nederlands Grand Prix", tournament: "Formel 1", time: inDays(2) },
+	{ id: "golf-a", sport: "golf", title: "Wyndham Championship", tournament: "PGA Tour", time: inDays(3), norwegian: true },
+	{ id: "cyc-a", sport: "cycling", title: "Tour de Pologne", tournament: "UCI WorldTour", time: inDays(4), norwegian: true },
+	{ id: "fb-a", sport: "football", title: "Brann – Rosenborg", tournament: "Eliteserien", time: inDays(5), norwegian: true },
+];
+
+/** The interests shape ssProfileToInterests produces for ONE precise follow.
+ *
+ *  The absent/empty distinction is load-bearing and easy to get wrong (I did):
+ *  `followBroadly` ABSENT (null) means "no profile speaks" → lens.js falls back
+ *  to the nine-sport catalog default. EMPTY ([]) means "a profile speaks, and it
+ *  follows no sport wholesale" → only the precise follows get through. A
+ *  tournament/team/athlete rule produces the latter; only a `sport-…` entity
+ *  (the starter packs) puts a sport in the list. */
+const only = (sport, name) => ({
+	followBroadly: [],
+	alwaysTrack: { teams: [], athletes: [], tournaments: [{ name, aliases: [], sport }] },
+});
+
+describe("agendaDayGroups is lensed (WP-200b)", () => {
+	it("no profile ⇒ the catalog-wide board, unchanged", () => {
+		dash.allEvents = board();
+		dash.interests = null;
+		const ids = dash.agendaDayGroups().groups.flatMap((g) => g.events.map((e) => e.id));
+		expect(ids.sort()).toEqual(["cyc-a", "f1-a", "fb-a", "golf-a"]);
+	});
+
+	it("a profile that follows only Formel 1 gets an agenda of only F1", () => {
+		// The bug this package exists for: golf/cycling/football were all Norwegian,
+		// so rule (3) waved them through regardless of what the user chose.
+		dash.allEvents = board();
+		dash.interests = only("f1", "Formel 1");
+		const ids = dash.agendaDayGroups().groups.flatMap((g) => g.events.map((e) => e.id));
+		expect(ids).toEqual(["f1-a"]);
+	});
+
+	it("the forward glance is lensed by the same rule", () => {
+		dash.allEvents = [
+			{ id: "far-f1", sport: "f1", title: "Grand Prix", tournament: "Formel 1", time: inDays(20) },
+			{ id: "far-golf", sport: "golf", title: "Open", tournament: "PGA Tour", time: inDays(21), norwegian: true },
+		];
+		dash.interests = only("f1", "Formel 1");
+		expect(dash.forwardWindow().map((e) => e.id)).toEqual(["far-f1"]);
+	});
+
+	it("keeps the FULL set resolvable by id, so a filtered event still opens", () => {
+		// _eventById is deliberately unlensed — a deep link or a series row must
+		// resolve an event the agenda filtered away, rather than 404 silently.
+		dash.allEvents = board();
+		dash.interests = only("f1", "Formel 1");
+		dash.agendaDayGroups();
+		expect(dash._eventById.get("golf-a")).toBeTruthy();
+	});
+
+	it("lensed() is a pass-through when no profile speaks", () => {
+		dash.interests = null;
+		expect(dash.lensed(board())).toHaveLength(4);
+	});
+});


### PR DESCRIPTION
Oppfølger til WP-200 (#423).

## Problemet

WP-200 fikset lensa på begge flater, men **web-agendaen konsumerte den ikke**.
`agendaDayGroups()` og `forwardWindow()` bygget rett fra `this.allEvents` uten
`ssIsRelevant`. iOS-agendaen kompilerte allerede fra lensa, så fiksen var usynlig for
nøyaktig de brukerne den ble laget for: en web-profil som følger kun Formel 1 fikk
fortsatt golf, sykkel og skiskyting.

`docs/js/dashboard.js` var eid av WP-246 (#422) i en parallell branch da WP-200 landet,
så innkoblingen måtte bli en oppfølger. Begge er nå merget.

## Løsningen

Ny `Dashboard.lensed()` delegerer til den **shippede** lensa — samme `ssIsRelevant` som
de gyldne vektorene fryser og iOS-agendaen kompilerer fra.

To bevisste valg:

- **`_eventById` er IKKE filtrert.** En dyplenke eller en serie-rad må fortsatt kunne slå
  opp et event lensa filtrerte bort, i stedet for å feile stille.
- **Fail-open** hvis `lens.js` mangler — tavla blir aldri blank.

## Absent vs. tom `followBroadly`

Verdt å skrive ned, for det er lett å ta feil av (jeg gjorde det først, og testen min
feilet på det):

| `followBroadly` | Betyr | Resultat |
|---|---|---|
| **fraværende** (`null`) | ingen profil taler | katalogbred tavle, som før |
| **tom** (`[]`) | en presis følging taler, men ingen sport følges bredt | kun de presise følgingene |

Bare en `sport-…`-entitet (startpakkene) legger en sport i lista.

## Verifisering

- `npx vitest run --maxWorkers=1` → **78 filer / 1317 tester grønne** (5 nye)
- Ingen profil ⇒ katalogbred tavle uendret — samme garanti som vektor 01–14 fryser
- Kun-F1-profil ⇒ kun F1, både i agendaen og i «Fremover»
- `node scripts/screenshot.js --width=375 --full-page` sett: tavla er uendret rolig

Retter samtidig `CLAUDE.md`: 11 RSS-feeder oppgitt, 14 faktiske (verifisert mot
`scripts/fetch-rss.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)