### PR TITLE
WP-241+242: Autoritetskart + proveniens per faktum

### DIFF
--- a/scripts/agents/research.md
+++ b/scripts/agents/research.md
@@ -42,6 +42,15 @@ matter to a Norwegian sports fan that are NOT in the static data feeds**.
   go find and add those events. This is a smarter signal than coverage-gaps.json.
 - `docs/data/calibration.json` — per-source trust stats from past verifications.
   Prefer sources with high reliability for the sport at hand; distrust repeat offenders.
+- `scripts/config/authority.json` — **the authority map (WP-241): who CREATES each
+  fact.** For every covered competition it names the source that sets the START TIME
+  (the organizer/league/federation) and the source that carries the NORWEGIAN CHANNEL
+  (the broadcaster itself), by id into `scripts/config/sources.json` (the WP-240
+  register — the truth about which domain IS the organizer). **Look the competition
+  up here and go to the registered authority FIRST**, before any open web search.
+  You maintain the map like the catalog: when you start covering a new competition,
+  add its entry — and register the organizer in `sources.json` first (its real
+  domain, verified — never a search hit that merely looks official).
 - `.claude/skills/source-quirks/SKILL.md` — structural failure modes of specific
   sources and how to compensate (e.g. ESPN mis-dates F1 weekends, so confirm the
   current race against the official calendar, not the feed). Read it before trusting
@@ -154,7 +163,27 @@ bare string, never `null`. `norwegianPlayers` may also carry optional golf tee-t
 status fields (`teeTime`, `teeTimeUTC`, `status`); leave the field out entirely (or
 `[]`) rather than writing a string or null when there's no one to name.
 
-Use the **web-search** and **web-fetch** capabilities provided by your runtime. Source priority:
+Use the **web-search** and **web-fetch** capabilities provided by your runtime.
+
+**Authority first (WP-241) — look it up, don't search for it.** Before searching
+broadly for a competition's dates/times: open `scripts/config/authority.json`, find
+the competition, and fetch its registered TIME authority (the organizer's own site)
+directly; for the channel, the registered Norwegian broadcaster's own pages. Search
+engines rank the practical over the authoritative — which is exactly how this board
+once cited the lookalike domain franceletour.com as evidence on a Tour de France
+stage while letour.fr (A.S.O., who actually creates the route and the start times)
+was never cited once. Fall back to the priority list below only when the map has no
+entry, or the authority's site is unreachable/bot-blocked (then cite the best
+secondary source honestly with `basis: "secondary"` and note it in research-log).
+
+**Beware lookalike domains.** The register (`scripts/config/sources.json`) is the
+truth about which domain IS the organizer. A domain that merely *looks* official
+(franceletour.com next to the real letour.fr) must never be cited as evidence and
+never appear in `provenance` — check the competition's `lookalikes` list in
+authority.json, and when a search result claims to be the organizer, confirm the
+domain against the register before trusting it.
+
+Source priority:
 - Norwegian: nrk.no/sport, tv2.no/sport, vg.no/sport, dagbladet.no/sport
 - Official: fis-ski.com, biathlonworld.com, uci.org, atptour.com, pgatour.com, espn.com
 - Esports (CS2): see the `cs2-sources` skill (`.claude/skills/cs2-sources/SKILL.md`) —
@@ -248,9 +277,26 @@ Append discovered events to the existing array in `docs/data/events.json`
   "researchedAt": "2026-07-02T10:00:00Z",
   "confidence": "high",
   "evidence": ["https://nrk.no/...", "https://biathlonworld.com/..."],
