### PR TITLE
WP-247: iOS speiler urlKind — kun en «deep»-URL ser ut som en lenke

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -181,6 +181,31 @@ pipeline always writes a field the schema doesn't strictly require,
 `source`, entity `type`, …) stay plain `String`, not closed Swift enums, so a new
 server value decodes gracefully on an older client rather than crashing the event.
 
+### «Lenkeløftet» (urlKind)
+
+`StreamingChannel.urlKind` (WP-246, mirrored on iOS by WP-247) says what the URL
+actually points at: `"deep"` = the broadcast itself, `"landing"` = the service's
+front page or a generic section. `StreamingChannel.linkURL` is the **single choke
+point** deciding whether a channel may look like a link — the Swift twin of
+`docs/js/dashboard.js`'s `streamLink`, read by the detail sheet; the agenda row and
+the widget render the channel through `AgendaFormat.channelLabel`, which is a NAME
+and never a link by construction.
+
+The channel name is always shown (it is true and useful); only a `deep`, http(s)
+URL is presented as a link. Two deliberate strictnesses:
+
+- **A missing `urlKind` is treated as `landing`** — stricter than web, which keeps
+  the old behaviour for unstamped entries. iOS is the surface with a persistent
+  on-device cache, so "no `urlKind`" means "cached before the pipeline stamped it",
+  not "this URL is fine"; the honest degradation is the name without the link.
+- **A `tentative` (shared-rights «NRK / TV 2») entry links only to a tvkampen match
+  guide** — linking one of the two broadcasters would mislead whenever it turns out
+  to be the other.
+
+The detail sheet explains a withheld link with a quiet «(ingen direkte lenke)» —
+no warning icon (DESIGN.md § Grunnlov 3, § Stemme). Pinned by
+`StreamingLinkContractTests`.
+
 ### Model fixtures
 
 `SportivistaTests/Fixtures/` holds **checked-in, deliberately-frozen snapshots** of the
