### PR TITLE
WP-242b: fjern lookalike-domener fra evidens + rett urlKind-kontrakten

### DIFF
--- a/scripts/build-events.js
+++ b/scripts/build-events.js
@@ -4,7 +4,7 @@ import path from "path";
 import crypto from "crypto";
 import { readJsonIfExists, rootDataPath, configDirPath, MS_PER_DAY, makeCoverageGate, normalizeParticipants, normalizeNorwegianPlayers, normalizeText, containsName, entityTerms } from "./lib/helpers.js";
 import { resolveStreaming, stampUrlKinds } from "./lib/norwegian-rights.js";
-import { deriveProvenance } from "./lib/provenance.js";
+import { deriveProvenance, lookalikeHosts, stripLookalikeEvidence } from "./lib/provenance.js";
 import { writeManifest } from "./build-manifest.js";
 import { writePortReport } from "./build-port-report.js";
 import { readIosCommit, buildAppVersion, readTestflight } from "./lib/app-version.js";
@@ -586,6 +586,9 @@ const provenanceConfig =
 		? { sources: sourcesRegister.sources, authority: authorityMap }
 		: null;
 let provenanceMigrated = 0;
+// Domener autoritetskartet flagger som lookalikes (franceletour.com ≠ letour.fr).
+const lookalikeSet = lookalikeHosts(authorityMap);
+let lookalikesStripped = 0;
 
 // Keep events from the last 14 days + upcoming, and only those the catalog covers
 const cutoff = Date.now() - 14 * MS_PER_DAY;
@@ -641,9 +644,21 @@ for (const e of kept) {
 			provenanceMigrated++;
 		}
 	}
+	// WP-242b: en lookalike skal ikke bare nektes SITERT — den skal ikke stå igjen
+	// i den flate evidens-lista heller, for det er den ⓘ-modalen viser brukeren.
+	if (lookalikeSet.size > 0) {
+		for (const field of ["evidence", "verificationSources"]) {
+			if (!Array.isArray(e[field])) continue;
+			const { urls, removed } = stripLookalikeEvidence(e[field], lookalikeSet);
+			if (removed > 0) { e[field] = urls; lookalikesStripped += removed; }
+		}
+	}
 }
 if (provenanceMigrated > 0) {
 	console.log(`Migrated flat evidence to per-fact provenance on ${provenanceMigrated} AI-research event(s) (WP-242).`);
+}
+if (lookalikesStripped > 0) {
+	console.log(`Stripped ${lookalikesStripped} lookalike-domain evidence URL(s) — a domain posing as the organizer is not a source (WP-242b).`);
 }
 // WP-94: validate the array in-process BEFORE writing it, and degrade instead
 // of freezing the hourly pipeline on a violation. static-pipeline.yml runs

--- a/scripts/config/events.schema.json
+++ b/scripts/config/events.schema.json
@@ -198,7 +198,7 @@
 				"tentative": { "type": "boolean" },
 				"urlKind": {
 					"enum": ["deep", "landing"],
-					"description": "WP-246 — hva URL-en faktisk peker på: \"deep\" = selve sendingen/kampen/streamen, \"landing\" = tjenestens forside eller en generisk seksjon (sport/direkte/språkkode). Settes deterministisk av classifyStreamingUrl() (scripts/lib/norwegian-rights.js) og stemples sist i build-events.js, så etiketten aldri kan drifte fra URL-en. Feltet er VALGFRITT: en oppføring uten URL (eller en URL vi ikke kan parse) har det ikke, og eldre publiserte events uten feltet forblir gyldige — klientene faller da tilbake til gammel oppførsel. Kontrakten: kun \"deep\" får presenteres som en lenke til sendingen; \"landing\" viser kanalNAVNET (som er sant og nyttig) uten lenke."
+					"description": "WP-246 — hva URL-en faktisk peker på: \"deep\" = selve sendingen/kampen/streamen, \"landing\" = tjenestens forside eller en generisk seksjon (sport/direkte/språkkode). Settes deterministisk av classifyStreamingUrl() (scripts/lib/norwegian-rights.js) og stemples sist i build-events.js, så etiketten aldri kan drifte fra URL-en. Feltet er VALGFRITT: en oppføring uten URL (eller en URL vi ikke kan parse) har det ikke, og eldre publiserte events uten feltet forblir SKJEMAGYLDIGE. Men de to klientene tolker et MANGLENDE felt ULIKT, og det er et bevisst valg (WP-247): web beholder gammel oppførsel for ustemplede oppføringer, mens iOS behandler manglende felt som \"landing\" — appen har varig cache på enheten, så «ingen urlKind» betyr der «cachet før pipelinen stemplet det», ikke «URL-en er grei». Kontrakten: kun \"deep\" får presenteres som en lenke til sendingen; \"landing\" viser kanalNAVNET (som er sant og nyttig) uten lenke."
 				}
 			}
 		},