+  "provenance": {
+    "time": { "sourceId": "ibu", "url": "https://www.biathlonworld.com/...", "basis": "primary", "retrievedAt": "2026-07-02T10:00:00Z" },
+    "streaming": { "sourceId": "nrk", "url": "https://tv.nrk.no/...", "basis": "official", "retrievedAt": "2026-07-02T10:00:00Z" }
+  },
   "summary": "Norge er regjerende mester."
 }
 ```
+
+**Provenance per fact (WP-242).** `evidence` stays as the flat breadth list, but the
+two facts the product stands on each get their own citation in `provenance`: `time`
+from the party that CREATES it (`basis: "primary"` — the organizer/league/federation
+named in authority.json), `streaming` from the broadcaster's OWN source
+(`basis: "official"`; `"primary"` when the organizer self-streams, e.g. BLAST on its
+own Twitch). Each fact carries `sourceId` (the `sources.json` id — register a new
+organizer there first), `url` (the page you actually read — never a URL you didn't
+reach), `basis`, and `retrievedAt`. `basis: "secondary"` is the honest label for a
+fact you could only source second-hand — but then the event's confidence must not be
+`high`: validate-events counts every high-confidence event whose time lacks a
+primary/official basis, or whose channel lacks the broadcaster's own source, as a
+warning today (the WP-246 pattern), and the contract will harden.
 
 **Streaming is a first-class field — "hvor kan jeg se det" is half the product.**
 For EVERY event you add (and every static event you touch): fill `streaming`
@@ -277,7 +323,9 @@ Confidence:
 - `medium` = 1 source + reasonable corroboration
 - `low` = mentioned but fuzzy details
 
-Never write `high` without 2+ URLs in evidence.
+Never write `high` without 2+ URLs in evidence — and `high` also expects
+`provenance.time` with a primary/official basis and (when `streaming` is set)
+`provenance.streaming` from the broadcaster's own source (WP-242).
 
 Dedupe key: `sport|title|time`. If a static-pipeline event already covers the
 same thing, do not add a duplicate — enrich your understanding and move on.

--- a/scripts/agents/verify.md
+++ b/scripts/agents/verify.md
@@ -57,6 +57,26 @@ matches), use the `cs2-sources` skill (`.claude/skills/cs2-sources/SKILL.md`) �
 maps the ground-truth schedule sources (Liquipedia/HLTV/official X) and the
 Twitch/Kick viewing options for the late-announced matches the fetcher misses.
 
+**Check the channel against the broadcaster's OWN source (WP-241/242).** The rights
+map and tv-listings are priors; the party that CREATES the channel fact is the
+broadcaster itself. `scripts/config/authority.json` names the registered Norwegian
+broadcaster(s) per competition — and the registered TIME authority (the organizer/
+league/federation) — by id into `scripts/config/sources.json`. When you confirm or
+amend a channel, prefer the broadcaster's own page (programme schedule, help/rights
+page, press release) and stamp the event's `provenance.streaming` with
+`{ "sourceId": …, "url": …, "basis": "official", "retrievedAt": … }` for the page
+you actually read (`basis: "primary"` when the organizer self-streams). Likewise,
+when you verify or amend a `time`, stamp `provenance.time` from the organizer's own
+source (`basis: "primary"`). Never leave a `provenance` entry standing that
+contradicts what you just verified — the ⓘ-modal shows these citations to the user.
+
+**Beware lookalike domains.** The register (`sources.json`) is the truth about which
+domain IS the organizer. A domain that merely *looks* official — franceletour.com
+posing next to the real letour.fr — is not a source: never verify against one, and
+if you find one cited in an event's `evidence`, replace it with the real authority's
+URL as part of your amendment (the competition's `lookalikes` list in authority.json
+records the known offenders; add new ones you catch).
+
 **Resolve tentative channels to the real one.** A `streaming` entry marked
 `"tentative": true` (e.g. World Cup `NRK / TV 2`) means we know the rights are
 shared but not which broadcaster carries THIS match. Find the confirmed channel

--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -4,6 +4,7 @@ import path from "path";
 import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, configDirPath, MS_PER_DAY, makeCoverageGate, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
 import { resolveStreaming, stampUrlKinds } from "./lib/norwegian-rights.js";
+import { deriveProvenance } from "./lib/provenance.js";
 import { writeManifest } from "./build-manifest.js";
 import { writePortReport } from "./build-port-report.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
@@ -140,6 +141,8 @@ function pushEvent(ev, sport, tournament) {
 	if (ev.source) event.source = ev.source;
 	if (ev.confidence) event.confidence = ev.confidence;
 	if (ev.evidence) event.evidence = ev.evidence;
+	if (ev.provenance) event.provenance = ev.provenance; // WP-242: per-faktum-proveniens
+
 	if (ev.researchedAt) event.researchedAt = ev.researchedAt;
 	if (ev.verifiedAt) event.verifiedAt = ev.verifiedAt;
 	if (ev.verificationStatus) event.verificationStatus = ev.verificationStatus;
@@ -199,6 +202,10 @@ const CARRY_FORWARD_FIELDS = [
 	"norwegianPlayers",
 	"participants",
 	"summary",
+	// WP-242: en agent-stemplet per-faktum-proveniens på et statisk event må
+	// overleve at fetcheren regenererer eventet tomt hver time — samme
+	// begrunnelse som verifikasjonsstemplene over.
+	"provenance",
 ];
 // A verified streaming channel must beat a *non-empty* default — not just fill an
 // empty one. The carry-forward above only fills gaps, and the streaming-resolution
@@ -569,6 +576,17 @@ const catalog = readJsonIfExists(path.join(configDir, "catalog.json")) || {};
 // anomaly. See tests/build-events.test.js + tests/fixtures/feed-vectors/DIVERGENCES.md §6.
 const isCovered = makeCoverageGate(catalog);
 
+// WP-242: konfig for den mekaniske proveniens-migreringen i normaliserings-
+// passet under. Fail-soft: mangler registeret/kartet (f.eks. i testenes tomme
+// SPORTSYNC_CONFIG_DIR), skjer ingen migrering — feltet er valgfritt.
+const sourcesRegister = readJsonIfExists(path.join(configDir, "sources.json"));
+const authorityMap = readJsonIfExists(path.join(configDir, "authority.json"));
+const provenanceConfig =
+	Array.isArray(sourcesRegister?.sources) && Array.isArray(authorityMap?.competitions)
+		? { sources: sourcesRegister.sources, authority: authorityMap }
+		: null;
+let provenanceMigrated = 0;
+
 // Keep events from the last 14 days + upcoming, and only those the catalog covers
 const cutoff = Date.now() - 14 * MS_PER_DAY;
 let droppedIrrelevant = 0;
@@ -611,6 +629,21 @@ for (const e of kept) {
 	// without recomputing it). Idempotent for unchanged events: same inputs,
 	// same hash, same id across consecutive builds.
 	e.id = computeEventId(e.sport, e.title, e.time);
+	// WP-242: migrer flat evidence → per-faktum-proveniens der det er MEKANISK
+	// trygt (autoritetskartet + kilderegisteret, eksakt domenetreff — aldri
+	// lookalikes). Rører aldri et event som allerede bærer eksplisitt
+	// `provenance` (agent-skrevet vinner), og er deterministisk/idempotent:
+	// samme evidence + samme konfig ⇒ samme stempel på hvert bygg.
+	if (provenanceConfig && e.source === "ai-research" && !e.provenance) {
+		const derived = deriveProvenance(e, provenanceConfig);
+		if (derived) {
+			e.provenance = derived;
+			provenanceMigrated++;
+		}
+	}
+}
+if (provenanceMigrated > 0) {
+	console.log(`Migrated flat evidence to per-fact provenance on ${provenanceMigrated} AI-research event(s) (WP-242).`);
 }
 // WP-94: validate the array in-process BEFORE writing it, and degrade instead
 // of freezing the hourly pipeline on a violation. static-pipeline.yml runs

--- a/scripts/config/authority.json
+++ b/scripts/config/authority.json
@@ -1,0 +1,287 @@
+{
+	"$schema": "./authority.schema.json",
+	"updatedAt": "2026-07-29",
+	"notes": "WP-241 · Autoritetskartet: hvem SKAPER faktumet, per konkurranse på tavla. To kilder per event, fordi produktets to kjernefelt har to ulike skapere: TIDEN settes av arrangøren/ligaen/forbundet, KANALEN av kringkasteren selv. Id-ene peker inn i scripts/config/sources.json (WP-240) — registeret er sannheten om hvilket domene som ER arrangøren, og det er lookalike-vernet: da dette kartet ble seedet sto lookalike-domenet franceletour.com som evidens på en Tour de France-etappe, mens letour.fr (A.S.O., som faktisk lager ruta og starttidene) forekom NULL ganger i hele events.json. Research slår opp konkurransen her og går til autoriteten FØRST (scripts/agents/research.md); verify sjekker kanalen mot kringkasterens egen kilde (scripts/agents/verify.md); scripts/lib/provenance.js migrerer flat evidence til per-faktum-proveniens (WP-242) med det samme kartet. SEEDET 29.07.2026 med hver konkurranse som faktisk sto på tavla den dagen; kanal-valgene speiler .claude/skills/norwegian-rights (prioren) og tavlas verifiserte verdier. AI-VEDLIKEHOLDT som catalog.json: research utvider kartet når en ny konkurranse dekkes — alltid med arrangørens VIRKELIGE domene, registrert i sources.json først.",
+	"competitions": [
+		{
+			"id": "athletics:diamond-league",
+			"name": "Wanda Diamond League",
+			"sport": "athletics",
+			"match": ["diamond league"],
+			"time": { "sourceIds": ["diamond-league"], "note": "Diamond League AG setter stevneprogrammet; stevnene har egne underdomener (london.diamondleague.com)." },
+			"channel": { "options": [{ "sourceId": "nrk", "platform": "NRK" }], "note": "NRK har rettighetene 2025–2029 (inkl. Bislett Games)." }
+		},
+		{
+			"id": "athletics:em-friidrett",
+			"name": "EM friidrett (European Athletics Championships)",
+			"sport": "athletics",
+			"match": ["em friidrett", "european athletics championships"],
+			"time": { "sourceIds": ["european-athletics"] },
+			"channel": { "options": [{ "sourceId": "nrk", "platform": "NRK" }], "note": "NRK har friidretts-EM 2026." }
+		},
+		{
+			"id": "athletics:nm-friidrett",
+			"name": "NM friidrett",
+			"sport": "athletics",
+			"match": ["nm friidrett"],
+			"time": { "sourceIds": ["nm-friidrett-2026", "friidrettsforbundet"], "note": "Arrangørens egen mesterskapsside setter tidsskjemaet; Norges Friidrettsforbund sanksjonerer terminlista." },
+			"channel": { "options": [{ "sourceId": "nrk", "platform": "NRK" }] }
+		},
+		{
+			"id": "chess:esports-world-cup",
+			"name": "Esports World Cup (sjakk)",
+			"sport": "chess",
+			"match": ["esports world cup"],
+			"time": { "sourceIds": ["esports-world-cup"] },
+			"channel": { "options": [{ "sourceId": "twitch", "platform": "Twitch" }], "note": "Offisiell EWC-strøm; sendes også på Chess.com (registerets chess-com-oppføring er aggregator for terminlister — strømmen deres er likevel offisiell for dette formatet)." }
+		},
+		{
+			"id": "chess:grand-chess-tour",
+			"name": "Grand Chess Tour",
+			"sport": "chess",
+			"match": ["grand chess tour"],
+			"time": { "sourceIds": ["grand-chess-tour"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "grand-chess-tour", "platform": "YouTube", "note": "Selv-strømmet via Saint Louis Chess Club — arrangørens egen sending." },
+					{ "sourceId": "twitch", "platform": "Twitch" }
+				]
+			}
+		},
+		{
+			"id": "cycling:arctic-race-of-norway",
+			"name": "Arctic Race of Norway",
+			"sport": "cycling",
+			"match": ["arctic race"],
+			"time": { "sourceIds": ["arctic-race-of-norway"], "note": "Arrangert i partnerskap med A.S.O.; egen offisiell side." },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "Alle etapper direkte på TV 2 Direkte + TV 2 Play (TV2 Sykkels egen kunngjøring)." }
+		},
+		{
+			"id": "cycling:danmark-rundt",
+			"name": "PostNord Danmark Rundt",
+			"sport": "cycling",
+			"match": ["danmark rundt", "tour of denmark"],
+			"time": { "sourceIds": ["postnord-danmark-rundt"] },
+			"channel": { "options": [{ "sourceId": "hbo-max", "platform": "HBO Max" }], "note": "Verifisert på tavla juli 2026 (historisk Eurosport Norge/Max; DR/DRTV er dansk rettighetshaver)." }
+		},
+		{
+			"id": "cycling:tour-de-france",
+			"name": "Tour de France",
+			"sport": "cycling",
+			"match": ["tour de france"],
+			"time": { "sourceIds": ["letour"], "note": "A.S.O. LAGER ruta og starttidene — letour.fr er kilden, ikke aggregatorene som refererer den." },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "TV 2-avtale 2026–2030; eierpreferanse: vis kun TV 2 Play (se norwegian-rights-skillen)." },
+			"lookalikes": ["franceletour.com"],
+			"notes": "Kartets opphavseksempel: franceletour.com (en lookalike) sto som evidens på en etappe mens letour.fr aldri var sitert."
+		},
+		{
+			"id": "cycling:tour-de-france-femmes",
+			"name": "Tour de France Femmes",
+			"sport": "cycling",
+			"match": ["tour de france femmes"],
+			"time": { "sourceIds": ["letour"], "note": "A.S.O.; offisiell side letourfemmes.fr (registrert som endpoint på letour-kilden)." },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }] },
+			"lookalikes": ["franceletour.com"]
+		},
+		{
+			"id": "cycling:tour-de-pologne",
+			"name": "Tour de Pologne",
+			"sport": "cycling",
+			"match": ["tour de pologne"],
+			"time": { "sourceIds": ["tour-de-pologne"], "note": "Lang Team er arrangør; tourdepologne.pl setter etappetidene." },
+			"channel": {
+				"options": [
+					{ "sourceId": "hbo-max", "platform": "HBO Max" },
+					{ "sourceId": "eurosport-no", "platform": "Eurosport" }
+				]
+			}
+		},
+		{
+			"id": "cycling:vuelta-a-espana",
+			"name": "Vuelta a España",
+			"sport": "cycling",
+			"match": ["vuelta"],
+			"time": { "sourceIds": ["lavuelta"], "note": "Unipublic/A.S.O.; lavuelta.es er arrangørens side." },
+			"channel": { "options": [{ "sourceId": "hbo-max", "platform": "HBO Max" }], "note": "WBD-porteføljen; verifiser per etappe." }
+		},
+		{
+			"id": "esports:blast",
+			"name": "BLAST (Bounty/Premier)",
+			"sport": "esports",
+			"match": ["blast"],
+			"time": { "sourceIds": ["blast"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "blast", "platform": "BLAST.tv", "note": "Selv-strømmet — arrangørens egen gratissending." },
+					{ "sourceId": "twitch", "platform": "Twitch" },
+					{ "sourceId": "kick", "platform": "Kick" }
+				]
+			}
+		},
+		{
+			"id": "esports:esports-world-cup",
+			"name": "Esports World Cup (CS2)",
+			"sport": "esports",
+			"match": ["esports world cup"],
+			"time": { "sourceIds": ["esports-world-cup"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "twitch", "platform": "Twitch" },
+					{ "sourceId": "esports-world-cup", "platform": "YouTube", "note": "Arrangørens egen offisielle strøm." }
+				]
+			}
+		},
+		{
+			"id": "esports:starladder",
+			"name": "StarLadder (StarSeries)",
+			"sport": "esports",
+			"match": ["starladder"],
+			"time": { "sourceIds": ["starladder"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "kick", "platform": "Kick" },
+					{ "sourceId": "twitch", "platform": "Twitch" }
+				],
+				"note": "StarLadder selv-strømmer gratis (Kick/Twitch)."
+			}
+		},
+		{
+			"id": "f1:world-championship",
+			"name": "Formula 1 World Championship",
+			"sport": "f1",
+			"match": ["formula 1", "formel 1"],
+			"time": { "sourceIds": ["formula1"], "note": "formula1.com er arrangøren og MØNSTERET (4 av 4 kalibreringssjekker riktige); ESPN feildaterer notorisk løpshelger (source-quirks)." },
+			"channel": { "options": [{ "sourceId": "viaplay", "platform": "Viaplay" }], "note": "Viaplay har alle økter (trening/kvalik/sprint/løp)." }
+		},
+		{
+			"id": "football:champions-league",
+			"name": "UEFA Champions League",
+			"sport": "football",
+			"match": ["champions league"],
+			"time": { "sourceIds": ["uefa"] },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "CL er TV 2s i Norge t.o.m. 2030/31." }
+		},
+		{
+			"id": "football:club-friendlies",
+			"name": "Treningskamper (klubb)",
+			"sport": "football",
+			"match": ["treningskamp", "friendly"],
+			"time": {
+				"sourceIds": ["fc-barcelona", "manchester-united", "tromso-il", "birmingham-city"],
+				"note": "Klubbens EGEN side er primærkilden for egne treningskamper (rolledoktrinen i sources.json) — listen er klubbene vi faktisk følger; utvid registeret når en ny klubbs kamp dekkes."
+			},
+			"channel": { "options": [], "note": "Varierer per kamp (VG TV, TV 2 Play, klubb-TV …) — docs/data/tv-listings.json er norsk fasit; ellers kringkasterens egen kunngjøring per kamp." }
+		},
+		{
+			"id": "football:community-shield",
+			"name": "FA Community Shield",
+			"sport": "football",
+			"match": ["community shield"],
+			"time": { "sourceIds": ["the-fa"], "note": "The FA arrangerer og setter avspark." },
+			"channel": { "options": [{ "sourceId": "viaplay", "platform": "Viaplay" }] }
+		},
+		{
+			"id": "football:conference-league",
+			"name": "UEFA Conference League",
+			"sport": "football",
+			"match": ["conference league"],
+			"time": { "sourceIds": ["uefa"] },
+			"channel": { "options": [{ "sourceId": "viaplay", "platform": "Viaplay" }], "note": "Viaplay har EL+ECL i Norge t.o.m. 2030/31; norske klubbers tidlige kvalikkamper kan ha fri-sublisens (VG TV)." }
+		},
+		{
+			"id": "football:eliteserien",
+			"name": "Eliteserien",
+			"sport": "football",
+			"match": ["eliteserien"],
+			"time": { "sourceIds": ["eliteserien", "fotball-no"], "note": "Norsk Toppfotball setter kampoppsettet; NFF (fotball.no) er forbundets terminliste-register." },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }] }
+		},
+		{
+			"id": "football:europa-league",
+			"name": "UEFA Europa League",
+			"sport": "football",
+			"match": ["europa league"],
+			"time": { "sourceIds": ["uefa"] },
+			"channel": { "options": [{ "sourceId": "viaplay", "platform": "Viaplay" }], "note": "Se conference-league-noten om fri-sublisenser." }
+		},
+		{
+			"id": "football:la-liga",
+			"name": "La Liga",
+			"sport": "football",
+			"match": ["la liga"],
+			"time": { "sourceIds": ["laliga"] },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "TV 2 fornyet de norske rettighetene t.o.m. sommeren 2030." }
+		},
+		{
+			"id": "football:obos-ligaen",
+			"name": "OBOS-ligaen",
+			"sport": "football",
+			"match": ["obos"],
+			"time": { "sourceIds": ["eliteserien", "fotball-no"], "note": "Norsk Toppfotball (obos-ligaen.no er endpoint på eliteserien-kilden)." },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }] }
+		},
+		{
+			"id": "football:premier-league",
+			"name": "Premier League",
+			"sport": "football",
+			"match": ["premier league"],
+			"time": { "sourceIds": ["premier-league"] },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "TV 2 Play / TV 2 Sport Premium." }
+		},
+		{
+			"id": "football:super-cup",
+			"name": "UEFA Super Cup",
+			"sport": "football",
+			"match": ["super cup"],
+			"time": { "sourceIds": ["uefa"] },
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }] }
+		},
+		{
+			"id": "football:world-cup",
+			"name": "FIFA World Cup",
+			"sport": "football",
+			"match": ["fifa world cup", "world cup", "vm"],
+			"time": { "sourceIds": ["fifa"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "nrk", "platform": "NRK" },
+					{ "sourceId": "tv2", "platform": "TV 2" }
+				],
+				"note": "Delte rettigheter, per-kamp-fordeling — verify løser hver kamp til én konkret kanal."
+			}
+		},
+		{
+			"id": "golf:dp-world-tour",
+			"name": "DP World Tour",
+			"sport": "golf",
+			"match": ["dp world tour"],
+			"time": { "sourceIds": ["european-tour"] },
+			"channel": { "options": [{ "sourceId": "viaplay", "platform": "Viaplay" }] }
+		},
+		{
+			"id": "golf:pga-tour",
+			"name": "PGA Tour (inkl. FedExCup)",
+			"sport": "golf",
+			"match": ["pga tour", "fedexcup", "fedex cup"],
+			"time": { "sourceIds": ["pgatour"] },
+			"channel": {
+				"options": [
+					{ "sourceId": "hbo-max", "platform": "HBO Max" },
+					{ "sourceId": "eurosport-no", "platform": "Eurosport" }
+				],
+				"note": "WBD tok ordinær PGA Tour for 2026 (Corales-revert-krigen); The Open + US Open er Viaplays."
+			}
+		},
+		{
+			"id": "tennis:tour",
+			"name": "ATP/WTA Tour",
+			"sport": "tennis",
+			"match": ["atp", "wta"],
+			"time": {
+				"sourceIds": ["atp-tour", "wta", "swiss-open-gstaad"],
+				"note": "Touren setter kampprogrammet (atptour.com/wtatennis.com); den enkelte turneringens egen side (f.eks. swissopengstaad.ch) er likeverdig primær for sitt eget program. NB WP-246: ATPs vilkår § 4A forbyr dyplenking til undersider — tennis håndteres særskilt der."
+			},
+			"channel": { "options": [{ "sourceId": "tv2", "platform": "TV 2" }], "note": "TV 2 har ATP-rettighetene i Norge t.o.m. 2026; WTA/Grand Slam-rettigheter avviker (Discovery/Max) — verifiser per turnering." }
+		}
+	]
+}

--- a/scripts/config/authority.schema.json
+++ b/scripts/config/authority.schema.json
@@ -1,0 +1,103 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "Sportivista – autoritetskart per konkurranse",
+	"description": "WP-241: HVEM skaper faktumet, per dekket konkurranse. Produktet står og faller på to felt per event — starttiden og den norske kanalen — og de har to ULIKE skapere: arrangøren/ligaen/forbundet setter tiden, kringkasteren setter kanalen. Dette kartet binder hver konkurranse til de to kildene, ved id inn i scripts/config/sources.json (WP-240-registeret er sannheten om hvilket domene som ER arrangøren — lookalike-vernet). Kartet finnes fordi research-laget beviselig siterer det PRAKTISKE framfor det AUTORITATIVE: letour.fr (A.S.O., som faktisk lager Tour de France-ruta) forekom null ganger i events.json, mens lookalike-domenet franceletour.com sto som evidens på en etappe. Agentene slår opp konkurransen her og går til autoriteten FØRST; scripts/lib/provenance.js bruker det samme kartet til å migrere flat evidence til per-faktum-proveniens (WP-242).",
+	"type": "object",
+	"required": ["updatedAt", "competitions"],
+	"additionalProperties": false,
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "Relativ sti til dette skjemaet — github.dev-autofullføring og CI-kontrakt (tests/authority-schema.test.js) fra samme fil."
+		},
+		"updatedAt": {
+			"type": "string",
+			"description": "Siste helhetlige gjennomgang (YYYY-MM-DD).",
+			"pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+		},
+		"notes": {
+			"type": "string",
+			"description": "Fritt notat til mennesker og agenter (metode, kjente hull)."
+		},
+		"competitions": {
+			"type": "array",
+			"description": "Konkurransene, SORTERT på id (determinisme — ren diff ved endringer). Minst konkurransene som faktisk er på tavla.",
+			"items": { "$ref": "#/definitions/competition" }
+		}
+	},
+	"definitions": {
+		"competition": {
+			"type": "object",
+			"required": ["id", "name", "sport", "match", "time", "channel"],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "Stabil nøkkel på formen sport:konkurranse — samme navnerom som sources.json sitt authorityFor (\"cycling:tour-de-france\", \"football:eliteserien\").",
+					"pattern": "^[a-z0-9]+(-[a-z0-9]+)*:[a-z0-9]+(-[a-z0-9]+)*$"
+				},
+				"name": { "type": "string", "description": "Menneskelig navn på konkurransen." },
+				"sport": {
+					"type": "string",
+					"description": "Sport-nøkkelen slik events.json bruker den (\"cycling\", \"football\", \"f1\").",
+					"pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+				},
+				"match": {
+					"type": "array",
+					"description": "Små bokstaver-substrenger som identifiserer konkurransen i et events tournament/meta/title (f.eks. [\"tour de france\"]). Ved overlapp vinner det LENGSTE treffet (\"tour de france femmes\" foran \"tour de france\") — håndhevet i scripts/lib/provenance.js.",
+					"items": { "type": "string" }
+				},
+				"time": {
+					"type": "object",
+					"description": "Hvem SKAPER starttiden: arrangøren, ligaen eller forbundet. sourceIds peker inn i sources.json; flere id-er betyr flere legitime skapere (klubbenes egne sider for treningskamper).",
+					"required": ["sourceIds"],
+					"additionalProperties": false,
+					"properties": {
+						"sourceIds": {
+							"type": "array",
+							"description": "Id-er i sources.json med rolle primary eller federation (håndhevet av testen). TOM liste er et ærlig hull — da MÅ note forklare hvorfor.",
+							"items": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" }
+						},
+						"note": { "type": "string" }
+					}
+				},
+				"channel": {
+					"type": "object",
+					"description": "Hvem SKAPER kanalfaktumet for et norsk publikum: kringkasteren selv (eller arrangøren når den selv-strømmer, som BLAST/StarLadder på Twitch/Kick). options-listen kobler hver registrert kringkaster til plattformnavnet slik det står i events streaming[].platform.",
+					"required": ["options"],
+					"additionalProperties": false,
+					"properties": {
+						"options": {
+							"type": "array",
+							"description": "Én oppføring per legitim norsk visningskanal. TOM liste er et ærlig \"rettigheter ikke avklart\" — da MÅ note forklare.",
+							"items": {
+								"type": "object",
+								"required": ["sourceId", "platform"],
+								"additionalProperties": false,
+								"properties": {
+									"sourceId": {
+										"type": "string",
+										"description": "Id i sources.json med rolle official-broadcaster (eller primary ved selv-strømming — håndhevet av testen).",
+										"pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+									},
+									"platform": {
+										"type": "string",
+										"description": "Plattformnavnet slik det (typisk) står i streaming[].platform — matches som ord-prefiks («TV 2 Play» dekker også «TV 2 Play / TV 2 Sport Premium»)."
+									},
+									"note": { "type": "string" }
+								}
+							}
+						},
+						"note": { "type": "string" }
+					}
+				},
+				"lookalikes": {
+					"type": "array",
+					"description": "KJENTE lookalike-domener som utgir seg for å være arrangøren og ALDRI skal siteres (franceletour.com for Tour de France). Registeret (sources.json) er sannheten om hvilket domene som ER arrangøren; denne listen er varselskiltene vi allerede har snublet i.",
+					"items": { "type": "string" }
+				},
+				"notes": { "type": "string", "description": "Fritt notat: rettighetsvindu, kjente feller, hva som må avklares." }
+			}
+		}
+	}
+}

--- a/scripts/config/events.schema.json
+++ b/scripts/config/events.schema.json
@@ -136,8 +136,17 @@
 		},
 		"evidence": {
 			"type": "array",
-			"description": "Kilde-URLer for et ai-research-event.",
+			"description": "Kilde-URLer for et ai-research-event. LEGACY-FORM (WP-242): én flat liste for hele eventet, som ikke sier HVILKET faktum hver URL bærer. Beholdes for bakoverkompatibilitet og som bredde-dokumentasjon; per-faktum-proveniensen ligger i \"provenance\".",
 			"items": { "type": "string" }
+		},
+		"provenance": {
+			"type": "object",
+			"description": "WP-242 — proveniens PER FAKTUM. Produktets to kjernefelt har to ulike skapere (arrangøren setter tiden, kringkasteren setter kanalen — se scripts/config/authority.json), så hvert av dem får sin egen kildeoppføring i stedet for én flat evidence-liste for hele eventet. Skrives av research/verify når de finner/verifiserer faktumet; scripts/lib/provenance.js migrerer i tillegg mekanisk fra flat evidence der det er trygt (kun eksakt domenetreff mot registeret — lookalike-domener som franceletour.com migreres ALDRI). Valgfritt felt: eldre events med bare flat evidence forblir gyldige.",
+			"additionalProperties": false,
+			"properties": {
+				"time": { "$ref": "#/definitions/provenanceFact" },
+				"streaming": { "$ref": "#/definitions/provenanceFact" }
+			}
 		},
 		"researchedAt": {
 			"type": "string",
@@ -167,6 +176,19 @@
 		}
 	},
 	"definitions": {
+		"provenanceFact": {
+			"description": "Proveniens for ETT faktum (WP-242). sourceId peker inn i scripts/config/sources.json (WP-240-registeret — sannheten om hvilket domene som ER arrangøren); url er siden faktumet faktisk ble lest på; basis sier hvilken plass kilden har i kjeden: \"primary\" = skaperen av faktumet (arrangøren/ligaen/forbundet for tid; jf. authority.json), \"official\" = en offisiell parts egen publisering (kringkasterens egen side for kanal — kanalens skaper), \"secondary\" = alt annet (aggregator, media, wiki). retrievedAt er når kilden ble lest (ISO 8601); for mekanisk migrerte fakta brukes researchedAt/verifiedAt som ærlig tilnærming, med \"note\" som sier at oppføringen er migrert.",
+			"type": "object",
+			"required": ["sourceId", "url", "basis"],
+			"additionalProperties": false,
+			"properties": {
+				"sourceId": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" },
+				"url": { "type": "string" },
+				"basis": { "enum": ["primary", "official", "secondary"] },
+				"retrievedAt": { "type": "string" },
+				"note": { "type": "string" }
+			}
+		},
 		"streamingChannel": {
 			"description": "Én visningsmulighet. platform/url er kjernefeltene; tentative markerer et uverifisert kanalgjett (f.eks. det delte \"NRK / TV 2\"-gjettet før verify løser det); urlKind sier hva slags URL det er (WP-246).",
 			"type": "object",

--- a/scripts/config/sources.json
+++ b/scripts/config/sources.json
@@ -41,6 +41,43 @@
 			"notes": "En av 14 RSS-kilder i scripts/fetch-rss.js. Bærer nyhetspekere (docs/data/news.json), aldri artikkeltekst."
 		},
 		{
+			"id": "arctic-race-of-norway",
+			"name": "Arctic Race of Norway",
+			"publisher": "Arctic Race of Norway AS / A.S.O.",
+			"url": "https://www.arctic-race-of-norway.com",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"cycling:arctic-race-of-norway"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"route",
+				"results"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "none",
+				"mechanism": "robots.txt nevner ingen AI-agenter eller TDM-forbehold (kun admin-/api-stier sperret). NB: kun robots sjekket i denne seedingen — vilkårstekst ikke gjennomgått.",
+				"evidence": [
+					"https://www.arctic-race-of-norway.com/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": true,
+				"note": "`*`-blokken sperrer /admin, /api, /graphql o.l. — ikke rittsidene.",
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): arrangøren av Arctic Race of Norway (A.S.O.-partnerskap) — autoritativ på egne etappetider. robots.txt sjekket mekanisk 29.07.2026; vilkår ennå ikke lest (`unknown` betyr her «ikke avklart»)."
+		},
+		{
 			"id": "atp-tour",
 			"name": "ATP Tour",
 			"publisher": "ATP Tour, Inc.",
@@ -814,7 +851,8 @@
 			"role": "primary",
 			"status": "in-use",
 			"authorityFor": [
-				"esports:esports-world-cup"
+				"esports:esports-world-cup",
+				"chess:esports-world-cup"
 			],
 			"facts": [
 				"schedule",
@@ -841,6 +879,43 @@
 				"checkedAt": "2026-07-29"
 			},
 			"calibrationKey": "esportsworldcup.com"
+		},
+		{
+			"id": "european-athletics",
+			"name": "European Athletics",
+			"publisher": "European Athletic Association",
+			"url": "https://european-athletics.com",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"athletics:european-championships"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"results",
+				"entry-list"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "unknown",
+				"mechanism": "robots.txt utilgjengelig fra dette miljøet (Cloudflare-utfordring svarer i stedet) — intet maskinlesbart signal å tolke",
+				"evidence": [
+					"https://european-athletics.com/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": null,
+				"note": "Cloudflare bot-utfordring foran hele nettstedet — samme operasjonelle klasse som letour.fr/hltv (mater WP-244).",
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): det europeiske friidrettsforbundet — arrangør av EM friidrett (på tavla i dag) og autoritativ på mesterskapets tidsskjema. Vilkår ennå ikke lest."
 		},
 		{
 			"id": "european-tour",
@@ -1610,6 +1685,43 @@
 				"checkedAt": "2026-07-29"
 			},
 			"notes": "Visningsplattform for CS2 i scripts/config/sports-config.js. Vi lenker dit; vi henter ikke data derfra."
+		},
+		{
+			"id": "laliga",
+			"name": "LALIGA",
+			"publisher": "Liga Nacional de Fútbol Profesional",
+			"url": "https://www.laliga.com",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"football:la-liga"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"results",
+				"standings"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "none",
+				"mechanism": "robots.txt nevner ingen AI-agenter eller TDM-forbehold (kun språkprefiks-styring for søkemotorer). NB: kun robots sjekket i denne seedingen — vilkårstekst ikke gjennomgått.",
+				"evidence": [
+					"https://www.laliga.com/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": true,
+				"note": "`Allow: /` for `*`; Disallow-linjene gjelder dype språkstier, ikke terminlistene.",
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): ligaen selv setter La Liga-kampoppsettet (på tavla i dag via TV 2-rettighetene). Vilkår ennå ikke lest."
 		},
 		{
 			"id": "lavuelta",
@@ -2537,6 +2649,42 @@
 			"notes": "Kommersiell resultattjeneste (2 bruk) — sterkt databasevern, ingen egen autoritet. Bør ikke stå som grunnlag."
 		},
 		{
+			"id": "starladder",
+			"name": "StarLadder",
+			"publisher": "StarLadder",
+			"url": "https://starladder.com",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"esports:starladder"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"results",
+				"channel"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "none",
+				"mechanism": "robots.txt er `User-agent: * / Allow: /` — ingen AI-agenter eller TDM-forbehold nevnt. NB: kun robots sjekket i denne seedingen — vilkårstekst ikke gjennomgått.",
+				"evidence": [
+					"https://starladder.com/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": true,
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): turneringsarrangør i CS2 (StarSeries, på tavla i dag) — autoritativ på egne kampoppsett og selv-strømmer gratis (Kick/Twitch). Se .claude/skills/cs2-sources. Vilkår ennå ikke lest."
+		},
+		{
 			"id": "swiss-open-gstaad",
 			"name": "Swiss Open Gstaad",
 			"url": "https://www.swissopengstaad.ch",
@@ -2571,6 +2719,43 @@
 			"rateLimit": "Crawl-delay: 10 (robots.txt)",
 			"calibrationKey": "swissopengstaad.ch",
 			"notes": "Turneringsarrangørens egen side — riktig kilde for banetider."
+		},
+		{
+			"id": "the-fa",
+			"name": "The Football Association",
+			"publisher": "The Football Association Limited",
+			"url": "https://www.thefa.com",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"football:community-shield",
+				"football:fa-cup"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"results"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "none",
+				"mechanism": "robots.txt har KUN blokker for navngitte søkecrawlere (gsa-crawler, Googlebot, Bingbot …) og ingen `*`-blokk — ingen AI-agenter eller TDM-forbehold nevnt. NB: kun robots sjekket i denne seedingen — vilkårstekst ikke gjennomgått.",
+				"evidence": [
+					"https://www.thefa.com/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": true,
+				"note": "Ingen `User-agent: *`-blokk ⇒ udefinerte agenter er uregulert (alt tillatt etter standarden).",
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): FA arrangerer Community Shield (på tavla i dag) og FA-cupen — autoritativ på avspark for egne kamper. Vilkår ennå ikke lest."
 		},
 		{
 			"id": "the-guardian",
@@ -2609,6 +2794,42 @@
 				"checkedAt": "2026-07-29"
 			},
 			"notes": "RSS-kilde for internasjonal fotball (entity-modus). Guardian oppgir en kontaktadresse for lisensiering — forbeholdet er altså «betal, ikke forsvinn»."
+		},
+		{
+			"id": "tour-de-pologne",
+			"name": "Tour de Pologne",
+			"publisher": "Lang Team",
+			"url": "https://www.tourdepologne.pl",
+			"role": "primary",
+			"status": "candidate",
+			"authorityFor": [
+				"cycling:tour-de-pologne"
+			],
+			"facts": [
+				"schedule",
+				"start-time",
+				"route",
+				"results"
+			],
+			"terms": {
+				"automatedAccess": "unknown",
+				"basis": "not-found",
+				"attributionRequired": null,
+				"reviewedAt": "2026-07-29"
+			},
+			"tdmReservation": {
+				"status": "none",
+				"mechanism": "robots.txt (Yoast-standard, `Disallow:` tom) nevner ingen AI-agenter eller TDM-forbehold. NB: kun robots sjekket i denne seedingen — vilkårstekst ikke gjennomgått.",
+				"evidence": [
+					"https://www.tourdepologne.pl/robots.txt"
+				],
+				"checkedAt": "2026-07-29"
+			},
+			"robots": {
+				"allowsOurPaths": true,
+				"checkedAt": "2026-07-29"
+			},
+			"notes": "Seedet av WP-241 (autoritetskartet): Lang Team arrangerer Tour de Pologne (på tavla i dag) og setter etappetidene — dagens evidens siterer i stedet aggregatorer. Vilkår ennå ikke lest."
 		},
 		{
 			"id": "tromso-il",

--- a/scripts/lib/provenance.js
+++ b/scripts/lib/provenance.js
@@ -1,0 +1,176 @@
+// WP-242 · Proveniens per faktum — den mekaniske migreringsbiten.
+//
+// Dagens ai-research-events bærer én flat `evidence`-liste for HELE eventet,
+// som ikke sier hvilket faktum hver URL faktisk understøtter. Produktets to
+// kjernefelt har to ulike skapere (arrangøren setter TIDEN, kringkasteren
+// setter KANALEN — scripts/config/authority.json), så per-faktum-proveniensen
+// er formet som `provenance: { time, streaming }` med sourceId/url/basis/
+// retrievedAt per faktum (skjemaet: scripts/config/events.schema.json).
+//
+// Denne fila migrerer det som lar seg migrere MEKANISK, og ikke mer:
+//   • et tidsfaktum stemples kun når evidensen inneholder en URL som beviselig
+//     hører til en registrert tidsautoritet for konkurransen (authority.json),
+//     eller en primær-/forbundskilde som er autoritativ for sporten
+//     (sources.json-rolledoktrinen);
+//   • et kanalfaktum stemples kun når evidensen inneholder en URL fra den
+//     registrerte kringkasteren OG eventets streaming-plattform faktisk matcher
+//     kartets opsjon;
+//   • alt annet beholder bare sin flate evidence — å gjette hvilken URL som bar
+//     hvilket faktum ville gjort proveniensen verdiløs.
+//
+// LOOKALIKE-VERNET er kjernen: domenetreff er eksakt vert eller ekte
+// under-/overdomene av registerets registrerte verter — aldri fuzzy. Dermed kan
+// franceletour.com (lookaliken som faktisk sto som evidens på en TdF-etappe)
+// ALDRI migreres til A.S.O.-kilden `letour` (letour.fr).
+//
+// Brukes av build-events.js i den avsluttende normaliseringspassen (fail-soft:
+// mangler authority.json/sources.json, skjer ingen migrering) og er
+// nettverksfri — ren funksjon av (event, config).
+
+const MIGRATED_NOTE = "migrert mekanisk fra evidence (WP-242)";
+
+/** Rolledoktrinen (sources.json) → basis-enum (events.schema.json). */
+export function basisForRole(role) {
+	if (role === "primary" || role === "federation") return "primary";
+	if (role === "official-broadcaster") return "official";
+	return "secondary";
+}
+
+function hostOfUrl(u) {
+	try {
+		return new URL(u).hostname.replace(/^www\./, "").toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+/** Alle vertene en kilde dekker: `url` + `endpoints`, uten www. */
+export function sourceHosts(source) {
+	return [source.url, ...(source.endpoints || [])].map(hostOfUrl).filter(Boolean);
+}
+
+/**
+ * Hører URL-en beviselig til kilden? Eksakt vert eller ekte under-/overdomene
+ * i begge retninger (hjelp.tv2.no ↔ tv2.no; en.wikipedia.org ↔ wikipedia.org)
+ * — samme regel som tests/sources-schema.test.js. ALDRI fuzzy/likhets-match:
+ * lookalike-vernet (franceletour.com ≠ letour.fr) er hele poenget.
+ */
+export function urlBelongsToSource(url, source) {
+	const h = hostOfUrl(url);
+	if (!h) return false;
+	return sourceHosts(source).some((reg) => h === reg || h.endsWith(`.${reg}`) || reg.endsWith(`.${h}`));
+}
+
+/**
+ * Slå opp konkurransen et event hører til i autoritetskartet: samme sport +
+ * substring-treff i tournament/meta/title. Ved overlappende mønstre vinner det
+ * LENGSTE treffet ("tour de france femmes" foran "tour de france").
+ */
+export function findCompetition(event, authority) {
+	if (!event || !authority || !Array.isArray(authority.competitions)) return null;
+	const hay = [event.tournament, event.meta, event.title]
+		.filter((v) => typeof v === "string" && v)
+		.join(" ")
+		.toLowerCase();
+	if (!hay) return null;
+	let best = null;
+	let bestLen = -1;
+	for (const comp of authority.competitions) {
+		if (comp.sport !== event.sport) continue;
+		for (const m of comp.match || []) {
+			if (typeof m !== "string" || !m) continue;
+			const needle = m.toLowerCase();
+			if (hay.includes(needle) && needle.length > bestLen) {
+				best = comp;
+				bestLen = needle.length;
+			}
+		}
+	}
+	return best;
+}
+
+/** Er kilden autoritativ for sporten (bar sport eller sport:konkurranse)? */
+function coversSport(source, sport) {
+	return (source.authorityFor || []).some((a) => a === sport || a.startsWith(`${sport}:`));
+}
+
+/** Ord-prefiks-match mellom events plattformnavn og kartets opsjon ("TV 2" dekker "TV 2 Play"). */
+function platformMatches(eventPlatform, optionPlatform) {
+	const ev = String(eventPlatform || "").toLowerCase();
+	const opt = String(optionPlatform || "").toLowerCase();
+	return !!ev && !!opt && ev.startsWith(opt);
+}
+
+/** Første URL i lista som beviselig hører til en av kandidatkildene. */
+function pickFact(urls, candidateSources) {
+	for (const url of urls) {
+		for (const source of candidateSources) {
+			if (urlBelongsToSource(url, source)) {
+				return { sourceId: source.id, url, basis: basisForRole(source.role) };
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Mekanisk migrering: utled per-faktum-proveniens for ett ai-research-event fra
+ * dets flate evidence (+ verificationSources), autoritetskartet og
+ * kilderegisteret. Konservativ: returnerer null når ingenting kan migreres
+ * trygt, og rører ALDRI et event som allerede har eksplisitt `provenance`
+ * (agent-skrevet proveniens vinner alltid over en mekanisk utledning).
+ * retrievedAt settes til verifiedAt/researchedAt — tidspunktet faktumet
+ * beviselig sist ble lest av en agent — og hver migrert oppføring bærer en
+ * `note` som sier at den er migrert, så den kan skilles fra førstehånds
+ * proveniens.
+ */
+export function deriveProvenance(event, { authority, sources } = {}) {
+	if (!event || event.source !== "ai-research" || event.provenance) return null;
+	const register = Array.isArray(sources) ? sources : [];
+	if (!register.length) return null;
+	const urls = [...(event.evidence || []), ...(event.verificationSources || [])].filter(
+		(u) => typeof u === "string" && u
+	);
+	if (!urls.length) return null;
+	const retrievedAt = event.verifiedAt || event.researchedAt || null;
+	const byId = new Map(register.map((s) => [s.id, s]));
+	const comp = findCompetition(event, authority);
+	const out = {};
+
+	// TID — kartets registrerte tidsautoritet for konkurransen først; ellers en
+	// primær-/forbundskilde som er autoritativ for sporten (klubbens egen side
+	// for egne kamper hører hjemme her via rolledoktrinen).
+	const mappedTimeAuthorities = (comp?.time?.sourceIds || [])
+		.map((id) => byId.get(id))
+		.filter(Boolean);
+	const sportAuthorities = register.filter(
+		(s) => (s.role === "primary" || s.role === "federation") && coversSport(s, event.sport)
+	);
+	const timeFact = pickFact(urls, mappedTimeAuthorities) || pickFact(urls, sportAuthorities);
+	if (timeFact) {
+		out.time = { ...timeFact, ...(retrievedAt ? { retrievedAt } : {}), note: MIGRATED_NOTE };
+	}
+
+	// KANAL — kun via kartets kanal-opsjoner, og kun når eventets synlige
+	// plattform matcher opsjonen OG evidensen faktisk inneholder en URL fra den
+	// registrerte kringkasteren. Alt annet er for usikkert å migrere.
+	const platforms = (event.streaming || []).map((s) => s && s.platform).filter(Boolean);
+	for (const opt of comp?.channel?.options || []) {
+		if (!platforms.some((p) => platformMatches(p, opt.platform))) continue;
+		const source = byId.get(opt.sourceId);
+		if (!source) continue;
+		const url = urls.find((u) => urlBelongsToSource(u, source));
+		if (url) {
+			out.streaming = {
+				sourceId: source.id,
+				url,
+				basis: basisForRole(source.role),
+				...(retrievedAt ? { retrievedAt } : {}),
+				note: MIGRATED_NOTE,
+			};
+			break;
+		}
+	}
+
+	return out.time || out.streaming ? out : null;
+}

--- a/scripts/validate-events.js
+++ b/scripts/validate-events.js
@@ -24,7 +24,8 @@ export function loadEventSchema() {
  * degraded instead of freezing the whole hourly pipeline (see build-events.js
  * for the retain-previous-good-data + build-alert.json behaviour).
  *
- * Returns { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages } — `errors` is
+ * Returns { errors, streamingMissing, streamingLandingOnly, timeBasisWeak,
+ * channelBasisWeak, enrichedCount, messages } — `errors` is
  * the hard-error count (a caller treats > 0 as "do not publish this array");
  * `messages` are the human-readable warn/violation lines, in the same wording
  * this script has always printed.
@@ -34,6 +35,8 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 	let errors = 0;
 	let streamingMissing = 0;
 	let streamingLandingOnly = 0;
+	let timeBasisWeak = 0;
+	let channelBasisWeak = 0;
 	const cutoff = now - GRACE_WINDOW_MS; // allow tiny grace window
 	const seenKeys = new Set();
 	for (const ev of events) {
@@ -100,6 +103,23 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 					streamingMissing++;
 				}
 			}
+			// Basis contract (soft, WP-242): HIGH confidence requires per-fact
+			// provenance with a primary/official basis — the TIME from the party
+			// that CREATES it (organizer/league/federation, see
+			// scripts/config/authority.json), the CHANNEL from the broadcaster's
+			// own source (or the organizer when it self-streams). Same form as the
+			// hard "high needs 2+ evidence URLs" rule above, but counted as a
+			// WARNING first so the gap becomes measurable without felling the
+			// pipeline on day one (the WP-246 pattern). "secondary" or missing
+			// provenance on a high-confidence fact is the exact cyclingstage/
+			// franceletour failure this contract exists to close.
+			if (ev.confidence === "high") {
+				const strong = (fact) => fact && (fact.basis === "primary" || fact.basis === "official");
+				if (!strong(ev.provenance?.time)) timeBasisWeak++;
+				if (Array.isArray(ev.streaming) && ev.streaming.length > 0 && !strong(ev.provenance?.streaming)) {
+					channelBasisWeak++;
+				}
+			}
 		}
 		// Link-honesty signal (soft, WP-246): a near-term event whose ONLY viewing URL
 		// is a service landing page (front page / sport section) does not answer "hvor
@@ -131,7 +151,7 @@ export function validateEvents(events, eventSchema, { now = Date.now() } = {}) {
 		}
 	}
 	const enrichedCount = events.filter((e) => e.importance != null).length;
-	return { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages };
+	return { errors, streamingMissing, streamingLandingOnly, timeBasisWeak, channelBasisWeak, enrichedCount, messages };
 }
 
 function main() {
@@ -155,13 +175,19 @@ function main() {
 		process.exit(1);
 	}
 
-	const { errors, streamingMissing, streamingLandingOnly, enrichedCount, messages } = validateEvents(events, eventSchema);
+	const { errors, streamingMissing, streamingLandingOnly, timeBasisWeak, channelBasisWeak, enrichedCount, messages } = validateEvents(events, eventSchema);
 	for (const m of messages) console.warn(m);
 	if (streamingMissing > 0) {
 		console.warn(`Streaming info missing on ${streamingMissing} near-term AI-research event(s) — "hvor kan jeg se det" unanswered.`);
 	}
 	if (streamingLandingOnly > 0) {
 		console.warn(`Landing-page-only channel URL on ${streamingLandingOnly} near-term event(s) — the channel name is right, but the link points at a service front page, not the broadcast (WP-246).`);
+	}
+	if (timeBasisWeak > 0) {
+		console.warn(`Weak time basis on ${timeBasisWeak} high-confidence AI-research event(s) — the start time is not backed by a primary/official source (see scripts/config/authority.json; WP-242).`);
+	}
+	if (channelBasisWeak > 0) {
+		console.warn(`Weak channel basis on ${channelBasisWeak} high-confidence AI-research event(s) — the channel is not backed by the broadcaster's own source (WP-242).`);
 	}
 	console.log(`Validated ${events.length} events with ${errors} error(s). ${enrichedCount} enriched.`);
 	if (errors) process.exit(1);