@@ -325,7 +350,9 @@ emphasis — a 6pt amber dot, never a card; must-watch shows no inline glyph (th
 varsel state is in the detail sheet); a quiet mono `ⓘ` trails only on
 `ai-research` rows. Pull-to-refresh re-syncs + recompiles but does **not** run the
 notification reconcile (see [Notifications](#notifications)). Tapping a row opens
-`EventDetailSheet` (venue, summary, streaming as real `Link`s, the AI-provenance
+`EventDetailSheet` (venue, summary, streaming — every channel NAMED, but only a
+URL that points at the broadcast itself rendered as a real `Link`; see
+[«Lenkeløftet»](#lenkeløftet-urlkind) — the AI-provenance
 block only on `ai-research` rows, a quiet varsel read-out, the spoiler-masked
 `RESULTAT`, the **`TABELL`** section (WP-171 — `EventStandingsSection`: the league
 table / golf leaderboard / F1 championship from `standings.json`, built by the pure

--- a/ios/Sportivista/Agenda/EventDetailSheet.swift
+++ b/ios/Sportivista/Agenda/EventDetailSheet.swift
@@ -404,15 +404,22 @@ private struct NotifyStatusRow: View {
     }
 }
 
-/// One streaming option: a real tappable Link when it has a URL, plain text
-/// otherwise (mirrors dashboard.js's `streamLink` honesty — never fake a
-/// link). A tentative (shared-rights, not-yet-confirmed) entry is marked.
+/// One streaming option: a real tappable Link only when the URL points at the
+/// BROADCAST, plain text otherwise (`StreamingChannel.linkURL` — the Swift twin
+/// of dashboard.js's `streamLink`; never fake a link).
+///
+/// WP-247/WP-246: a `landing` URL drops you on TV 2 Play / Viaplay's front page,
+/// not on this match, so we name the channel — which is true and useful — and
+/// admit the missing link instead of dressing the rights map up as an answer.
+/// The sheet has room to say WHY, so it does, quietly, in the same muted voice
+/// as «(bekreftes)». No warning icon: DESIGN.md § Grunnlov 3 ("Ærlig innhold")
+/// and § Stemme ("Kanal ukjent", ikke "Ingen streaming!").
 private struct StreamingLinkRow: View {
     let channel: StreamingChannel
 
     var body: some View {
         Group {
-            if let urlString = channel.url, let url = URL(string: urlString) {
+            if let url = channel.linkURL {
                 Link(destination: url) {
                     row(linked: true)
                 }
@@ -423,13 +430,22 @@ private struct StreamingLinkRow: View {
         .listRowBackground(SportivistaTokens.cell)
     }
 
+    /// The quiet aside after the channel name. A tentative entry's «(bekreftes)»
+    /// wins — it is the more specific truth, and two asides on one row would be
+    /// noise (mirrors detail.js, which picks exactly one).
+    private var note: String? {
+        if channel.tentative == true { return "(bekreftes)" }
+        if channel.hasUnlinkableURL { return "(ingen direkte lenke)" }
+        return nil
+    }
+
     private func row(linked: Bool) -> some View {
         HStack {
             Text(channel.platform?.isEmpty == false ? channel.platform! : "Ukjent kanal")
                 .font(.sportivista(.subheadline))
                 .foregroundStyle(linked ? SportivistaTokens.accent : SportivistaTokens.label)
-            if channel.tentative == true {
-                Text("(bekreftes)")
+            if let note {
+                Text(note)
                     .font(.sportivista(.caption2))
                     .foregroundStyle(SportivistaTokens.secondaryLabel)
             }

--- a/ios/Sportivista/Models/StreamingChannel.swift
+++ b/ios/Sportivista/Models/StreamingChannel.swift
@@ -18,4 +18,71 @@ struct StreamingChannel: Codable, Equatable, Hashable {
     /// True while the channel is an unverified guess (e.g. the shared
     /// "NRK / TV 2" placeholder before the verify agent resolves it).
     var tentative: Bool?
+    /// WP-246 — what the URL actually points at: `"deep"` = the broadcast/match/
+    /// stream itself, `"landing"` = the service's front page or a generic section
+    /// (sport/direkte/language code). Stamped deterministically by the pipeline
+    /// (`classifyStreamingUrl` in scripts/lib/norwegian-rights.js, applied last in
+    /// build-events.js) so the label can never drift from the URL it describes.
+    ///
+    /// Kept as the RAW string rather than an enum on purpose: the schema may grow
+    /// a third kind, and an unknown value must decode rather than throw. `linkURL`
+    /// below is the only reader, and it allowlists — so a kind we don't know is
+    /// simply not a link.
+    var urlKind: String?
+}
+
+extension StreamingChannel {
+    /// The `urlKind` value that earns a link. Everything else — `"landing"`, a
+    /// future kind, or a missing field — does not (see `linkURL`).
+    static let deepURLKind = "deep"
+
+    /// The URL to present as a tappable link, or `nil` when this channel must be
+    /// shown as plain text. The Swift twin of `dashboard.js`'s `streamLink`, and
+    /// the ONE place either answer is decided — the row, the detail sheet and the
+    /// widget all read this rather than re-deriving it.
+    ///
+    /// DESIGN.md § Radens anatomi (Kanal / "Lenkeløftet", WP-246): the channel NAME
+    /// is always true and always shown, but only a URL that points at the broadcast
+    /// itself may look like a link. A front page dressed up as the answer to "hvor
+    /// ser jeg det" breaks Grunnlov 3 ("Ærlig innhold — aldri lat som").
+    ///
+    /// Two rules, both allowlists:
+    ///
+    /// 1. **`urlKind` must be `"deep"`.** A MISSING field is treated exactly like
+    ///    `"landing"` — deliberately stricter than web, which keeps the old
+    ///    behaviour for entries without the field. iOS is the surface with a
+    ///    persistent on-device cache (`CacheStore`), so "no `urlKind`" here means
+    ///    "this event was cached before the pipeline stamped it", not "this URL is
+    ///    fine". Falling back to a link would be guessing; the honest degradation
+    ///    is the channel name without the link, until the next sync says otherwise.
+    ///    DESIGN.md words the contract as an allowlist too — only `"deep"` gets to
+    ///    look like a link.
+    /// 2. **A tentative entry links only to a tvkampen match guide.** When rights
+    ///    are shared ("NRK / TV 2") we don't know which broadcaster carries THIS
+    ///    match, so linking one of them would mislead when it turns out to be the
+    ///    other. The neutral match guide is the one honest destination.
+    ///
+    /// The URL must also be http(s). `URL(string:)` is deliberately lenient (it
+    /// happily builds a scheme-less, un-openable URL out of arbitrary text), so
+    /// the scheme is what actually separates "a web address" from "a string".
+    var linkURL: URL? {
+        guard let raw = url, !raw.isEmpty, let parsed = URL(string: raw) else { return nil }
+        guard let scheme = parsed.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return nil }
+        guard urlKind == Self.deepURLKind else { return nil }
+        guard tentative != true else { return Self.isMatchGuide(parsed) ? parsed : nil }
+        return parsed
+    }
+
+    /// True when the channel carries a URL we refuse to link — the case the detail
+    /// sheet explains with a quiet "(ingen direkte lenke)". A channel with NO url at
+    /// all is not this: there is nothing to explain, so it stays silent.
+    var hasUnlinkableURL: Bool {
+        url?.isEmpty == false && linkURL == nil
+    }
+
+    /// tvkampen.com — the neutral Norwegian match guide (host or a subdomain of it).
+    private static func isMatchGuide(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "tvkampen.com" || host.hasSuffix(".tvkampen.com")
+    }
 }

--- a/ios/SportivistaTests/StreamingLinkContractTests.swift
+++ b/ios/SportivistaTests/StreamingLinkContractTests.swift
@@ -1,0 +1,179 @@
+//
+//  StreamingLinkContractTests.swift
+//  SportivistaTests
+//
+//  WP-247 — «Lenkeløftet» on iOS. DESIGN.md § Radens anatomi (Kanal) makes the
+//  channel NAME always true and always visible, but lets only a URL that points
+//  at the broadcast itself (`urlKind: "deep"`) look like a link. A front page
+//  (`urlKind: "landing"`) is shown as plain text — no underline, no tap, no
+//  warning icon — because a front page posing as the answer to «hvor ser jeg
+//  det» breaks Grunnlov 3 ("Ærlig innhold — aldri lat som").
+//
+//  These pin the whole contract at its single choke point
+//  (`StreamingChannel.linkURL`, the Swift twin of dashboard.js `streamLink`),
+//  plus the decoding half (the field is OPTIONAL — older cached events without
+//  it must still decode) and the name-only channel column the row and the widget
+//  render.
+//
+
+import XCTest
+
+final class StreamingLinkContractTests: XCTestCase {
+
+    // MARK: - linkURL: only "deep" is a link
+
+    func testDeepURL_isTappable() {
+        let channel = StreamingChannel(platform: "TV 2 Play", url: "https://play.tv2.no/kamp/lyn-sogndal", tentative: nil, urlKind: "deep")
+        XCTAssertEqual(channel.linkURL?.absoluteString, "https://play.tv2.no/kamp/lyn-sogndal")
+        XCTAssertFalse(channel.hasUnlinkableURL, "a linked channel has nothing to explain")
+    }
+
+    func testLandingURL_isNotTappable() {
+        // The rights map's fallback: TV 2 Play's sport section, not this match.
+        let channel = StreamingChannel(platform: "TV 2 Play", url: "https://play.tv2.no/sport", tentative: nil, urlKind: "landing")
+        XCTAssertNil(channel.linkURL, "a front page must never look like a link to the broadcast")
+        XCTAssertTrue(channel.hasUnlinkableURL, "the sheet explains this one with «(ingen direkte lenke)»")
+    }
+
+    /// The conservative half of the contract, and the deliberate divergence from
+    /// web: iOS caches events on device, so a MISSING `urlKind` means "cached
+    /// before the pipeline stamped it", not "this URL is fine". We don't pretend.
+    func testMissingURLKind_behavesAsLanding() {
+        let channel = StreamingChannel(platform: "Viaplay", url: "https://viaplay.no/no-no/sport", tentative: nil, urlKind: nil)
+        XCTAssertNil(channel.linkURL, "no urlKind ⇒ we don't know it's the broadcast ⇒ not a link")
+        XCTAssertTrue(channel.hasUnlinkableURL)
+    }
+
+    /// Forward compatibility: if the schema ever grows a third kind, an app that
+    /// predates it must not start linking it. The rule is an allowlist.
+    func testUnknownFutureURLKind_isNotTappable() {
+        let channel = StreamingChannel(platform: "NRK", url: "https://tv.nrk.no/serie/xyz", tentative: nil, urlKind: "someFutureKind")
+        XCTAssertNil(channel.linkURL)
+    }
+
+    // MARK: - linkURL: nothing to link
+
+    func testNoURL_isNotTappableAndExplainsNothing() {
+        let channel = StreamingChannel(platform: "Lichess", url: nil, tentative: nil, urlKind: nil)
+        XCTAssertNil(channel.linkURL)
+        XCTAssertFalse(channel.hasUnlinkableURL, "no URL at all ⇒ nothing to admit; the name stands alone")
+    }
+
+    func testEmptyURLString_isNotTappableAndExplainsNothing() {
+        let channel = StreamingChannel(platform: "Lichess", url: "", tentative: nil, urlKind: "deep")
+        XCTAssertNil(channel.linkURL)
+        XCTAssertFalse(channel.hasUnlinkableURL)
+    }
+
+    /// `URL(string:)` is lenient — on current Foundation it happily builds a
+    /// scheme-less URL out of prose. Only an http(s) address is a web address we
+    /// can honestly offer to open.
+    func testNonWebURL_isNotTappable() {
+        for raw in ["ikke en url", "play.tv2.no/kamp/x", "javascript:alert(1)", "tel:12345678"] {
+            let channel = StreamingChannel(platform: "TV 2 Play", url: raw, tentative: nil, urlKind: "deep")
+            XCTAssertNil(channel.linkURL, "\(raw) is not an http(s) address")
+        }
+    }
+
+    // MARK: - linkURL: a tentative (shared-rights) entry
+
+    /// "NRK / TV 2" before verify resolves it: we don't know WHICH broadcaster
+    /// carries this match, so only the neutral match guide is honest to link.
+    func testTentativeDeepURL_linksOnlyTheMatchGuide() {
+        let guide = StreamingChannel(platform: "NRK / TV 2", url: "https://tvkampen.com/kamp/lyn-sogndal", tentative: true, urlKind: "deep")
+        XCTAssertEqual(guide.linkURL?.absoluteString, "https://tvkampen.com/kamp/lyn-sogndal")
+
+        let subdomain = StreamingChannel(platform: "NRK / TV 2", url: "https://www.tvkampen.com/kamp/lyn-sogndal", tentative: true, urlKind: "deep")
+        XCTAssertEqual(subdomain.linkURL?.absoluteString, "https://www.tvkampen.com/kamp/lyn-sogndal")
+    }
+
+    func testTentativeDeepURL_onOneBroadcaster_isNotTappable() {
+        // Linking NRK would mislead whenever it turns out to be TV 2.
+        let channel = StreamingChannel(platform: "NRK / TV 2", url: "https://tv.nrk.no/serie/fotball/kamp", tentative: true, urlKind: "deep")
+        XCTAssertNil(channel.linkURL)
+        XCTAssertTrue(channel.hasUnlinkableURL)
+    }
+
+    func testTentativeLandingURL_isNotTappable() {
+        let channel = StreamingChannel(platform: "NRK / TV 2", url: "https://tv.nrk.no/direkte", tentative: true, urlKind: "landing")
+        XCTAssertNil(channel.linkURL)
+    }
+
+    /// A tvkampen guide still has to be a DEEP url — tvkampen's own front page is
+    /// no more an answer than a broadcaster's.
+    func testTentativeMatchGuideLandingURL_isNotTappable() {
+        let channel = StreamingChannel(platform: "NRK / TV 2", url: "https://tvkampen.com", tentative: true, urlKind: "landing")
+        XCTAssertNil(channel.linkURL)
+    }
+
+    // MARK: - Decoding: the field is optional, and unknown values must not throw
+
+    func testURLKindDecodesFromEventJSON() throws {
+        let event = EventBuilder.make(
+            sport: "football", title: "Lyn – Sogndal", time: "2026-08-02T15:00:00Z",
+            streaming: [
+                ["platform": "TV 2 Play", "url": "https://play.tv2.no/kamp/lyn-sogndal", "urlKind": "deep"],
+                ["platform": "Viaplay", "url": "https://viaplay.no/no-no/sport", "urlKind": "landing"],
+            ]
+        )
+        XCTAssertEqual(event.streaming.count, 2)
+        XCTAssertEqual(event.streaming.first?.urlKind, "deep")
+        XCTAssertNotNil(event.streaming.first?.linkURL)
+        XCTAssertEqual(event.streaming.last?.urlKind, "landing")
+        XCTAssertNil(event.streaming.last?.linkURL)
+    }
+
+    /// The compatibility case that actually ships: an event cached before WP-246
+    /// (or one whose URL the pipeline couldn't classify) has no `urlKind` key at
+    /// all. It must decode — the app just declines to link it.
+    func testStreamingWithoutURLKindStillDecodes() throws {
+        let json = """
+        {
+            "sport": "football",
+            "title": "Gammel cachet kamp",
+            "time": "2026-08-02T15:00:00Z",
+            "streaming": [{ "platform": "TV 2 Play", "url": "https://play.tv2.no/sport" }]
+        }
+        """.data(using: .utf8)!
+
+        let event = try SportivistaJSON.decoder.decode(Event.self, from: json)
+        XCTAssertEqual(event.streaming.count, 1)
+        XCTAssertEqual(event.streaming.first?.platform, "TV 2 Play")
+        XCTAssertNil(event.streaming.first?.urlKind)
+        XCTAssertNil(event.streaming.first?.linkURL)
+    }
+
+    func testUnknownURLKindValueDecodesRatherThanThrows() throws {
+        let json = #"[{ "platform": "NRK", "url": "https://tv.nrk.no/x", "urlKind": "sometimeLater" }]"#.data(using: .utf8)!
+        let channels = try SportivistaJSON.decoder.decode([StreamingChannel].self, from: json)
+        XCTAssertEqual(channels.first?.urlKind, "sometimeLater")
+        XCTAssertNil(channels.first?.linkURL)
+    }
+
+    // MARK: - The channel COLUMN (row + widget) is name-only, never a link
+
+    /// The agenda row and the widget render the channel through
+    /// `AgendaFormat.channelLabel`, which yields a String and nothing else — so
+    /// neither surface can present a landing URL as a tappable match link. Pinned
+    /// so a future "make the row channel tappable" change has to face this test.
+    func testChannelLabel_isTheNameOnly_regardlessOfURLKind() {
+        let deep = [StreamingChannel(platform: "TV 2 Play", url: "https://play.tv2.no/kamp/x", tentative: nil, urlKind: "deep")]
+        let landing = [StreamingChannel(platform: "TV 2 Play", url: "https://play.tv2.no/sport", tentative: nil, urlKind: "landing")]
+        XCTAssertEqual(AgendaFormat.channelLabel(deep), "TV 2 Play")
+        XCTAssertEqual(AgendaFormat.channelLabel(landing), "TV 2 Play",
+                       "the channel NAME is true either way — only the LINK depends on urlKind")
+    }
+
+    func testWidgetEntry_landingChannel_stillShowsTheChannelName() throws {
+        let now = ISO8601DateFormatter().date(from: "2026-07-13T08:00:00Z")!
+        let event = EventBuilder.make(
+            sport: "golf", title: "The Open", time: "2026-07-13T10:00:00Z",
+            streaming: [["platform": "Viaplay", "url": "https://viaplay.no/no-no/sport", "urlKind": "landing"]]
+        )
+        let entries = WidgetTimelineBuilder.buildEntries(events: [event], interests: Interests(followBroadly: ["golf"]), now: now)
+
+        let first = try XCTUnwrap(entries.first)
+        XCTAssertEqual(first.channelLabel, "Viaplay")
+        XCTAssertNil(event.streaming.first?.linkURL, "…and the widget has no link to give it anyway")
+    }
+}


### PR DESCRIPTION
## Hva

WP-246 stemplet `urlKind` på hver strømme-oppføring, og web sluttet å lenke
landingssider. iOS dekodet feltet bort og lenket forsiden videre som om den var
svaret. Denne pakken gjør DESIGN.md § Radens anatomi («Lenkeløftet») sann på
begge flater.

`68 av 80` publiserte strømme-oppføringer er i dag landingssider, så dette er
ikke et kantttilfelle — det er flertallet av kanalene i appen.

## Endringene

**`StreamingChannel`** dekoder `urlKind`. Feltet er valgfritt og lagres som rå
`String`, ikke enum: en fremtidig tredje verdi skal dekode, ikke kaste (samme
forward-compat-linje som `confidence`/`status`/`source`).

**`StreamingChannel.linkURL`** er nå ETT valgpunkt for «får denne se ut som en
lenke» — Swift-tvillingen til `dashboard.js` `streamLink`. Tre regler, alle
allowlists:

- `urlKind` må være `"deep"`.
- URL-en må være `http(s)`. `URL(string:)` er svært slepphendt på iOS 26 og
  bygger gladelig en uåpnbar URL av vanlig prosa — skjemaet er det som faktisk
  skiller «en nettadresse» fra «en streng».
- En `tentative` oppføring (delt rettighet, «NRK / TV 2») lenker bare til
  tvkampen-kampguiden. Å lenke NRK ville villede hver gang det viste seg å være
  TV 2.

**Detaljarket** bruker `linkURL`, og sier stille «(ingen direkte lenke)» når vi
har en URL vi nekter å lenke. Ingen varselikon (Grunnlov 3, § Stemme). En
tentativ oppførings «(bekreftes)» vinner over den — to sidebemerkninger på én
rad er støy, og det speiler `detail.js`, som også velger nøyaktig én.

**Rad og widget** var allerede navn-bare: begge går gjennom
`AgendaFormat.channelLabel`, som gir en `String` og ingenting annet, så ingen av
dem KAN presentere en landingsside som kamplenke. Det er nå pinnet av en test,
så en fremtidig «gjør kanalen i raden trykkbar» må møte den.

## Én bevisst divergens fra web

**Manglende `urlKind` behandles som `landing` på iOS.** Web beholder gammel
oppførsel for ustemplede oppføringer; iOS gjør det ikke.

Begrunnelsen er en ekte plattformforskjell, ikke smak: iOS er flaten med varig
cache på enheten (`CacheStore`), så «ingen `urlKind`» betyr her «dette eventet
ble cachet før pipelinen stemplet det», ikke «denne URL-en er grei». Å falle
tilbake til en lenke ville vært å gjette. Ærlig degradering er kanalnavnet uten
lenke, til neste synk sier noe annet. DESIGN.md formulerer kontrakten som en
allowlist også — «bare en URL som peker på selve sendingen får se ut som en
lenke».

Divergensen står dokumentert i `StreamingChannel.swift` og i `ios/README.md`
(ny seksjon «Lenkeløftet (urlKind)»), ikke bare her.

## Verifisering

- iOS unit-suite: **891 tester, 0 feil** (16 nye i `StreamingLinkContractTests`).
- Alle fire schemes bygger: `Sportivista`, `SportivistaWidgetExtension`,
  `SportivistaUITests` (build-for-testing), `SportivistaDeviceDev`
  (`generic/platform=iOS`, signert).
- `npx vitest run --maxWorkers=1`: **78 filer, 1317 tester**, uendret — ingen
  filer utenfor `ios/` er rørt.

De nye testene pinner: `deep` er trykkbar; `landing` er ikke; manglende felt
oppfører seg som landing; en ukjent fremtidig verdi lenkes ikke; ingen URL sier
ingenting (navnet står alene); tentativ lenker bare kampguiden; feltet dekoder
både når det finnes, mangler og er ukjent; og kanalkolonnen i rad + widget er
navnet uansett `urlKind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