--- a/scripts/lib/provenance.js
+++ b/scripts/lib/provenance.js
@@ -62,6 +62,44 @@ export function urlBelongsToSource(url, source) {
 }
 
 /**
+ * Alle domener autoritetskartet registrerer som LOOKALIKES — et domene som poserer
+ * som arrangøren uten å være den (franceletour.com ved siden av ekte letour.fr).
+ */
+export function lookalikeHosts(authority) {
+	const out = new Set();
+	for (const comp of authority?.competitions || []) {
+		for (const d of comp.lookalikes || []) {
+			const h = String(d || "").trim().toLowerCase().replace(/^www\./, "");
+			if (h) out.add(h);
+		}
+	}
+	return out;
+}
+
+/**
+ * Fjern evidens-URLer som serveres av et kjent lookalike-domene.
+ *
+ * `deriveProvenance` nekter allerede å SITERE en lookalike, men den flate
+ * `evidence`-lista er det ⓘ-modalen rendrer til brukeren (detail.js) — så en
+ * lookalike som blir stående der vises fortsatt som «kilde N». Det var nøyaktig
+ * tilstanden da denne ble skrevet: franceletour.com sto som evidens på en
+ * TdF-etappe, mens letour.fr ikke forekom én eneste gang i hele filen.
+ *
+ * Å fjerne den gjør eventet ÆRLIGERE, ikke fattigere: mister det sin eneste
+ * tidskilde, er det nettopp det «weak time basis»-varselet skal telle.
+ * Returnerer { urls, removed }.
+ */
+export function stripLookalikeEvidence(urls, hosts) {
+	if (!Array.isArray(urls) || !hosts || hosts.size === 0) return { urls: urls || [], removed: 0 };
+	const kept = urls.filter((u) => {
+		const h = hostOfUrl(u);
+		if (!h) return true; // uparsbar — la den stå, dette er ikke en URL-validator
+		return ![...hosts].some((bad) => h === bad || h.endsWith(`.${bad}`));
+	});
+	return { urls: kept, removed: urls.length - kept.length };
+}
+
+/**
  * Slå opp konkurransen et event hører til i autoritetskartet: samme sport +
  * substring-treff i tournament/meta/title. Ved overlappende mønstre vinner det
  * LENGSTE treffet ("tour de france femmes" foran "tour de france").

--- a/tests/provenance.test.js
+++ b/tests/provenance.test.js
@@ -8,7 +8,7 @@
 import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
-import { basisForRole, urlBelongsToSource, findCompetition, deriveProvenance } from "../scripts/lib/provenance.js";
+import { basisForRole, urlBelongsToSource, findCompetition, deriveProvenance, lookalikeHosts, stripLookalikeEvidence } from "../scripts/lib/provenance.js";
 
 // ── Inline-fixturer ─────────────────────────────────────────────────────────
 
@@ -217,5 +217,49 @@ describe("deriveProvenance mot ekte authority.json + sources.json", () => {
 		const ev = tdfEvent({ evidence: ["https://hjelp.tv2.no/hovedkategori/sport/tour-de-france"] });
 		const p = deriveProvenance(ev, realCfg);
 		expect(p.streaming).toMatchObject({ sourceId: "tv2", basis: "official" });
+	});
+});
+
+// --- WP-242b: lookalikes skal ikke stå igjen i den flate evidens-lista ---------
+//
+// `deriveProvenance` nektet allerede å SITERE en lookalike, men `evidence` er det
+// ⓘ-modalen rendrer til brukeren (detail.js). Da dette ble skrevet sto
+// franceletour.com som evidens på en Tour de France-etappe, mens letour.fr —
+// A.S.O., som faktisk lager ruta — ikke forekom én eneste gang i hele filen.
+describe("stripLookalikeEvidence (WP-242b)", () => {
+	const hosts = lookalikeHosts({
+		competitions: [{ id: "tdf", lookalikes: ["franceletour.com"] }],
+	});
+
+	it("plukker lookalike-domenene ut av autoritetskartet", () => {
+		expect([...hosts]).toEqual(["franceletour.com"]);
+	});
+
+	it("fjerner lookaliken og lar den ekte arrangøren stå", () => {
+		const { urls, removed } = stripLookalikeEvidence([
+			"https://franceletour.com/tour-de-france-2026-stage-14/",
+			"https://www.letour.fr/en/stage-14",
+		], hosts);
+		expect(removed).toBe(1);
+		expect(urls).toEqual(["https://www.letour.fr/en/stage-14"]);
+	});
+
+	it("tar subdomener av en lookalike, men aldri et domene som bare ligner", () => {
+		const { urls } = stripLookalikeEvidence([
+			"https://news.franceletour.com/x",
+			"https://franceletour.com.example.org/x", // annet domene — skal IKKE fjernes
+		], hosts);
+		expect(urls).toEqual(["https://franceletour.com.example.org/x"]);
+	});
+
+	it("lar uparsbare oppføringer stå — dette er ikke en URL-validator", () => {
+		const { urls, removed } = stripLookalikeEvidence(["ikke en url"], hosts);
+		expect(removed).toBe(0);
+		expect(urls).toEqual(["ikke en url"]);
+	});
+
+	it("er en no-op uten registrerte lookalikes", () => {
+		const before = ["https://franceletour.com/x"];
+		expect(stripLookalikeEvidence(before, new Set()).urls).toBe(before);
 	});
 });


### PR DESCRIPTION
To oppfølgere etter bølge 2, begge funnet i granskning.

## 1 · Lookaliken sto fortsatt i ⓘ-modalen

WP-242s lookalike-vern nektet å **sitere** `franceletour.com` i den nye
`provenance`-strukturen, og det virket etter hensikten: TdF-etappe 14 fikk
`provenance.streaming` fra TV 2s egen side, men **ingen `provenance.time`** — fordi den
eneste tidskilden var lookaliken. Det er nettopp det «weak time basis»-varselet skal telle.

Men den flate `evidence`-lista er det [detail.js:146](docs/js/detail.js) rendrer til
brukeren som «kilde N». Vernet hindret altså at det ble verre, uten å rydde det som
allerede lå der — og produktet viste fortsatt et domene som etterligner arrangøren, som
sin kilde.

Nå strippes kjente lookalikes (fra `authority.json`) fra både `evidence` og
`verificationSources` i `build-events.js`.

Å fjerne den gjør eventet **ærligere, ikke fattigere**: mister det sin eneste tidskilde,
er det riktig at basis-varselet teller det.

## 2 · Skjemaet påsto noe som ikke lenger er sant

`events.schema.json` sa om `urlKind` at «eldre publiserte events uten feltet forblir
gyldige — klientene faller da tilbake til gammel oppførsel». Etter WP-247 er den
setningen usann for iOS, som behandler manglende felt som `landing` (appen har varig
cache på enheten, så «ingen urlKind» betyr «cachet før pipelinen stemplet det», ikke
«URL-en er grei»).

Divergensen var dokumentert i `StreamingChannel.swift` og `ios/README.md` — men den
motstridende setningen sto igjen i selve kontrakten, der neste agent ville lest den.

## Verifisering

- `npx vitest run --maxWorkers=1` → **1373 tester grønne** (5 nye)
- `node scripts/build-events.js` → `Stripped 1 lookalike-domain evidence URL(s)`
- `node scripts/validate-events.js` → 72 events, **0 feil**
- `franceletour` forekommer ikke lenger i publisert `events.json`

Testene dekker også det som IKKE skal fjernes: `franceletour.com.example.org` er et annet
domene og blir stående; uparsbare oppføringer røres ikke (dette er ikke en URL-validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)