--- a/tests/agent-prompts.test.js
+++ b/tests/agent-prompts.test.js
@@ -55,6 +55,26 @@ describe("agent prompts", () => {
 		}
 	});
 
+	it("WP-241/242: autoritet-først og proveniens per faktum er promptede kontrakter", () => {
+		const research = read("research.md");
+		const verify = read("verify.md");
+		// Research slår opp autoritetskartet og går til skaperen av faktumet først.
+		expect(research).toContain("authority.json");
+		expect(research).toContain("sources.json");
+		expect(research).toContain('"provenance"');
+		expect(research).toContain('"basis"');
+		// Verify sjekker kanalen mot kringkasterens EGEN kilde og stempler proveniens.
+		expect(verify).toContain("authority.json");
+		expect(verify).toContain("provenance.streaming");
+		expect(verify).toContain("provenance.time");
+		// Lookalike-advarselen står i BEGGE, med opphavseksempelet navngitt —
+		// registeret er sannheten om hvilket domene som ER arrangøren.
+		for (const [name, p] of [["research.md", research], ["verify.md", verify]]) {
+			expect(p.toLowerCase(), `${name} mangler lookalike-advarselen`).toContain("lookalike");
+			expect(p, `${name} bør navngi franceletour-eksempelet`).toContain("franceletour.com");
+		}
+	});
+
 	it("scout prompt exists with escalation cap and log contract", () => {
 		const p = read("scout.md");
 		expect(p).toContain("scout-log.json");

--- a/tests/authority-schema.test.js
+++ b/tests/authority-schema.test.js
@@ -1,0 +1,182 @@
+// WP-241: authority.json er AUTORITETSKARTET — hvem SKAPER faktumet, per dekket
+// konkurranse. To kilder per event fordi produktets to kjernefelt har to ulike
+// skapere: arrangøren/ligaen/forbundet setter TIDEN, kringkasteren setter
+// KANALEN. Denne koherenstesten er kartets CI-kontrakt (à la
+// sources-schema.test.js): skjemavalidering med den samme avhengighetsfrie
+// validatoren, pluss invariantene skjemaspråket ikke kan uttrykke — at hver
+// sourceId faktisk finnes i sources.json (WP-240-registeret er sannheten om
+// hvilket domene som ER arrangøren), at tidsautoriteter er primær/forbund og
+// kanalautoriteter kringkaster/selv-strømmende arrangør (rolledoktrinen), og at
+// et ærlig hull (tom kildeliste) alltid bærer en forklaring.
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { validateAgainstSchema } from "../scripts/lib/validate-schema.js";
+
+const configDir = path.resolve(process.cwd(), "scripts", "config");
+const authority = JSON.parse(fs.readFileSync(path.join(configDir, "authority.json"), "utf-8"));
+const schema = JSON.parse(fs.readFileSync(path.join(configDir, "authority.schema.json"), "utf-8"));
+const register = JSON.parse(fs.readFileSync(path.join(configDir, "sources.json"), "utf-8"));
+
+const validate = (data) => validateAgainstSchema(data, schema, schema);
+const competitions = authority.competitions;
+const sourceById = new Map(register.sources.map((s) => [s.id, s]));
+
+// FRYST forankring i tavla slik den så ut da kartet ble seedet (29.07.2026) —
+// konkurransene et events.json-øyeblikksbilde faktisk bar. Fryst med vilje
+// (samme begrunnelse som sources-schema.test.js sin seed-liste): docs/data/
+// skrives om hver time, og en test som drev med dataene ville rødne av
+// datadrift alene. Kartet kan alltid VOKSE; disse skal aldri stille forsvinne.
+const SEEDED_BOARD_COMPETITIONS_2026_07_29 = [
+	"athletics:diamond-league",
+	"athletics:em-friidrett",
+	"athletics:nm-friidrett",
+	"chess:esports-world-cup",
+	"chess:grand-chess-tour",
+	"cycling:arctic-race-of-norway",
+	"cycling:danmark-rundt",
+	"cycling:tour-de-france",
+	"cycling:tour-de-france-femmes",
+	"cycling:tour-de-pologne",
+	"cycling:vuelta-a-espana",
+	"esports:blast",
+	"esports:esports-world-cup",
+	"esports:starladder",
+	"f1:world-championship",
+	"football:champions-league",
+	"football:club-friendlies",
+	"football:community-shield",
+	"football:conference-league",
+	"football:eliteserien",
+	"football:europa-league",
+	"football:la-liga",
+	"football:obos-ligaen",
+	"football:premier-league",
+	"football:super-cup",
+	"football:world-cup",
+	"golf:dp-world-tour",
+	"golf:pga-tour",
+	"tennis:tour",
+];
+
+describe("authority.json mot authority.schema.json", () => {
+	it("kartet validerer med null feil", () => {
+		expect(validate(authority)).toEqual([]);
+	});
+
+	it("validatoren fanger faktisk brudd (så kontrakten har tenner)", () => {
+		const bad = (mutate) => {
+			const clone = JSON.parse(JSON.stringify(authority));
+			mutate(clone);
+			return validate(clone).length;
+		};
+		expect(bad((a) => (a.competitions[0].id = "ikke sport-kolon-form"))).toBeGreaterThan(0);
+		expect(bad((a) => delete a.competitions[0].time)).toBeGreaterThan(0);
+		expect(bad((a) => delete a.competitions[0].channel)).toBeGreaterThan(0);
+		expect(bad((a) => delete a.competitions[0].match)).toBeGreaterThan(0);
+		expect(bad((a) => (a.competitions[0].time.sourceIds = "letour"))).toBeGreaterThan(0);
+		expect(bad((a) => (a.competitions[0].channel.options = [{ platform: "TV 2" }]))).toBeGreaterThan(0);
+		expect(bad((a) => (a.competitions[0].surprise = true))).toBeGreaterThan(0);
+		expect(bad((a) => delete a.updatedAt)).toBeGreaterThan(0);
+	});
+});
+
+describe("authority.json — identitet og determinisme", () => {
+	it("id-ene er unike", () => {
+		const ids = competitions.map((c) => c.id);
+		expect(ids.length).toBe(new Set(ids).size);
+	});
+
+	it("konkurransene er sortert på id (ren diff ved endringer)", () => {
+		const ids = competitions.map((c) => c.id);
+		expect(ids).toEqual([...ids].sort());
+	});
+
+	it("id-ens sport-prefiks stemmer med sport-feltet", () => {
+		for (const c of competitions) {
+			expect(c.id.split(":")[0], c.id).toBe(c.sport);
+		}
+	});
+
+	it("hvert match-mønster er små bokstaver (substring-kontrakten i provenance.js)", () => {
+		for (const c of competitions) {
+			for (const m of c.match) {
+				expect(m, `${c.id}: "${m}"`).toBe(m.toLowerCase());
+				expect(m.trim().length, `${c.id}: tomt mønster`).toBeGreaterThan(0);
+			}
+		}
+	});
+});
+
+describe("authority.json — rolledoktrinen (broen til sources.json)", () => {
+	it("hver tids-sourceId finnes i registeret og er primær eller forbund", () => {
+		for (const c of competitions) {
+			for (const id of c.time.sourceIds) {
+				const src = sourceById.get(id);
+				expect(src, `${c.id}: ukjent tidskilde "${id}"`).toBeTruthy();
+				expect(["primary", "federation"], `${c.id}: ${id} (${src.role}) kan ikke skape tiden`).toContain(src.role);
+			}
+		}
+	});
+
+	it("hver kanal-sourceId finnes i registeret og er kringkaster (eller selv-strømmende arrangør)", () => {
+		for (const c of competitions) {
+			for (const opt of c.channel.options) {
+				const src = sourceById.get(opt.sourceId);
+				expect(src, `${c.id}: ukjent kanalkilde "${opt.sourceId}"`).toBeTruthy();
+				expect(
+					["official-broadcaster", "primary"],
+					`${c.id}: ${opt.sourceId} (${src.role}) kan ikke bære kanalen`
+				).toContain(src.role);
+			}
+		}
+	});
+
+	it("en tidsautoritet er faktisk autoritativ for konkurransens sport", () => {
+		for (const c of competitions) {
+			for (const id of c.time.sourceIds) {
+				const src = sourceById.get(id);
+				const covers = (src.authorityFor || []).some((a) => a === c.sport || a.startsWith(`${c.sport}:`));
+				expect(covers, `${c.id}: ${id} hevder ingen autoritet i ${c.sport} (authorityFor: ${JSON.stringify(src.authorityFor)})`).toBe(true);
+			}
+		}
+	});
+
+	it("et ærlig hull (tom kildeliste) bærer alltid en forklaring", () => {
+		for (const c of competitions) {
+			if (c.time.sourceIds.length === 0) {
+				expect(c.time.note, `${c.id}: tom time.sourceIds uten note`).toBeTruthy();
+			}
+			if (c.channel.options.length === 0) {
+				expect(c.channel.note, `${c.id}: tomme channel.options uten note`).toBeTruthy();
+			}
+		}
+	});
+});
+
+describe("authority.json — dekning og lookalike-vernet", () => {
+	it("hver konkurranse fra seed-tavla står fortsatt i kartet", () => {
+		const ids = new Set(competitions.map((c) => c.id));
+		const missing = SEEDED_BOARD_COMPETITIONS_2026_07_29.filter((id) => !ids.has(id));
+		expect(missing, `seedede konkurranser borte fra kartet: ${missing.join(", ")}`).toEqual([]);
+	});
+
+	it("opphavseksempelet er registrert: franceletour.com står som lookalike på Tour de France", () => {
+		const tdf = competitions.find((c) => c.id === "cycling:tour-de-france");
+		expect(tdf.lookalikes).toContain("franceletour.com");
+	});
+
+	it("et lookalike-domene er ALDRI samtidig en registrert vert i kilderegisteret", () => {
+		const hostOf = (u) => {
+			try { return new URL(u).hostname.replace(/^www\./, "").toLowerCase(); } catch { return null; }
+		};
+		const registered = new Set(
+			register.sources.flatMap((s) => [s.url, ...(s.endpoints || [])].map(hostOf).filter(Boolean))
+		);
+		for (const c of competitions) {
+			for (const domain of c.lookalikes || []) {
+				expect(registered.has(domain.toLowerCase()), `${c.id}: lookalike "${domain}" er registrert som ekte kilde`).toBe(false);
+			}
+		}
+	});
+});

--- a/tests/provenance.test.js
+++ b/tests/provenance.test.js
@@ -1,0 +1,221 @@
+// WP-242: scripts/lib/provenance.js — den mekaniske migreringen fra flat
+// evidence til per-faktum-proveniens. Kjernen som testes her er
+// LOOKALIKE-VERNET (franceletour.com må ALDRI migreres til A.S.O.-kilden
+// letour) og konservatismen: bare det som beviselig kan knyttes til en
+// registrert autoritet stemples — resten beholder sin flate evidence.
+// Enhetstestene bruker små inline-fixturer; en avsluttende blokk kjører mot de
+// EKTE konfigfilene så kartet, registeret og lib-en aldri driver fra hverandre.
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { basisForRole, urlBelongsToSource, findCompetition, deriveProvenance } from "../scripts/lib/provenance.js";
+
+// ── Inline-fixturer ─────────────────────────────────────────────────────────
+
+const SOURCES = [
+	{ id: "letour", url: "https://www.letour.fr", endpoints: ["https://www.letourfemmes.fr"], role: "primary", authorityFor: ["cycling:tour-de-france", "cycling:tour-de-france-femmes"] },
+	{ id: "tv2", url: "https://www.tv2.no", endpoints: ["https://hjelp.tv2.no", "https://play.tv2.no"], role: "official-broadcaster", authorityFor: [] },
+	{ id: "fc-barcelona", url: "https://www.fcbarcelona.com", role: "primary", authorityFor: ["football:fc-barcelona"] },
+	{ id: "blast", url: "https://blast.tv", role: "primary", authorityFor: ["esports:blast"] },
+	{ id: "wikipedia", url: "https://en.wikipedia.org", role: "encyclopedic", authorityFor: [] },
+];
+
+const AUTHORITY = {
+	competitions: [
+		{
+			id: "cycling:tour-de-france",
+			name: "Tour de France",
+			sport: "cycling",
+			match: ["tour de france"],
+			time: { sourceIds: ["letour"] },
+			channel: { options: [{ sourceId: "tv2", platform: "TV 2" }] },
+			lookalikes: ["franceletour.com"],
+		},
+		{
+			id: "cycling:tour-de-france-femmes",
+			name: "Tour de France Femmes",
+			sport: "cycling",
+			match: ["tour de france femmes"],
+			time: { sourceIds: ["letour"] },
+			channel: { options: [{ sourceId: "tv2", platform: "TV 2" }] },
+		},
+		{
+			id: "esports:blast",
+			name: "BLAST",
+			sport: "esports",
+			match: ["blast"],
+			time: { sourceIds: ["blast"] },
+			channel: { options: [{ sourceId: "blast", platform: "BLAST.tv" }] },
+		},
+	],
+};
+
+const CFG = { sources: SOURCES, authority: AUTHORITY };
+
+const tdfEvent = (overrides = {}) => ({
+	sport: "cycling",
+	tournament: "Tour de France 2026",
+	title: "Etappe 12",
+	time: "2026-07-16T11:30:00Z",
+	source: "ai-research",
+	confidence: "medium",
+	researchedAt: "2026-07-04T17:33:56Z",
+	streaming: [{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" }],
+	evidence: ["https://www.letour.fr/en/stage-12", "https://en.wikipedia.org/wiki/2026_Tour_de_France"],
+	...overrides,
+});
+
+describe("basisForRole — rolledoktrinen oversatt til basis-enum", () => {
+	it("arrangør/liga og forbund skaper faktumet", () => {
+		expect(basisForRole("primary")).toBe("primary");
+		expect(basisForRole("federation")).toBe("primary");
+	});
+	it("kringkasteren er offisiell; alt annet er annenhånds", () => {
+		expect(basisForRole("official-broadcaster")).toBe("official");
+		expect(basisForRole("aggregator")).toBe("secondary");
+		expect(basisForRole("encyclopedic")).toBe("secondary");
+		expect(basisForRole("media")).toBe("secondary");
+	});
+});
+
+describe("urlBelongsToSource — eksakt vert, aldri fuzzy", () => {
+	const letour = SOURCES[0];
+	it("treffer kildens egen vert og registrerte endpoints", () => {
+		expect(urlBelongsToSource("https://www.letour.fr/en/stage-12", letour)).toBe(true);
+		expect(urlBelongsToSource("https://www.letourfemmes.fr/en/", letour)).toBe(true);
+	});
+	it("treffer under-/overdomene i begge retninger (hjelp.tv2.no ↔ tv2.no)", () => {
+		expect(urlBelongsToSource("https://hjelp.tv2.no/sport/tour-de-france", SOURCES[1])).toBe(true);
+		expect(urlBelongsToSource("https://sport.tv2.no/sykkel", SOURCES[1])).toBe(true);
+	});
+	it("LOOKALIKE-VERNET: franceletour.com hører ALDRI til letour", () => {
+		expect(urlBelongsToSource("https://www.franceletour.com/etape-14", letour)).toBe(false);
+		expect(urlBelongsToSource("https://letour-france.com/x", letour)).toBe(false);
+	});
+	it("tåler søppel-URLer", () => {
+		expect(urlBelongsToSource("ikke en url", letour)).toBe(false);
+		expect(urlBelongsToSource("", letour)).toBe(false);
+	});
+});
+
+describe("findCompetition — sport-gated substring med lengste-treff-regel", () => {
+	it("finner konkurransen via tournament", () => {
+		expect(findCompetition(tdfEvent(), AUTHORITY).id).toBe("cycling:tour-de-france");
+	});
+	it("LENGSTE mønster vinner: Femmes-etapper går til femmes-oppføringen", () => {
+		const ev = tdfEvent({ tournament: "Tour de France Femmes 2026" });
+		expect(findCompetition(ev, AUTHORITY).id).toBe("cycling:tour-de-france-femmes");
+	});
+	it("sport må stemme — «blast» i en fotballtittel matcher ikke esports-oppføringen", () => {
+		const ev = tdfEvent({ sport: "football", tournament: "Blast fra fortiden cup" });
+		expect(findCompetition(ev, AUTHORITY)).toBeNull();
+	});
+});
+
+describe("deriveProvenance — konservativ mekanisk migrering", () => {
+	it("stempler tid fra kartets registrerte tidsautoritet (letour.fr → basis primary)", () => {
+		const p = deriveProvenance(tdfEvent(), CFG);
+		expect(p.time).toMatchObject({
+			sourceId: "letour",
+			url: "https://www.letour.fr/en/stage-12",
+			basis: "primary",
+			retrievedAt: "2026-07-04T17:33:56Z",
+		});
+		expect(p.time.note).toMatch(/migrert/);
+	});
+
+	it("stempler kanal kun når plattformen matcher kart-opsjonen OG kringkasterens egen URL finnes i evidensen", () => {
+		const ev = tdfEvent({ evidence: ["https://www.letour.fr/en/stage-12", "https://hjelp.tv2.no/sport/tour-de-france"] });
+		const p = deriveProvenance(ev, CFG);
+		expect(p.streaming).toMatchObject({ sourceId: "tv2", basis: "official", url: "https://hjelp.tv2.no/sport/tour-de-france" });
+	});
+
+	it("ingen kanalstempel når plattformen ikke matcher opsjonen", () => {
+		const ev = tdfEvent({
+			streaming: [{ platform: "Eurosport" }],
+			evidence: ["https://www.letour.fr/x", "https://hjelp.tv2.no/y"],
+		});
+		expect(deriveProvenance(ev, CFG).streaming).toBeUndefined();
+	});
+
+	it("LOOKALIKE-VERNET ende-til-ende: kun franceletour.com + wiki i evidensen ⇒ ingenting migreres", () => {
+		const ev = tdfEvent({ evidence: ["https://www.franceletour.com/etape-14", "https://en.wikipedia.org/wiki/2026_Tour_de_France"] });
+		expect(deriveProvenance(ev, CFG)).toBeNull();
+	});
+
+	it("faller tilbake til en sport-autoritativ primærkilde når kartet mangler oppføring (klubbens egen side)", () => {
+		const ev = tdfEvent({
+			sport: "football",
+			tournament: "Treningskamp",
+			title: "Barcelona – Como",
+			streaming: [],
+			evidence: ["https://www.fcbarcelona.com/en/football/first-team/news/kickoff"],
+		});
+		const p = deriveProvenance(ev, CFG);
+		expect(p.time).toMatchObject({ sourceId: "fc-barcelona", basis: "primary" });
+	});
+
+	it("selv-strømmende arrangør får basis primary på kanalen (BLAST på BLAST.tv)", () => {
+		const ev = tdfEvent({
+			sport: "esports",
+			tournament: "BLAST Bounty 2026",
+			streaming: [{ platform: "BLAST.tv (gratis offisiell strøm)" }],
+			evidence: ["https://blast.tv/counter-strike/schedule"],
+		});
+		const p = deriveProvenance(ev, CFG);
+		expect(p.streaming).toMatchObject({ sourceId: "blast", basis: "primary" });
+	});
+
+	it("verifiedAt foretrekkes som retrievedAt, og verificationSources telles som kandidat-URLer", () => {
+		const ev = tdfEvent({
+			evidence: ["https://en.wikipedia.org/wiki/2026_Tour_de_France"],
+			verifiedAt: "2026-07-10T09:30:00Z",
+			verificationSources: ["https://www.letour.fr/en/stage-12"],
+		});
+		const p = deriveProvenance(ev, CFG);
+		expect(p.time).toMatchObject({ sourceId: "letour", retrievedAt: "2026-07-10T09:30:00Z" });
+	});
+
+	it("rører ALDRI eksplisitt agent-skrevet proveniens", () => {
+		const ev = tdfEvent({ provenance: { time: { sourceId: "letour", url: "https://www.letour.fr/x", basis: "primary" } } });
+		expect(deriveProvenance(ev, CFG)).toBeNull();
+	});
+
+	it("gjelder kun ai-research-events, og tåler manglende konfig/evidens (fail-soft)", () => {
+		expect(deriveProvenance(tdfEvent({ source: "espn" }), CFG)).toBeNull();
+		expect(deriveProvenance(tdfEvent({ evidence: [] }), CFG)).toBeNull();
+		expect(deriveProvenance(tdfEvent(), {})).toBeNull();
+		expect(deriveProvenance(tdfEvent(), { sources: [], authority: AUTHORITY })).toBeNull();
+	});
+
+	it("er deterministisk: samme event + samme konfig ⇒ identisk stempel", () => {
+		const a = deriveProvenance(tdfEvent(), CFG);
+		const b = deriveProvenance(tdfEvent(), CFG);
+		expect(a).toEqual(b);
+	});
+});
+
+// ── Mot de EKTE konfigfilene: kartet, registeret og lib-en i samme kontrakt ──
+
+describe("deriveProvenance mot ekte authority.json + sources.json", () => {
+	const configDir = path.resolve(process.cwd(), "scripts", "config");
+	const realAuthority = JSON.parse(fs.readFileSync(path.join(configDir, "authority.json"), "utf-8"));
+	const realSources = JSON.parse(fs.readFileSync(path.join(configDir, "sources.json"), "utf-8"));
+	const realCfg = { sources: realSources.sources, authority: realAuthority };
+
+	it("en TdF-etappe med letour.fr-evidens får A.S.O. som tidsbasis", () => {
+		const p = deriveProvenance(tdfEvent(), realCfg);
+		expect(p.time).toMatchObject({ sourceId: "letour", basis: "primary" });
+	});
+
+	it("franceletour.com migreres aldri, heller ikke mot det ekte registeret", () => {
+		const ev = tdfEvent({ evidence: ["https://www.franceletour.com/etape-14"], streaming: [] });
+		expect(deriveProvenance(ev, realCfg)).toBeNull();
+	});
+
+	it("hjelp.tv2.no-evidens på en TdF-etappe gir TV 2 som offisiell kanalbasis", () => {
+		const ev = tdfEvent({ evidence: ["https://hjelp.tv2.no/hovedkategori/sport/tour-de-france"] });
+		const p = deriveProvenance(ev, realCfg);
+		expect(p.streaming).toMatchObject({ sourceId: "tv2", basis: "official" });
+	});
+});

--- a/tests/validate-events.test.js
+++ b/tests/validate-events.test.js
@@ -116,3 +116,97 @@ describe("landing-page-only channel URLs are a counted warning (WP-246)", () => 
 		expect(check([{ sport: "f1", title: "Ugyldig", time: soon, streaming: [{ platform: "Viaplay", urlKind: "kanskje" }] }]).errors).toBeGreaterThan(0);
 	});
 });
+
+// ── WP-242: høy tillit krever primær/offisiell basis — TELT, ikke usynlig ────
+
+describe("basis-kontrakten er et telt varsel for høytillits-events (WP-242)", () => {
+	const schema = loadEventSchema();
+	const soon = new Date(Date.now() + 2 * 86400000).toISOString();
+	const check = (events) => validateEvents(events, schema);
+	const high = (overrides = {}) => ({
+		sport: "cycling",
+		title: "Etappe 1",
+		time: soon,
+		source: "ai-research",
+		confidence: "high",
+		evidence: ["https://www.letour.fr/a", "https://www.tv2.no/b"],
+		streaming: [{ platform: "TV 2 Play", url: "https://play.tv2.no/sport" }],
+		...overrides,
+	});
+
+	it("teller et høytillits-event UTEN proveniens som svakt på både tid og kanal — men aldri som feil", () => {
+		const r = check([high()]);
+		expect(r.timeBasisWeak).toBe(1);
+		expect(r.channelBasisWeak).toBe(1);
+		expect(r.errors).toBe(0); // varsel, ikke pipeline-fellende — WP-246-mønsteret
+	});
+
+	it("primær tidsbasis + kringkasterens egen kanalbasis ⇒ null svake", () => {
+		const r = check([
+			high({
+				provenance: {
+					time: { sourceId: "letour", url: "https://www.letour.fr/a", basis: "primary" },
+					streaming: { sourceId: "tv2", url: "https://hjelp.tv2.no/b", basis: "official" },
+				},
+			}),
+		]);
+		expect(r.timeBasisWeak).toBe(0);
+		expect(r.channelBasisWeak).toBe(0);
+		expect(r.errors).toBe(0);
+	});
+
+	it("offisiell basis for tid godtas også (arrangør-nær offisiell publisering)", () => {
+		const r = check([
+			high({
+				streaming: [],
+				provenance: { time: { sourceId: "nrk", url: "https://nrk.no/a", basis: "official" } },
+			}),
+		]);
+		expect(r.timeBasisWeak).toBe(0);
+	});
+
+	it("secondary basis teller som svak — det er nettopp cyclingstage-klassen", () => {
+		const r = check([
+			high({
+				provenance: {
+					time: { sourceId: "cyclingstage", url: "https://www.cyclingstage.com/x", basis: "secondary" },
+					streaming: { sourceId: "wikipedia", url: "https://en.wikipedia.org/y", basis: "secondary" },
+				},
+			}),
+		]);
+		expect(r.timeBasisWeak).toBe(1);
+		expect(r.channelBasisWeak).toBe(1);
+	});
+
+	it("et event uten streaming teller ikke som svak kanal (ingenting å basere)", () => {
+		const r = check([high({ streaming: [] })]);
+		expect(r.timeBasisWeak).toBe(1);
+		expect(r.channelBasisWeak).toBe(0);
+	});
+
+	it("kontrakten gjelder kun høy tillit — medium teller ikke", () => {
+		const r = check([high({ confidence: "medium", evidence: ["https://a.no"] })]);
+		expect(r.timeBasisWeak).toBe(0);
+		expect(r.channelBasisWeak).toBe(0);
+	});
+
+	it("skjemaet godtar proveniens-formen og fanger brudd (basis-enum, ukjente felter, manglende sourceId)", () => {
+		const ok = high({
+			provenance: {
+				time: { sourceId: "letour", url: "https://www.letour.fr/a", basis: "primary", retrievedAt: soon, note: "migrert mekanisk fra evidence (WP-242)" },
+			},
+		});
+		expect(check([ok]).errors).toBe(0);
+		const badBasis = high({ provenance: { time: { sourceId: "letour", url: "https://x.no", basis: "vibes" } } });
+		expect(check([badBasis]).errors).toBeGreaterThan(0);
+		const unknownProp = high({ provenance: { time: { sourceId: "letour", url: "https://x.no", basis: "primary", surprise: 1 } } });
+		expect(check([unknownProp]).errors).toBeGreaterThan(0);
+		const missingSource = high({ provenance: { time: { url: "https://x.no", basis: "primary" } } });
+		expect(check([missingSource]).errors).toBeGreaterThan(0);
+	});
+
+	it("bakoverkompatibilitet: flat evidence uten provenance validerer fortsatt med null feil", () => {
+		const legacy = high(); // ingen provenance i det hele tatt
+		expect(check([legacy]).errors).toBe(0);
+	});
+});


### PR DESCRIPTION
## Hva

Den tyngste pakken i bølgen — bærer spor E. Det verifiserte problemet: research-laget siterer det som er PRAKTISK, ikke det som er AUTORITATIVT. letour.fr (A.S.O., som faktisk lager Tour de France-ruta og starttidene) forekom **null** ganger i events.json; lookalike-domenet **franceletour.com** sto derimot som evidens på en etappe — og evidens-URLene vises til brukeren i ⓘ-modalen.

### 1. Autoritetskartet (WP-241)
- **`scripts/config/authority.json`** + **`authority.schema.json`**: hvem SKAPER faktumet, per konkurranse. To kilder per event, som svarer nøyaktig til produktets to kjernefelt: arrangøren/ligaen/forbundet skaper **tiden**, kringkasteren skaper **kanalen**. 29 konkurranser seedet — hver konkurranse som faktisk sto på tavla 29.07.
- Id-referanser inn i WP-240-registeret (`sources.json`), som får **seks nye arrangørkilder** (tour-de-pologne, arctic-race-of-norway, european-athletics, laliga, the-fa, starladder) — robots.txt sjekket mekanisk; vilkår ærlig merket som ulest (`unknown`).
- Kjente lookalikes registreres per konkurranse (`lookalikes`), med franceletour.com som opphavseksempel.

### 2. Proveniens per faktum (WP-242)
- Nytt valgfritt **`provenance`-felt** på events: `{ time, streaming }`, hver med `sourceId`/`url`/`retrievedAt`/`basis` (`primary` | `official` | `secondary`). Flat `evidence` beholdes — full bakoverkompatibilitet (eksisterende events validerer uendret).
- **`scripts/lib/provenance.js`**: mekanisk, KONSERVATIV migrering fra flat evidence — kun eksakt domenetreff mot registerets registrerte verter. **Lookalike-vernet er kjernen**: franceletour.com kan aldri migreres til A.S.O.-kilden (testet ende-til-ende, mot både fixturer og de ekte konfigfilene).
- `build-events.js` bærer feltet gjennom alle stier (pushEvent, carry-forward, preservering) og stempler migreringen idempotent (verifisert byte-identisk over to bygg).

### 3. Validator-kontrakten
`validate-events.js` håndhever, i samme form som «høy tillit krever 2+ evidens-URLer»: **høy tillit krever primær/offisiell basis for tid, og kringkasterens egen kilde for kanal**. Startet som telt VARSEL (WP-246-mønsteret) — aldri feil, så gapet blir målbart uten å felle pipelinen på dag én.

### 4. Promptene
- `research.md`: nytt input-avsnitt for authority.json + «Authority first — look it up, don't search for it»-instruks, provenance i Step 3-skjemaeksempelet, og eksplisitt lookalike-advarsel.
- `verify.md`: kanal verifiseres mot kringkasterens EGEN kilde; verify stempler `provenance.streaming`/`provenance.time`; lookalike-advarsel med instruks om å bytte ut lookalike-evidens ved amendering.

## Målt på dagens tavle (kjørt lokalt, ikke committet — pipelinen migrerer på neste kjøring)

- **54 av 60** ai-research-events får per-faktum-proveniens mekanisk
- **41 av 60 har nå primær/offisiell basis for tid** (letour ×9, fotball-no ×6, formula1 ×4, uefa, pgatour, grand-chess-tour, arrangørkildene m.fl.)
- 24 får kringkaster-basis for kanal (tv2 ×13, nrk ×3, hbo-max ×4 …)
- Etappen med franceletour-evidens fikk INGEN tidsproveniens — lookalike-vernet virker beviselig
- Varsler målt i dag: **12 svake tidsbaser + 25 svake kanalbaser** blant 37 høytillits-events (det målbare gapet research/verify nå skal lukke)

## Aksept

- `npx vitest run --maxWorkers=1`: **80 filer / 1361 tester grønne** (nye: `tests/authority-schema.test.js`, `tests/provenance.test.js`; utvidet: `validate-events`, `agent-prompts`)
- `node scripts/build-events.js && node scripts/validate-events.js`: **0 feil**, exit 0 (varsler som forventet: 1 streaming-mangel, 20 landing-only (WP-246), 12+25 basis-varsler (WP-242))
- Kun `scripts/` + `tests/` berørt; docs/data-artefaktene er tilbakestilt (genereres av pipelinen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)